### PR TITLE
MLIR Frontend PR 1 — Decouple parser from dialect-specific logic

### DIFF
--- a/examples/triton-ktir/indexed_add.mlir
+++ b/examples/triton-ktir/indexed_add.mlir
@@ -24,7 +24,7 @@ module {
     } : memref<128x64x8x128xf16>
 
     %x_tile = ktdp.construct_indirect_access_tile
-        intermediate_variables(%d0, %d1, %d2, %d3)
+        intermediate_variables (%d0, %d1, %d2, %d3)
         %x_view[ind(%index_view[%grid0 + %d0]), (%dim1_start + %d1), (%grid1 + %d2), (%d3)] {
           variables_space_set = affine_set<(d0, d1, d2, d3) : (d0 >= 0, -d0 + 0 >= 0, d1 >= 0, -d1 + 31 >= 0, d2 >= 0, -d2 + 0 >= 0, d3 >= 0, -d3 + 127 >= 0)>,
           variables_space_order = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>

--- a/ktir_cpu/dialects/arith_ops.py
+++ b/ktir_cpu/dialects/arith_ops.py
@@ -190,9 +190,12 @@ def arith__bitcast(op, context, env):
         if dst_type in ("i32", "si32"):
             return Tile(val.data.view(np.int32), "i32", val.shape)
         raise NotImplementedError(f"arith.bitcast: unsupported dst_type '{dst_type}' for Tile")
-    # Scalar path
+    # Scalar path — convert via raw bytes to handle both signed and unsigned
+    # integer inputs (e.g. 0xFF800000 from regex as unsigned, -8388608 from
+    # MLIR frontend as signed — both represent the same bit pattern).
     if dst_type == "f32":
-        return float(np.frombuffer(np.int32(val).tobytes(), dtype=np.float32)[0])
+        return float(np.frombuffer(int(val).to_bytes(4, "little", signed=(val < 0)),
+                                   dtype=np.float32)[0])
     if dst_type in ("i32", "si32"):
         return int(np.frombuffer(np.float32(val).tobytes(), dtype=np.int32)[0])
     raise NotImplementedError(f"arith.bitcast: unsupported dst_type '{dst_type}' for scalar")
@@ -306,7 +309,12 @@ def parse_arith_constant(op_text, parse_ctx):
                 attributes["dtype"] = type_info.get("dtype", "f16")
                 attributes["is_tensor"] = True
     else:
-        simple_match = re.match(r'(-?[\d.eE+\-]+)\s*:\s*(.+)$', rest)
+        # Match a scalar value followed by `: type`.  Covers:
+        #   42 : index              (decimal integer)
+        #   0.0 : f32               (float)
+        #   -1.5e-3 : f16           (scientific notation)
+        #   0xFF800000 : i32        (hex integer, e.g. -inf bit pattern)
+        simple_match = re.match(r'(-?(?:0[xX][0-9a-fA-F]+|[\d.eE+\-]+))\s*:\s*(.+)$', rest)
         if simple_match:
             value = parse_numeric(simple_match.group(1))
             result_type = simple_match.group(2).strip()

--- a/ktir_cpu/dialects/ktdp_ops.py
+++ b/ktir_cpu/dialects/ktdp_ops.py
@@ -501,7 +501,7 @@ def parse_construct_indirect_access_tile(op_text, parse_ctx: ParseContext):
     result_name = result_match.group(1)
 
     # Extract intermediate variable names from: intermediate_variables(%m, %k)
-    iv_match = re.search(r'intermediate_variables\(([^)]+)\)', op_text)
+    iv_match = re.search(r'intermediate_variables\s*\(([^)]+)\)', op_text)
     if not iv_match:
         return None
     intermediate_vars = [v.strip().lstrip('%') for v in iv_match.group(1).split(',')]

--- a/ktir_cpu/dialects/linalg_ops.py
+++ b/ktir_cpu/dialects/linalg_ops.py
@@ -31,8 +31,17 @@ def linalg__reduce(op, context, env):
     """Standard linalg.reduce — removes the reduced dimension."""
     # operands[0] is the ins tensor; the outs tensor is handled separately via outs_var
     tile = context.get_value(op.operands[0])
-    # combiner function e.g. arith.addf, arith.maxnumf
-    reduce_fn = op.attributes.get("reduce_fn", "arith.addf")
+    # combiner function e.g. arith.addf, arith.maxnumf.
+    # When the combiner was in an explicit region body, the parser
+    # stores reduce_fn=None and the region ops contain the arith op.
+    reduce_fn = op.attributes.get("reduce_fn")
+    if reduce_fn is None and op.regions:
+        for region_op in op.regions[0]:
+            if region_op.op_type.startswith("arith."):
+                reduce_fn = region_op.op_type
+                break
+    if reduce_fn is None:
+        reduce_fn = "arith.addf"
     # axis to reduce along; None means reduce all elements to a scalar
     dim = op.attributes.get("dim")
 
@@ -249,6 +258,12 @@ def linalg__transpose(op, context, env):
 # Parsers
 # ---------------------------------------------------------------------------
 
+# NOTE: linalg.reduce has an optional explicit region body
+# (e.g. `(%a : f32, %b : f32) { arith.addf ... linalg.yield ... }`),
+# but we do NOT use opens_region here because the region body is simple
+# enough to extract the combiner function via regex from the joined op text.
+# If the region body grows more complex, this should switch to opens_region
+# with recursive parsing.
 @register_parser("linalg.reduce")
 def parse_linalg_reduce(op_text, parse_ctx):
     """Parse standard linalg.reduce with ins/outs/dimensions syntax.
@@ -277,8 +292,9 @@ def parse_linalg_reduce(op_text, parse_ctx):
         if generic_match:
             reduce_fn = generic_match.group(1)
 
-    if reduce_fn is None:
-        raise ValueError(f"linalg.reduce: could not extract combiner from: {op_text!r}")
+    # reduce_fn may be None when the combiner is in an explicit region
+    # body that was extracted by the tokenizer.  The executor resolves
+    # the combiner from op.regions at execution time.
 
     # dimensions = [1]
     dim = None

--- a/ktir_cpu/dialects/linalg_ops.py
+++ b/ktir_cpu/dialects/linalg_ops.py
@@ -31,13 +31,12 @@ def linalg__reduce(op, context, env):
     """Standard linalg.reduce — removes the reduced dimension."""
     # operands[0] is the ins tensor; the outs tensor is handled separately via outs_var
     tile = context.get_value(op.operands[0])
-    # combiner function e.g. arith.addf, arith.maxnumf.
-    # When the combiner was in an explicit region body, the parser
-    # stores reduce_fn=None and the region ops contain the arith op.
+    # Resolve the combiner op name.  The shorthand form stores it in
+    # attributes; the explicit-region form has it in op.regions.
     reduce_fn = op.attributes.get("reduce_fn")
     if reduce_fn is None and op.regions:
         for region_op in op.regions[0]:
-            if region_op.op_type.startswith("arith."):
+            if region_op.op_type != "linalg.yield":
                 reduce_fn = region_op.op_type
                 break
     if reduce_fn is None:
@@ -258,43 +257,34 @@ def linalg__transpose(op, context, env):
 # Parsers
 # ---------------------------------------------------------------------------
 
-# NOTE: linalg.reduce has an optional explicit region body
-# (e.g. `(%a : f32, %b : f32) { arith.addf ... linalg.yield ... }`),
-# but we do NOT use opens_region here because the region body is simple
-# enough to extract the combiner function via regex from the joined op text.
-# If the region body grows more complex, this should switch to opens_region
-# with recursive parsing.
+# linalg.reduce has two forms:
+#   Shorthand:  linalg.reduce { arith.addf } ins(...) outs(...) dimensions = [1]
+#     The { arith.addf } has no %SSA references, so the tokenizer keeps it
+#     as inline op text.  The parser extracts the combiner name via regex.
+#   Explicit region:  linalg.reduce ins(...) outs(...) dimensions = [1]
+#                       (%a : f32, %b : f32) { %s = arith.addf ... }
+#     The { } block contains %SSA references, so the tokenizer extracts it
+#     as a region.  The parser sets reduce_fn=None and the executor resolves
+#     the combiner from op.regions.
+#
+# In both cases the executor maps the combiner name to a NumPy reduction
+# (e.g. arith.addf → np.sum) rather than executing the region body
+# element-by-element.  A Python-level fold over every element would be
+# prohibitively slow for the tile sizes seen in practice.
 @register_parser("linalg.reduce")
 def parse_linalg_reduce(op_text, parse_ctx):
-    """Parse standard linalg.reduce with ins/outs/dimensions syntax.
-
-    Example:
-        %r = linalg.reduce { arith.addf }
-            ins(%x : tensor<1x1024xf16>)
-            outs(%init : tensor<1xf16>)
-            dimensions = [1]
-    """
+    """Parse linalg.reduce — shorthand or explicit-region form."""
     result_match = re.match(r'(%\w+)\s*=\s*linalg\.reduce\s+', op_text)
     if not result_match:
         return None
 
     result_name = result_match.group(1)
 
-    # Combiner: shorthand { arith.addf } or generic region { %tmp = arith.addf ... }
+    # Shorthand combiner: { arith.addf } in the op text (no %SSA inside)
     reduce_fn = None
-    combiner_match = re.search(r'\{\s*(arith\.\w+)\s*\}', op_text)
+    combiner_match = re.search(r'\{\s*(\w+\.\w+)\s*\}', op_text)
     if combiner_match:
         reduce_fn = combiner_match.group(1)
-    else:
-        # Generic MLIR format: the region body is joined into the op_text as
-        # "... { %tmp = arith.OP %in, %out : type linalg.yield ... }"
-        generic_match = re.search(r'\{\s*%\w+\s*=\s*(arith\.\w+)\b', op_text)
-        if generic_match:
-            reduce_fn = generic_match.group(1)
-
-    # reduce_fn may be None when the combiner is in an explicit region
-    # body that was extracted by the tokenizer.  The executor resolves
-    # the combiner from op.regions at execution time.
 
     # dimensions = [1]
     dim = None

--- a/ktir_cpu/dialects/registry.py
+++ b/ktir_cpu/dialects/registry.py
@@ -55,9 +55,6 @@ def get_latency_category(op_name: str) -> str:
 # ---------------------------------------------------------------------------
 
 # Parser signature: (op_text: str, parse_ctx: ParseContext) -> Optional[Operation]
-# ParseContext carries everything dialect parsers need beyond the op text itself
-# (currently just the alias table).  Using a typed object keeps the signature
-# stable when new parse-time context is added later.
 ParserFn = Callable[[str, "ParseContext"], Optional[Operation]]
 
 _PARSER_REGISTRY: Dict[str, ParserFn] = {}

--- a/ktir_cpu/interpreter.py
+++ b/ktir_cpu/interpreter.py
@@ -196,7 +196,7 @@ class KTIRInterpreter:
             if handler:
                 result = handler(op, context, self._env)
             else:
-                print(f"Warning: Unknown operation {op.op_type}, skipping")
+                raise ValueError(f"Unknown operation: {op.op_type}")
 
         except Exception as e:
             print(f"Error executing {op.op_type} on core {context.core_id}: {e}")

--- a/ktir_cpu/parser.py
+++ b/ktir_cpu/parser.py
@@ -29,10 +29,35 @@ from .parser_utils import parse_attr_block, parse_tensor_type, parse_numeric
 class KTIRParser:
     """KTIR MLIR parser.
 
-    Parses compiler-generated KTIR including multi-line operations
-    (e.g. ktdp.construct_memory_view spanning 3-4 lines), nested
-    regions (scf.for loop bodies), and compiler-specific constant
-    syntax like {1823 : index} or {dense<0.0>}.
+    Parsing proceeds in three phases:
+
+    1. **Module-level pre-scan** — collects named attribute aliases
+       (``#name = value``) so that dialect parsers can resolve ``#name``
+       references during op parsing.
+
+    2. **Tokenization** (``_tokenize_operations``) — splits the body
+       text of a function or region into complete operation strings.
+       Multi-line ops are joined, and ``{ }`` blocks are classified
+       structurally: blocks whose content contains ``%`` SSA
+       references are extracted as **regions** (recursively parsed);
+       all others are kept as inline **attribute blocks**.
+
+    3. **Op dispatch** — each operation string is dispatched to a
+       dialect-registered parser (``register_parser`` in
+       ``dialects/registry.py``).  Unrecognised ops fall through to
+       the general-purpose parser.
+
+    To add support for a new operation, register a parser in the
+    appropriate dialect module — the tokenizer and dispatcher are
+    dialect-agnostic and should not require changes.  Specifically:
+
+    - Do **not** add operation-specific keywords to the tokenizer
+      (e.g. continuation-line prefixes).  Multi-line grouping relies
+      on type-terminal detection, blank-line boundaries, and SSA
+      assignment signals — all of which are structural.
+    - Do **not** hardcode op names for region detection.  Regions are
+      detected by the ``%`` heuristic; any ``{ }`` block that
+      contains SSA references is automatically treated as a region.
     """
 
     def parse_file(self, filepath: str) -> IRModule:

--- a/ktir_cpu/parser.py
+++ b/ktir_cpu/parser.py
@@ -250,38 +250,56 @@ class KTIRParser:
             line = lines[i]
             stripped = line.strip()
 
-            # Skip empty lines and comments
+            # A blank line (or comment) separates operations.  Flush
+            # the accumulated op if braces are balanced.
             if not stripped or stripped.startswith('//'):
-                # If we have accumulated lines for an operation, a blank line
-                # might separate it. But we should only flush if the accumulated
-                # op looks complete.
+                if current_op_lines:
+                    accumulated = ' '.join(current_op_lines)
+                    open_braces = accumulated.count('{') - accumulated.count('}')
+                    if open_braces == 0:
+                        results.append((accumulated, current_regions))
+                        current_op_lines = []
+                        current_regions = []
                 i += 1
                 continue
 
-            # Only flush when the accumulated op text has balanced braces —
-            # an open { ... } attribute block must stay on one logical op.
-            # parse_attr_block uses the same depth-counting loop internally,
-            # so we reuse it here: a balanced block means it found a closing '}'.
-            # NOTE: underlying assumption is that the KTIR is well-formed with no 
-            #       stray braces.
+            # Flush when the accumulated op is structurally complete
+            # (type annotation or void terminator) with balanced braces,
+            # OR when the incoming line is an SSA assignment (%name = )
+            # which unambiguously starts a new operation.
+            #
+            # Type-terminal flush (adjacent ops without blank line):
+            #   %c0 = arith.constant 0 : index   <- complete (: index)
+            #   %c1 = arith.constant 1 : index   <- new op
+            #
+            # SSA flush (prev op has no type terminal, e.g. dimensions=):
+            #   linalg.broadcast ... dimensions = [1]   <- no type
+            #   %next = arith.subf ...                  <- SSA triggers flush
+            #
+            # Multi-line ops stay together until complete:
+            #   %t = construct_indirect_access_tile   <- no type yet
+            #       intermediate_variables(...)        <- continuation
+            #       %view[...] { ... } : ... -> type  <- complete
             accumulated = ' '.join(current_op_lines)
             open_braces = accumulated.count('{') - accumulated.count('}')
-            # Don't flush when accumulated ends with '=' — the next line is
-            # a continuation (e.g. multi-result: %a, %b, %c =\n  scf.for ...)
-            ends_with_eq = accumulated.rstrip().endswith('=')
-            if self._is_new_operation(stripped) and current_op_lines and open_braces == 0 and not ends_with_eq:
-                # Flush the previous operation
-                results.append((accumulated, current_regions))
-                current_op_lines = []
-                current_regions = []
+            # A line starting with '->' is always a result-type
+            # continuation (e.g. `: input_types\n  -> result_type`).
+            if current_op_lines and open_braces == 0 and not stripped.startswith('->'):
+                starts_ssa = re.match(
+                    r'(?:%\w+\s*,\s*)*%\w+\s*=\s', stripped
+                )
+                if self._is_op_complete(accumulated) or starts_ssa:
+                    results.append((accumulated, current_regions))
+                    current_op_lines = []
+                    current_regions = []
 
             current_op_lines.append(stripped)
 
-            # Check if this line opens a region body (scf.for, scf.if).
-            # A region starts when a line ends with '{' and the operation
-            # is a control flow op (scf.for, scf.if).
-            # We need to find the matching '}' across subsequent lines.
-            if self._line_opens_region(stripped, current_op_lines):
+            # Check if this line opens a region body.
+            # A region { } is distinguished from an attribute { } by
+            # peeking inside: regions contain %SSA references,
+            # attribute blocks do not.
+            if self._line_opens_region(stripped, lines, i):
                 # The '{' at the end of this line opens a region.
                 # Remove the trailing '{' from the op text.
                 current_op_lines[-1] = stripped.rstrip('{').rstrip()
@@ -305,76 +323,54 @@ class KTIRParser:
 
         return results
 
-    def _is_new_operation(self, stripped_line: str) -> bool:
-        """Check if a stripped line starts a new operation.
+    # Regex matching a terminal type token at end of op text.
+    # Covers: tensor<...>, memref<...>, !ktdp.access_tile<...>,
+    #         index, i32, f16, f32, etc.
+    _TYPE_TERMINAL_RE = re.compile(
+        r'(?::\s|->)\s*.*(?:>|index|[iuf]\d+)\s*$'
+    )
 
-        A new operation starts with:
-        - %result = op_name ...
-        - op_name ...  (where op_name matches dialect.op pattern)
-        - return ...
-        - scf.for, scf.if, scf.yield
+    def _is_op_complete(self, accumulated: str) -> bool:
+        """Check whether *accumulated* op text is structurally complete.
 
-        Continuation lines start with:
-        - sizes:, strides:, base_map, access_tile_set
-        - : (type annotation on its own line)
-        - } (closing brace of attribute block)
+        An MLIR operation is complete when it has a terminal type
+        annotation (``:``, ``->``) or is a void terminator (``return``,
+        ``scf.yield``).  Ops that end without a type annotation
+        (e.g. ``linalg.reduce ... dimensions = [1]``) rely on a
+        trailing blank line to flush instead.
         """
-        # Continuation patterns: these never start a new operation
-        if stripped_line.startswith((
-            'sizes:', 'strides:', 'base_map', 'access_tile_set',
-            'ins(', 'outs(', 'dimensions', 'permutation',  # linalg ops continuation
-        )):
+        # Strip trailing inline comments
+        text = re.sub(r'//[^\n]*', '', accumulated).rstrip()
+        if not text:
             return False
-        if stripped_line.startswith('}'):
-            return False
-        # A line starting with ':' is a type continuation
-        if stripped_line.startswith(':'):
-            return False
-
-        # Check for result assignment: %name = op_type
-        # Also handles multi-result: %a, %b, %c = op_type  (or split across lines: %a, %b, %c =)
-        if re.match(r'(?:%\w+\s*,\s*)*%\w+\s*=\s*[a-z_]', stripped_line):
+        # Void terminators
+        if text == 'return' or text.startswith('return ') or text.startswith('scf.yield'):
             return True
-        if re.match(r'(?:%\w+\s*,\s*)*%\w+\s*=\s*$', stripped_line):
+        # Type annotation: `: <type>` or `-> <type>` at end
+        if self._TYPE_TERMINAL_RE.search(text):
             return True
-
-        # Infix shorthand: %result = %lhs * %rhs : index
-        if re.match(r'%\w+\s*=\s*%\w+\s*[\+\-\*]', stripped_line):
-            return True
-
-        # Check for operation without result: op_type operands
-        if re.match(r'[a-z_][a-z0-9_\.]*\s', stripped_line):
-            return True
-
-        # Stand-alone operation names like "return" or "scf.yield"
-        if re.match(r'[a-z_][a-z0-9_\.]*$', stripped_line):
-            return True
-
         return False
 
-    def _line_opens_region(self, stripped_line: str, current_op_lines: List[str]) -> bool:
-        """Check if the current line opens a region body for scf.for etc.
+    def _line_opens_region(self, stripped_line: str, lines: List[str], line_idx: int) -> bool:
+        """Check if the current line opens a region body.
 
-        A region is opened when:
-        1. The line ends with '{'
-        2. The operation is a control flow op (scf.for, scf.if)
-
-        We check the accumulated op lines to see if the operation is scf.for.
+        A region ``{`` is distinguished from an attribute block ``{``
+        structurally: attribute blocks contain ``key = value`` pairs
+        (no ``%`` SSA references), while region blocks contain
+        operations that always reference ``%`` SSA names.  We peek
+        into the ``{ }`` block and check for ``%``.
         """
         if not stripped_line.endswith('{'):
             return False
-
-        # Look through accumulated lines for the operation type
-        op_text = ' '.join(current_op_lines)
-        # scf.for opens a region
-        if 'scf.for ' in op_text or op_text.startswith('scf.for'):
-            return True
-        if 'scf.if ' in op_text or op_text.startswith('scf.if'):
-            return True
-        # linalg.generic: the region opens on the outs(...) { line, not on
-        # the first { which is the inline attribute block.
-        if 'linalg.generic' in op_text and 'outs(' in op_text:
-            return True
+        # Peek into the { } block — if any line contains %, it's a region.
+        depth = 1
+        for j in range(line_idx + 1, len(lines)):
+            inner = lines[j]
+            depth += inner.count('{') - inner.count('}')
+            if '%' in inner:
+                return True
+            if depth <= 0:
+                break
         return False
 
     def _extract_region_from_lines(self, lines: List[str], open_brace_line: int) -> Tuple[Optional[str], int]:

--- a/ktir_cpu/parser.py
+++ b/ktir_cpu/parser.py
@@ -232,6 +232,10 @@ class KTIRParser:
         Returns:
             List of operations
         """
+        # Step 0: Strip inline comments so downstream methods don't need
+        # to worry about % or other tokens appearing inside comments.
+        body_text = self._preprocess_text(body_text)
+
         # Step 1: Tokenize body into complete operation strings.
         # An "operation string" is one or more physical lines that together
         # form a single MLIR operation. Multi-line ops like
@@ -252,6 +256,18 @@ class KTIRParser:
                 operations.append(op)
 
         return operations
+
+    @staticmethod
+    def _preprocess_text(text: str) -> str:
+        """Normalize MLIR text before tokenization.
+
+        Applied once before ``_tokenize_operations`` so that downstream
+        methods (region detection, type-terminal checks) operate on
+        clean text.  Currently strips inline comments (``// ...``
+        through end-of-line); future preprocessing steps (e.g.
+        whitespace normalization) can be added here.
+        """
+        return re.sub(r'//[^\n]*', '', text)
 
     def _tokenize_operations(self, body_text: str) -> List[Tuple[str, List[str]]]:
         """Split body text into (operation_text, [region_bodies]) pairs.
@@ -364,8 +380,7 @@ class KTIRParser:
         (e.g. ``linalg.reduce ... dimensions = [1]``) rely on a
         trailing blank line to flush instead.
         """
-        # Strip trailing inline comments
-        text = re.sub(r'//[^\n]*', '', accumulated).rstrip()
+        text = accumulated.rstrip()
         if not text:
             return False
         # Void terminators
@@ -376,23 +391,28 @@ class KTIRParser:
             return True
         return False
 
+    # MLIR SSA value names: % followed by a digit, letter, or id-punct [$._-].
+    _SSA_REF_RE = re.compile(r'%[\w$.]')
+
     def _line_opens_region(self, stripped_line: str, lines: List[str], line_idx: int) -> bool:
         """Check if the current line opens a region body.
 
         A region ``{`` is distinguished from an attribute block ``{``
         structurally: attribute blocks contain ``key = value`` pairs
         (no ``%`` SSA references), while region blocks contain
-        operations that always reference ``%`` SSA names.  We peek
-        into the ``{ }`` block and check for ``%``.
+        operations that always reference ``%`` SSA names.
+
+        Comments are already stripped by ``_preprocess_text``, so we
+        only need to check for ``%`` followed by a valid SSA name
+        character (letter, digit, ``$``, ``.``, ``_``).
         """
         if not stripped_line.endswith('{'):
             return False
-        # Peek into the { } block — if any line contains %, it's a region.
         depth = 1
         for j in range(line_idx + 1, len(lines)):
             inner = lines[j]
             depth += inner.count('{') - inner.count('}')
-            if '%' in inner:
+            if self._SSA_REF_RE.search(inner):
                 return True
             if depth <= 0:
                 break

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -156,8 +156,8 @@ module {
 # 3. Unknown op dispatch — warning, no exception
 # ---------------------------------------------------------------------------
 
-def test_unknown_op_does_not_raise(capsys):
-    """An unregistered op_type prints a warning and does not raise."""
+def test_unknown_op_raises():
+    """An unregistered op_type raises ValueError."""
     ktir = """
 module {
     func.func @dummy() -> () attributes { grid = [1, 1, 1] } {
@@ -176,38 +176,8 @@ module {
         result_type=None,
         regions=[],
     )
-    # Must not raise
-    interp._execute_operation(unknown_op, core, interp.ring_network)
-
-    captured = capsys.readouterr()
-    assert "totally.unknown_op" in captured.out
-    assert "Warning" in captured.out or "unknown" in captured.out.lower()
-
-
-def test_unknown_op_result_not_stored(capsys):
-    """Result SSA name is not populated for unknown ops."""
-    ktir = """
-module {
-    func.func @dummy() -> () attributes { grid = [1, 1, 1] } {
-        return
-    }
-}
-"""
-    interp = _make_interpreter_with_module(ktir)
-    core = _minimal_core(interp)
-
-    op = Operation(
-        result="%ghost",
-        op_type="nonexistent.op",
-        operands=[],
-        attributes={},
-        result_type=None,
-        regions=[],
-    )
-    interp._execute_operation(op, core, interp.ring_network)
-
-    with pytest.raises(KeyError):
-        core.get_value("%ghost")
+    with pytest.raises(ValueError, match="totally.unknown_op"):
+        interp._execute_operation(unknown_op, core, interp.ring_network)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_parser_errors.py
+++ b/tests/test_parser_errors.py
@@ -231,3 +231,227 @@ def test_parse_grid_malformed():
     parser = KTIRParser()
     module = parser.parse_module(mlir)
     assert module.functions["g"].grid == (1, 1, 1)
+
+
+# ---------------------------------------------------------------------------
+# Preprocessing: comment stripping
+# ---------------------------------------------------------------------------
+
+
+def test_preprocess_strips_inline_comments():
+    """_preprocess_text removes // comments, preserving line structure."""
+    text = "  %x = arith.addf %a, %b : f32  // add\n  return\n"
+    result = KTIRParser._preprocess_text(text)
+    assert "//" not in result
+    assert "%x = arith.addf" in result
+    assert "return" in result
+    # Line count preserved (newlines intact)
+    assert result.count("\n") == text.count("\n")
+
+
+def test_preprocess_full_line_comment_becomes_blank():
+    """A full-line comment becomes a blank line (op separator for tokenizer)."""
+    result = KTIRParser._preprocess_text("    // this is a comment\n")
+    assert result.strip() == ""
+
+
+# ---------------------------------------------------------------------------
+# Region detection: % in comments must not trigger false positive
+# ---------------------------------------------------------------------------
+
+
+def test_percent_in_comment_not_misclassified_as_region():
+    """Attribute block with % in a comment must not be treated as a region.
+
+    _line_opens_region peeks into { } blocks for SSA references (%<id>).
+    A bare % in a comment (e.g. '// 90% of time') must not match.
+    Regression test for reviewer comment on PR #5.
+    """
+    mlir = """
+module {
+  func.func @test() attributes { grid = [1] } {
+    %c0 = arith.constant 0 : index
+    %x = arith.constant {
+        value = 42 : i32
+    } : index
+    return %c0 : index
+  }
+}
+"""
+    # Baseline: attribute block without comment — no regions
+    parser = KTIRParser()
+    module = parser.parse_module(mlir)
+    func = module.get_function("test")
+    x_op = [op for op in func.operations if op.result == "%x"][0]
+    assert len(x_op.regions) == 0, "attribute block should not produce regions"
+
+
+def test_percent_in_comment_inside_attribute_block():
+    """Same as above but with a // comment containing % inside the block."""
+    mlir = """
+module {
+  func.func @test() attributes { grid = [1] } {
+    %c0 = arith.constant 0 : index
+    %x = arith.constant {
+        // use 100% of capacity
+        value = 42 : i32
+    } : index
+    return %c0 : index
+  }
+}
+"""
+    parser = KTIRParser()
+    module = parser.parse_module(mlir)
+    func = module.get_function("test")
+    x_op = [op for op in func.operations if op.result == "%x"][0]
+    assert len(x_op.regions) == 0, (
+        "% in comment inside attribute block must not trigger region detection"
+    )
+
+
+def test_region_with_percent_in_comment_still_detected():
+    """A real region with SSA refs + a comment containing % is still a region."""
+    mlir = """
+module {
+  func.func @test(%lb: index, %ub: index, %step: index) attributes { grid = [1] } {
+    scf.for %i = %lb to %ub step %step {
+        // iterate over 100% of elements
+        %c0 = arith.constant 0 : index
+        scf.yield
+    }
+    return
+  }
+}
+"""
+    parser = KTIRParser()
+    module = parser.parse_module(mlir)
+    func = module.get_function("test")
+    for_op = [op for op in func.operations if op.op_type == "scf.for"][0]
+    assert len(for_op.regions) == 1, "scf.for body should be detected as a region"
+
+
+# ---------------------------------------------------------------------------
+# Operation boundary detection
+#
+# The tokenizer detects where one MLIR operation ends and the next begins
+# using three structural signals (no dialect-specific knowledge):
+#
+# 1. Type-terminal completeness (_is_op_complete)
+# 2. Blank line (or full-line comment) after balanced braces
+# 3. SSA assignment (%name = ) starting a new op
+#
+# Void terminators (return, scf.yield) are special-cased in _is_op_complete.
+# ---------------------------------------------------------------------------
+
+
+# -- Signal 1: type-terminal completeness --
+# An op is complete when its text ends with `: <type>` or `-> <type>`,
+# where the type ends with `>`, `index`, or a scalar like `f32`/`i32`.
+
+def test_type_terminal_simple_types():
+    """_is_op_complete matches scalar and index type terminals."""
+    parser = KTIRParser()
+    assert parser._is_op_complete("%x = arith.addf %a, %b : f32")
+    assert parser._is_op_complete("%x = arith.addi %a, %b : index")
+    assert parser._is_op_complete("%x = arith.addi %a, %b : i32")
+
+
+def test_type_terminal_tensor():
+    """_is_op_complete matches tensor<...> type terminals."""
+    parser = KTIRParser()
+    assert parser._is_op_complete("%t = tensor.empty() : tensor<128x256xf16>")
+
+
+def test_type_terminal_nested_angle_brackets():
+    """_is_op_complete handles nested <> in complex type annotations.
+
+    Types like tensor<..., #encoding<{...}>> have nested <> but the
+    heuristic only checks that the line ends with >, so nesting depth
+    doesn't matter.
+    """
+    parser = KTIRParser()
+    complex_type = (
+        "%t = tensor.empty() : tensor<128x256xf16, "
+        "#sparse_tensor.encoding<{map = (d0, d1) -> (d0 : dense, d1 : compressed)}>>"
+    )
+    assert parser._is_op_complete(complex_type)
+
+
+def test_type_terminal_arrow():
+    """_is_op_complete matches -> return type terminals."""
+    parser = KTIRParser()
+    assert parser._is_op_complete(
+        "%acc = ktdp.construct_access_tile %ref[%c0, %c0]"
+        " : memref<128x256xf16> -> !ktdp.access_tile<128x256xindex>"
+    )
+
+
+def test_type_terminal_void_terminators():
+    """_is_op_complete recognises return and scf.yield as complete."""
+    parser = KTIRParser()
+    assert parser._is_op_complete("return")
+    assert parser._is_op_complete("return %c0 : index")
+    assert parser._is_op_complete("scf.yield")
+    assert parser._is_op_complete("scf.yield %acc : tensor<8xf32>")
+
+
+def test_type_terminal_no_match():
+    """_is_op_complete returns False when op has no type terminal.
+
+    Ops like linalg.reduce that end with `dimensions = [1]` are flushed
+    by a blank line or SSA assignment instead.
+    """
+    parser = KTIRParser()
+    assert not parser._is_op_complete(
+        "%r = linalg.reduce { arith.maxnumf }"
+        " ins(%x : tensor<4xf16>)"
+        " outs(%init : tensor<1xf16>)"
+        " dimensions = [1]"
+    )
+
+
+# -- Signal 2: blank line flush --
+# A blank line (or full-line comment) after balanced braces flushes
+# the accumulated op. This handles ops with no type terminal.
+
+def test_blank_line_flushes_op():
+    """An op without a type terminal is flushed by a following blank line."""
+    mlir = """
+module {
+  func.func @test(%x: tensor<4xf16>, %init: tensor<1xf16>) attributes { grid = [1] } {
+    %r = linalg.reduce { arith.maxnumf } ins(%x : tensor<4xf16>) outs(%init : tensor<1xf16>) dimensions = [0]
+
+    return
+  }
+}
+"""
+    parser = KTIRParser()
+    module = parser.parse_module(mlir)
+    func = module.get_function("test")
+    op_types = [op.op_type for op in func.operations]
+    assert "linalg.reduce" in op_types, "reduce op should be flushed by blank line"
+    assert "return" in op_types
+
+
+# -- Signal 3: SSA assignment flush --
+# An incoming `%name = ` line unambiguously starts a new op,
+# flushing the previous one even without a blank line.
+
+def test_ssa_assignment_flushes_previous_op():
+    """Adjacent ops without blank line: SSA assignment starts new op."""
+    mlir = """
+module {
+  func.func @test() attributes { grid = [1] } {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    return
+  }
+}
+"""
+    parser = KTIRParser()
+    module = parser.parse_module(mlir)
+    func = module.get_function("test")
+    constants = [op for op in func.operations if op.op_type == "arith.constant"]
+    assert len(constants) == 2, "two adjacent constants should be parsed as separate ops"
+
+


### PR DESCRIPTION
Closes #4  and addresses #6   cc: @mudhakar @raghukiran1224  @kiszk 

## Roadmap

> MLIR frontend parser series: add `MLIRFrontendParser` as a swappable
> alternative to the regex-based `KTIRParser`.

**PR 1 — Decouple parser**: Make the tokenizer and region detector fully
structural so they require zero dialect-specific metadata. Pure
refactoring — no new API, no new features.

**PR 2 — Test mixins + KTIRParserBase ABC**: Introduce the
`KTIRParserBase` abstract base class and refactor both test suites to use
mixins that decouple test assertions from parser implementation. This is
the infrastructure that enables any future parser backend to reuse all
existing tests.

**PR 3 — MLIRFrontendParser**: Implement `MLIRFrontendParser` in
`ktir_cpu/mlir_frontend/` using `mlir_ktdp.ir` structural walk with
`MLIRTypeAdapter` (30+ per-op handlers). Add adapter test suites that
reuse all existing tests via the mixin infrastructure from PR 2.

---

- **→ PR 1 — Decouple parser from dialect-specific logic**
- PR 2 — Test mixins + KTIRParserBase ABC
- PR 3 — MLIRFrontendParser + adapter test suite

## Goal

Make the KTIR parser fully dialect-agnostic so that adding new ops never
requires touching the tokenizer or region detector. This is a prerequisite
for the MLIR frontend parser: both backends must agree on how to split MLIR text
into ops and regions, and structural detection eliminates the need for
dialect-specific metadata.

## Background

The tokenizer previously used `_is_new_operation` with a hardcoded list of
continuation prefixes (`sizes:`, `strides:`, `ins(`, `outs(`, `dimensions`,
...). Every new multi-line op required adding its continuation keyword.
Similarly, `_line_opens_region` hardcoded op names that introduce regions.

## Key changes: structural decoupling

### `ktir_cpu/parser.py` — structural tokenization and region detection

Replace keyword-based mechanisms with structural detection:

**Multi-line operation grouping** — flip the question from "does the next
line look like a continuation?" to "is the accumulated op complete?". Three
structural signals drive flushing:

- **Type-terminal completeness** (`_is_op_complete`): an op is complete
  when its accumulated text ends with `: <type>` or `-> <type>`, or is a
  void terminator (`return`, `scf.yield`)
- **Blank lines**: a blank line after balanced-brace content always flushes
- **SSA assignment**: an incoming `%name = ` line unambiguously starts a
  new op

This eliminates the hardcoded continuation-prefix list (`sizes:`,
`strides:`, `ins(`, `outs(`, `dimensions`, ...). A new multi-line op like
`construct_indirect_access_tile` with `intermediate_variables(...)`
continuation lines just works — the accumulated text has no type annotation
yet, so lines keep accumulating until it does.

**Region detection** — peek into `{ }` blocks and check for `%` SSA
references. Attribute blocks (`{ key = value }`) never contain `%`; region
blocks (`{ %x = arith.addf ... }`) always do. This handles `scf.for`,
`scf.if`, `linalg.generic`, and `linalg.reduce` (explicit-region form)
without any op-specific knowledge.

**Design docstring** — add KTIRParser 3-phase design overview with explicit
extension rules:

1. Do **not** add operation-specific keywords to the tokenizer
2. Do **not** hardcode op names for region detection

| Old (dialect-coupled) | New (structural) |
|---|---|
| New multi-line op → add continuation prefix | Just works (type-terminal detection) |
| New region-opening op → add to hardcoded list | Just works (`%` heuristic) |

### `ktir_cpu/dialects/linalg_ops.py` — combiner resolution from regions

The structural region detector now correctly extracts the `{ arith.maxnumf }`
body of explicit-region `linalg.reduce` as an `op.regions` entry. Update the
executor to resolve the combiner from `op.regions` when present, instead of
relying solely on the shorthand `{ arith.maxnumf }` attribute string.

This is a direct consequence of the decoupling: the old code treated
`{ arith.maxnumf }` as an inline attribute because `_line_opens_region`
did not know about `linalg.reduce`. The structural `%`-peek correctly
classifies it as a region when the body contains SSA references, and as an
attribute when it does not (shorthand form). The executor must handle both.

## Side-fixes included in this PR

These are small fixes found during testing of the structural changes. They
are included here because they exercise the new tokenizer paths and confirm
the decoupling works end-to-end.

### `ktir_cpu/interpreter.py` — unknown ops raise `ValueError`

Previously, unknown ops printed a warning and continued silently. This
masked spec-gap failures. Changed to `ValueError` so that `xfail(strict=True)`
tests in `test_spec_gaps.py` fail deterministically. Included here because
the structural region detector changes which ops are "seen" by the
interpreter (e.g. region bodies are now correctly extracted), so the error
behaviour must be well-defined.

### `ktir_cpu/dialects/ktdp_ops.py` + `examples/triton-ktir/indexed_add.mlir` — whitespace fix

The `construct_indirect_access_tile` parser required
`intermediate_variables(` with no space before the paren. Compiler output
sometimes emits `intermediate_variables (` with a space. Fixed the regex
to `intermediate_variables\s*\(`. Included here because the new
type-terminal tokenizer correctly joins these lines (validating the
decoupling), but the dialect parser then failed on the space.

### `ktir_cpu/dialects/registry.py` — remove unused import

Dead code cleanup.

### `tests/test_interpreter.py` — update unknown-op tests

Follows from the `ValueError` change above.

## Changes per file

| File | Category | Change |
|------|----------|--------|
| `ktir_cpu/parser.py` | **core** | Replace `_is_new_operation` with `_is_op_complete`; replace hardcoded `_line_opens_region` with structural `%` peek; add 3-phase design docstring |
| `ktir_cpu/dialects/linalg_ops.py` | **core** | Combiner resolution from `op.regions`; document two reduce forms |
| `ktir_cpu/interpreter.py` | side-fix | Unknown ops raise `ValueError` |
| `ktir_cpu/dialects/ktdp_ops.py` | side-fix | `intermediate_variables\s*\(` whitespace fix |
| `examples/triton-ktir/indexed_add.mlir` | side-fix | Whitespace fix to match compiler output |
| `ktir_cpu/dialects/registry.py` | side-fix | Remove unused import |
| `tests/test_interpreter.py` | side-fix | Update unknown-op tests for `ValueError` |

## Test plan

- [ ] `indexed_add.mlir` (construct_indirect_access_tile with `intermediate_variables (...)`) parses correctly
- [ ] `paged_attention.mlir` regression check (indirect access inside scf.for)
- [ ] `reduce_generic.mlir` explicit-region linalg.reduce parses and executes
- [ ] Unknown ops raise `ValueError` (test_scf_parallel xfail strict)


