### PR TITLE
[Fix] Centralize dtype handling in dtypes.py; fix byte-size bugs for non-f16 dtypes

### DIFF
--- a/ktir_cpu/dialects/arith_ops.py
+++ b/ktir_cpu/dialects/arith_ops.py
@@ -18,6 +18,7 @@ import re
 
 import numpy as np
 
+from ..dtypes import to_np_dtype
 from ..ir_types import Operation, Tile
 from ..latency import LatencyCategory as LC
 from ..ops.arith_ops import ArithOps
@@ -150,7 +151,7 @@ def arith__constant(op, context, env):
     if op.attributes.get("is_tensor"):
         shape = op.attributes["shape"]
         dtype_str = op.attributes.get("dtype", "f16")
-        np_dtype = np.float16 if dtype_str == "f16" else np.int32
+        np_dtype = to_np_dtype(dtype_str)
         return Tile(np.full(shape, value, dtype=np_dtype), dtype_str, shape)
     return value
 

--- a/ktir_cpu/dialects/tensor_ops.py
+++ b/ktir_cpu/dialects/tensor_ops.py
@@ -20,6 +20,7 @@ from typing import Optional, Tuple
 import numpy as np
 
 from ..grid import CoreContext
+from ..dtypes import to_np_dtype
 from ..ir_types import Operation, Tile
 from .registry import register, register_parser
 
@@ -47,7 +48,7 @@ def tensor__empty(op, context, env):
     """Create an uninitialized tensor of the given shape."""
     shape = op.attributes.get("shape", (1,))
     dtype_str = op.attributes.get("dtype", "f16")
-    dtype = np.float16 if "f16" in dtype_str else np.float32
+    dtype = to_np_dtype(dtype_str)
     data = np.zeros(shape, dtype=dtype)
     return Tile(data, dtype_str, shape)
 
@@ -77,9 +78,9 @@ def tensor__splat(op, context, env):
         np_dtype = np.int32
         dtype_str = "i32"
     else:
-        np_dtype = np.float16 if dtype_str in ("f16", "f32") else np.int32
+        np_dtype = to_np_dtype(dtype_str)
 
-    scalar_val = float(scalar) if np_dtype == np.float16 else int(scalar)
+    scalar_val = float(scalar) if np.issubdtype(np_dtype, np.floating) else int(scalar)
     data = np.full(shape, scalar_val, dtype=np_dtype)
     return Tile(data, dtype_str, shape)
 

--- a/ktir_cpu/dialects/tensor_ops.py
+++ b/ktir_cpu/dialects/tensor_ops.py
@@ -80,8 +80,7 @@ def tensor__splat(op, context, env):
     else:
         np_dtype = to_np_dtype(dtype_str)
 
-    scalar_val = float(scalar) if np.issubdtype(np_dtype, np.floating) else int(scalar)
-    data = np.full(shape, scalar_val, dtype=np_dtype)
+    data = np.full(shape, scalar, dtype=np_dtype)
     return Tile(data, dtype_str, shape)
 
 

--- a/ktir_cpu/dtypes.py
+++ b/ktir_cpu/dtypes.py
@@ -1,0 +1,84 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Canonical KTIR dtype mappings.
+
+Single source of truth for all dtype-related logic.  Every module that
+needs to convert between KTIR dtype strings and NumPy dtypes should
+import from here.
+"""
+
+import numpy as np
+
+SUPPORTED_DTYPES: dict[str, np.dtype] = {
+    # floating point
+    "f16":     np.dtype(np.float16),
+    "fp16":    np.dtype(np.float16),
+    "float16": np.dtype(np.float16),
+    "f32":     np.dtype(np.float32),
+    "float32": np.dtype(np.float32),
+    # integer
+    "i32":     np.dtype(np.int32),
+    "si32":    np.dtype(np.int32),
+    "index":   np.dtype(np.int32),
+    "i64":     np.dtype(np.int64),
+    "si64":    np.dtype(np.int64),
+}
+
+# Placeholder dtypes: not yet exercised by any example.  to_np_dtype raises
+# NotImplementedError for these so that any future example that uses them
+# fails test_examples immediately, forcing a proper implementation first.
+# Pending confirmation from @kiszk @Prasanth-Chatarasi on simulation semantics.
+_PLACEHOLDER_DTYPES: frozenset[str] = frozenset({"fp8", "mxfp8"})
+
+_REVERSE_MAP: dict[np.dtype, str] = {
+    np.dtype(np.float16): "f16",
+    np.dtype(np.float32): "f32",
+    np.dtype(np.int32):   "i32",
+    np.dtype(np.int64):   "i64",
+}
+
+
+def to_np_dtype(dtype: str) -> np.dtype:
+    """Convert a KTIR dtype string to a NumPy dtype.
+
+    Raises NotImplementedError for placeholder dtypes (fp8, mxfp8).
+    Raises ValueError for unrecognised strings.
+    """
+    if dtype in _PLACEHOLDER_DTYPES:
+        raise NotImplementedError(
+            f"dtype {dtype!r} is a placeholder pending hardware confirmation; "
+            "update SUPPORTED_DTYPES before adding examples that use it"
+        )
+    try:
+        return SUPPORTED_DTYPES[dtype]
+    except KeyError:
+        raise ValueError(f"Unsupported KTIR dtype: {dtype!r}")
+
+
+def bytes_per_elem(dtype: str) -> int:
+    """Return element size in bytes for a KTIR dtype string."""
+    return int(to_np_dtype(dtype).itemsize)
+
+
+def to_ktir_dtype(np_dtype: np.dtype) -> str:
+    """Map a NumPy dtype to a canonical KTIR dtype string.
+
+    Raises ValueError for unrecognised NumPy dtypes.
+    """
+    np_dtype = np.dtype(np_dtype)
+    try:
+        return _REVERSE_MAP[np_dtype]
+    except KeyError:
+        raise ValueError(f"No KTIR dtype for NumPy dtype: {np_dtype!r}")

--- a/ktir_cpu/dtypes.py
+++ b/ktir_cpu/dtypes.py
@@ -39,7 +39,9 @@ SUPPORTED_DTYPES: dict[str, np.dtype] = {
 # Placeholder dtypes: not yet exercised by any example.  to_np_dtype raises
 # NotImplementedError for these so that any future example that uses them
 # fails test_examples immediately, forcing a proper implementation first.
-# Pending confirmation from @kiszk @Prasanth-Chatarasi on simulation semantics.
+# fp8/mxfp8 are registered as placeholders that raise NotImplementedError. 
+# RFC 0682 doesn't define them; torch-spyre uses "fp8" at 1 byte/elem on hardware. 
+# NOTE: What should the simulation representation be?
 _PLACEHOLDER_DTYPES: frozenset[str] = frozenset({"fp8", "mxfp8"})
 
 _REVERSE_MAP: dict[np.dtype, str] = {

--- a/ktir_cpu/interpreter.py
+++ b/ktir_cpu/interpreter.py
@@ -31,16 +31,7 @@ from .latency import HardwareConfig, LatencyTracker, LatencyReport
 from .dialects import dispatch, ExecutionEnv
 
 
-def _ktir_dtype(np_dtype: np.dtype) -> str:
-    """Map a numpy dtype to a KTIR dtype string."""
-    if np_dtype == np.float16:
-        return "f16"
-    elif np_dtype == np.float32:
-        return "f32"
-    elif np_dtype == np.int32:
-        return "i32"
-    else:
-        return "f16"
+from .dtypes import to_ktir_dtype as _ktir_dtype
 
 
 class KTIRInterpreter:

--- a/ktir_cpu/ir_types.py
+++ b/ktir_cpu/ir_types.py
@@ -72,9 +72,9 @@ class TileRef:
 
     def size_bytes(self) -> int:
         """Calculate size in bytes."""
+        from .memory import _bytes_per_elem
         total_elements = np.prod(self.shape)
-        bytes_per_element = 2 if self.dtype == "f16" else 1  # f16=2, mxfp8=1
-        return int(total_elements * bytes_per_element)
+        return int(total_elements * _bytes_per_elem(self.dtype))
 
 
 @dataclass

--- a/ktir_cpu/ir_types.py
+++ b/ktir_cpu/ir_types.py
@@ -37,7 +37,7 @@ class Tile:
     in MLIR).  Produced by load operations and consumed by compute ops.
     """
     data: np.ndarray
-    dtype: str  # "f16" or "mxfp8"
+    dtype: str  # see dtypes.SUPPORTED_DTYPES
     shape: Tuple[int, ...]
 
     def copy(self) -> 'Tile':
@@ -72,9 +72,8 @@ class TileRef:
 
     def size_bytes(self) -> int:
         """Calculate size in bytes."""
-        from .memory import _bytes_per_elem
-        total_elements = np.prod(self.shape)
-        return int(total_elements * _bytes_per_elem(self.dtype))
+        from .dtypes import bytes_per_elem
+        return int(np.prod(self.shape) * bytes_per_elem(self.dtype))
 
 
 @dataclass

--- a/ktir_cpu/memory.py
+++ b/ktir_cpu/memory.py
@@ -91,20 +91,7 @@ import numpy as np
 # Module-level helpers shared by HBMSimulator and LXScratchpad
 # ---------------------------------------------------------------------------
 
-def _get_np_dtype(dtype: str) -> np.dtype:
-    """Convert a KTIR dtype string to a NumPy dtype."""
-    if dtype in ("f16", "fp16", "float16"):
-        return np.float16
-    if dtype in ("i32", "si32", "index"):
-        return np.int32
-    if dtype in ("i64", "si64"):
-        return np.int64
-    return np.float32  # f8 / mxfp8 / others approximated as float32
-
-
-def _bytes_per_elem(dtype: str) -> int:
-    """Return element size in bytes for a KTIR dtype string."""
-    return int(np.dtype(_get_np_dtype(dtype)).itemsize)
+from .dtypes import to_np_dtype as _get_np_dtype, bytes_per_elem as _bytes_per_elem
 
 
 def _find_allocation(
@@ -294,7 +281,7 @@ class HBMSimulator:
             Use ``read(ptr, 1, dtype)[0]`` instead.  This method will be
             removed when the tt dialect is updated.
         """
-        bytes_per_elem = 2 if dtype in ("f16", "fp16", "float16") else 4
+        bytes_per_elem = _bytes_per_elem(dtype)
         alloc = _find_allocation(self.memory, addr, bytes_per_elem)
         if alloc is None:
             return np.float16(0.0)

--- a/ktir_cpu/memory.py
+++ b/ktir_cpu/memory.py
@@ -91,13 +91,13 @@ import numpy as np
 # Module-level helpers shared by HBMSimulator and LXScratchpad
 # ---------------------------------------------------------------------------
 
-from .dtypes import to_np_dtype as _get_np_dtype, bytes_per_elem as _bytes_per_elem
+from .dtypes import to_np_dtype, bytes_per_elem
 
 
 def _find_allocation(
     memory: Dict[int, np.ndarray],
     ptr: int,
-    bytes_per_elem: int,
+    elem_size: int,
 ) -> Optional[Tuple[int, np.ndarray, int]]:
     """Find the allocation containing byte address *ptr*.
 
@@ -113,17 +113,17 @@ def _find_allocation(
         return (ptr, memory[ptr], 0)
     for base_ptr, data in memory.items():
         # Use the allocation's own itemsize to compute its byte span,
-        # not the caller's bytes_per_elem (which reflects the access dtype
+        # not the caller's elem_size (which reflects the access dtype
         # and may differ from the stored dtype).
         end_ptr = base_ptr + data.size * data.itemsize
- 
+
         # NOTE: the ptr in memory check in the first return
         #       actually handles the ptr == base_ptr case.
         # - therefore the strict equality base_ptr < ptr
-        #   is meant to emphasize that equality checks will 
+        #   is meant to emphasize that equality checks will
         #   not come to this branch of logic.
         if base_ptr < ptr < end_ptr:
-            elem_offset = (ptr - base_ptr) // bytes_per_elem
+            elem_offset = (ptr - base_ptr) // elem_size
             return (base_ptr, data, elem_offset)
     return None
 
@@ -133,7 +133,7 @@ def _read_flat(
     ptr: int,
     n_elements: int,
     np_dtype: np.dtype,
-    bytes_per_elem: int,
+    elem_size: int,
 ) -> np.ndarray:
     """Read *n_elements* elements starting at byte address *ptr*.
 
@@ -147,10 +147,10 @@ def _read_flat(
         memory = {0x1000: np.arange(16, dtype=np.float16)}
         # Read 13 elements starting at element 2 (byte offset 4 from base)
         flat = _read_flat(memory, ptr=0x1004, n_elements=13,
-                          np_dtype=np.float16, bytes_per_elem=2)
+                          np_dtype=np.float16, elem_size=2)
         # flat == [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]
     """
-    alloc = _find_allocation(memory, ptr, bytes_per_elem)
+    alloc = _find_allocation(memory, ptr, elem_size)
     if alloc is None:
         raise ValueError(f"Read from unmapped address 0x{ptr:x} (n_elements={n_elements})")
     _, data, elem_offset = alloc
@@ -254,8 +254,8 @@ class HBMSimulator:
         Returns:
             Flat NumPy array of length n_elements
         """
-        np_dtype = _get_np_dtype(dtype)
-        return _read_flat(self.memory, ptr, n_elements, np_dtype, _bytes_per_elem(dtype))
+        np_dtype = to_np_dtype(dtype)
+        return _read_flat(self.memory, ptr, n_elements, np_dtype, bytes_per_elem(dtype))
 
     def write(self, ptr: int, data: np.ndarray):
         """Write *data* (flat ndarray) starting at byte address *ptr*.
@@ -281,16 +281,12 @@ class HBMSimulator:
             Use ``read(ptr, 1, dtype)[0]`` instead.  This method will be
             removed when the tt dialect is updated.
         """
-        bytes_per_elem = _bytes_per_elem(dtype)
-        alloc = _find_allocation(self.memory, addr, bytes_per_elem)
+        elem_size = bytes_per_elem(dtype)
+        alloc = _find_allocation(self.memory, addr, elem_size)
         if alloc is None:
             return np.float16(0.0)
         _, data, elem_offset = alloc
         return data.flat[elem_offset]
-
-    def _get_np_dtype(self, dtype: str) -> np.dtype:
-        return _get_np_dtype(dtype)
-
 
 class LXScratchpad:
     """Simulates 2MB per-core scratchpad memory.
@@ -320,8 +316,8 @@ class LXScratchpad:
         Returns:
             Flat NumPy array of length n_elements
         """
-        np_dtype = _get_np_dtype(dtype)
-        return _read_flat(self.memory, ptr, n_elements, np_dtype, _bytes_per_elem(dtype))
+        np_dtype = to_np_dtype(dtype)
+        return _read_flat(self.memory, ptr, n_elements, np_dtype, bytes_per_elem(dtype))
 
     def write(self, ptr: int, data: np.ndarray):
         """Write *data* (flat ndarray) starting at byte address *ptr*.
@@ -340,10 +336,6 @@ class LXScratchpad:
         self.memory.clear()
         self.next_ptr = 0
         self.used = 0
-
-    def _get_np_dtype(self, dtype: str) -> np.dtype:
-        return _get_np_dtype(dtype)
-
 
 class SpyreMemoryHierarchy:
     """Complete memory hierarchy for Spyre: one shared HBM + per-core LX scratchpads.

--- a/ktir_cpu/ops/memory_ops.py
+++ b/ktir_cpu/ops/memory_ops.py
@@ -23,6 +23,7 @@ from typing import List, Optional, Tuple
 import numpy as np
 from ..affine import AffineMap
 from ..dialects.ktdp_helpers import eval_subscript_expr
+from ..dtypes import bytes_per_elem as _bytes_per_elem
 from ..ir_types import Tile, TileRef
 from ..grid import CoreContext
 
@@ -91,9 +92,9 @@ class MemoryOps:
             TileRef for the sub-tile
         """
         base_coords = base_map.eval(indices)
-        bytes_per_elem = 2 if parent_ref.dtype in ("f16", "fp16", "float16") else 4
+        bpe = _bytes_per_elem(parent_ref.dtype)
         offset = sum(coord * stride for coord, stride in zip(base_coords, parent_ref.strides))
-        new_ptr = parent_ref.base_ptr + offset * bytes_per_elem
+        new_ptr = parent_ref.base_ptr + offset * bpe
 
         return TileRef(
             base_ptr=new_ptr,

--- a/ktir_cpu/ops/memory_ops.py
+++ b/ktir_cpu/ops/memory_ops.py
@@ -292,7 +292,6 @@ class MemoryOps:
                     )
                     mem = context.hbm if idx_view.memory_space == "HBM" else context.lx
                     offset = sum(c * s for c, s in zip(idx_coords, idx_view.strides))
-                    from ..memory import _bytes_per_elem
                     addr = idx_view.base_ptr + offset * _bytes_per_elem(idx_view.dtype)
                     raw = mem.read(addr, 1, idx_view.dtype)
                     coord.append(int(raw[0]))

--- a/tests/test_dtypes.py
+++ b/tests/test_dtypes.py
@@ -1,0 +1,64 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for ktir_cpu.dtypes — the canonical dtype mapping module."""
+
+import numpy as np
+import pytest
+
+from ktir_cpu.dtypes import bytes_per_elem, to_ktir_dtype, to_np_dtype
+
+
+@pytest.mark.parametrize("ktir_dtype, expected_np, expected_bytes", [
+    ("f16",     np.float16, 2),
+    ("fp16",    np.float16, 2),
+    ("float16", np.float16, 2),
+    ("f32",     np.float32, 4),
+    ("float32", np.float32, 4),
+    ("i32",     np.int32,   4),
+    ("si32",    np.int32,   4),
+    ("index",   np.int32,   4),
+    ("i64",     np.int64,   8),
+    ("si64",    np.int64,   8),
+])
+def test_to_np_dtype(ktir_dtype, expected_np, expected_bytes):
+    assert to_np_dtype(ktir_dtype) == np.dtype(expected_np)
+    assert bytes_per_elem(ktir_dtype) == expected_bytes
+
+
+@pytest.mark.parametrize("bad_dtype", ["bf16", "i8", "unknown", ""])
+def test_unknown_dtype_raises(bad_dtype):
+    with pytest.raises(ValueError, match="Unsupported"):
+        to_np_dtype(bad_dtype)
+
+
+@pytest.mark.parametrize("placeholder_dtype", ["fp8", "mxfp8"])
+def test_placeholder_dtype_raises(placeholder_dtype):
+    with pytest.raises(NotImplementedError):
+        to_np_dtype(placeholder_dtype)
+
+
+@pytest.mark.parametrize("np_dtype, expected_ktir", [
+    (np.float16, "f16"),
+    (np.float32, "f32"),
+    (np.int32,   "i32"),
+    (np.int64,   "i64"),
+])
+def test_to_ktir_dtype(np_dtype, expected_ktir):
+    assert to_ktir_dtype(np.dtype(np_dtype)) == expected_ktir
+
+
+def test_to_ktir_dtype_unknown_raises():
+    with pytest.raises(ValueError, match="No KTIR dtype"):
+        to_ktir_dtype(np.dtype(np.float64))

--- a/tests/test_ktir_cpu.py
+++ b/tests/test_ktir_cpu.py
@@ -101,13 +101,16 @@ def test_hbm_write_partial_overwrite():
 
 
 def test_hbm_get_np_dtype():
-    """HBM._get_np_dtype: fp8 and else branches."""
+    """HBM._get_np_dtype: known dtypes, placeholders, and unknown."""
     hbm = HBMSimulator()
     assert hbm._get_np_dtype("f16") == np.float16
-    assert hbm._get_np_dtype("fp8") == np.float32
-    assert hbm._get_np_dtype("mxfp8") == np.float32
     assert hbm._get_np_dtype("float32") == np.float32
-    assert hbm._get_np_dtype("unknown") == np.float32
+    with pytest.raises(NotImplementedError):
+        hbm._get_np_dtype("fp8")
+    with pytest.raises(NotImplementedError):
+        hbm._get_np_dtype("mxfp8")
+    with pytest.raises(ValueError, match="Unsupported"):
+        hbm._get_np_dtype("unknown")
 
 
 def test_hbm_write_full_replacement():
@@ -150,13 +153,16 @@ def test_lx_read_shape_mismatch():
 
 
 def test_lx_get_np_dtype():
-    """LXScratchpad._get_np_dtype: fp8 and else branches."""
+    """LXScratchpad._get_np_dtype: known dtypes, placeholders, and unknown."""
     lx = LXScratchpad()
     assert lx._get_np_dtype("f16") == np.float16
-    assert lx._get_np_dtype("fp8") == np.float32
-    assert lx._get_np_dtype("mxfp8") == np.float32
     assert lx._get_np_dtype("float32") == np.float32
-    assert lx._get_np_dtype("unknown") == np.float32
+    with pytest.raises(NotImplementedError):
+        lx._get_np_dtype("fp8")
+    with pytest.raises(NotImplementedError):
+        lx._get_np_dtype("mxfp8")
+    with pytest.raises(ValueError, match="Unsupported"):
+        lx._get_np_dtype("unknown")
 
 
 def test_lx_clear():
@@ -426,13 +432,26 @@ def test_tile_operations():
     print("  ✓ TileRef works")
 
 
+@pytest.mark.parametrize("dtype, shape, expected_bytes", [
+    ("f16", (4,),  8),
+    ("f32", (4,), 16),
+    ("i32", (4,), 16),
+    ("i64", (4,), 32),
+])
+def test_tileref_size_bytes(dtype, shape, expected_bytes):
+    """TileRef.size_bytes: correct byte count for each supported dtype."""
+    ref = TileRef(base_ptr=0, shape=shape, strides=[1], memory_space="HBM", dtype=dtype)
+    assert ref.size_bytes() == expected_bytes
 
 
 def test_ktir_dtype_branches():
-    """_ktir_dtype: known dtypes and fallback."""
+    """_ktir_dtype: known dtypes and unknown raises."""
+    assert _ktir_dtype(np.dtype("float16")) == "f16"
     assert _ktir_dtype(np.dtype("float32")) == "f32"
     assert _ktir_dtype(np.dtype("int32")) == "i32"
-    assert _ktir_dtype(np.dtype("float16")) == "f16"
+    assert _ktir_dtype(np.dtype("int64")) == "i64"
+    with pytest.raises(ValueError):
+        _ktir_dtype(np.dtype("float64"))
 
 
 def test_interpreter_no_module_guard():

--- a/tests/test_ktir_cpu.py
+++ b/tests/test_ktir_cpu.py
@@ -100,19 +100,6 @@ def test_hbm_write_partial_overwrite():
     assert result[3] == np.float16(4), f"Expected 4 unchanged, got {result[3]}"
 
 
-def test_hbm_get_np_dtype():
-    """HBM._get_np_dtype: known dtypes, placeholders, and unknown."""
-    hbm = HBMSimulator()
-    assert hbm._get_np_dtype("f16") == np.float16
-    assert hbm._get_np_dtype("float32") == np.float32
-    with pytest.raises(NotImplementedError):
-        hbm._get_np_dtype("fp8")
-    with pytest.raises(NotImplementedError):
-        hbm._get_np_dtype("mxfp8")
-    with pytest.raises(ValueError, match="Unsupported"):
-        hbm._get_np_dtype("unknown")
-
-
 def test_hbm_write_full_replacement():
     """HBM.write: writing equal-or-larger data replaces existing allocation."""
     hbm = HBMSimulator()
@@ -150,19 +137,6 @@ def test_lx_read_shape_mismatch():
     assert result.shape == (6,)
     assert np.array_equal(result[:4], data)
     assert np.array_equal(result[4:], np.zeros(2, dtype=np.float16))
-
-
-def test_lx_get_np_dtype():
-    """LXScratchpad._get_np_dtype: known dtypes, placeholders, and unknown."""
-    lx = LXScratchpad()
-    assert lx._get_np_dtype("f16") == np.float16
-    assert lx._get_np_dtype("float32") == np.float32
-    with pytest.raises(NotImplementedError):
-        lx._get_np_dtype("fp8")
-    with pytest.raises(NotImplementedError):
-        lx._get_np_dtype("mxfp8")
-    with pytest.raises(ValueError, match="Unsupported"):
-        lx._get_np_dtype("unknown")
 
 
 def test_lx_clear():


### PR DESCRIPTION
## Problem

`TileRef.size_bytes()` was hardcoding `2 if dtype == "f16" else 1`, returning 1 byte/elem
for i32, i64, f32, and mxfp8. Investigating the fix revealed a broader issue: dtype
handling was duplicated across 8+ locations, with several containing real bugs:

| Location | Bug |
|---|---|
| `ops/memory_ops.py` tile_access | i64 → 4 bytes instead of 8 (wrong pointer offset) |
| `dialects/arith_ops.py` arith.constant | f32 → `np.int32` (wrong array dtype) |
| `dialects/tensor_ops.py` tensor.splat | f32 → `np.float16` (precision narrowing) |
| `dialects/tensor_ops.py` tensor.empty | substring match `"f16" in dtype_str` (fragile) |
| `interpreter.py` _ktir_dtype | missing i64 fallback → returned "f16" |
| `ir_types.py` TileRef.size_bytes | original bug: all non-f16 → 1 byte |

## Solution

Add `ktir_cpu/dtypes.py` as the single source of truth for all dtype mappings.
All six locations above now delegate here. No more silent fallbacks — unknown dtypes
raise `ValueError`; placeholder dtypes raise `NotImplementedError` (see below).

## Changes

- **new** `ktir_cpu/dtypes.py` — `SUPPORTED_DTYPES`, `to_np_dtype`, `bytes_per_elem`,
  `to_ktir_dtype`; private `_PLACEHOLDER_DTYPES` for fp8/mxfp8
- `ktir_cpu/ir_types.py` — `TileRef.size_bytes()` imports from `dtypes` (fixes layering)
- `ktir_cpu/memory.py` — `_get_np_dtype`/`_bytes_per_elem` re-exported from `dtypes`;
  `HBMSimulator.read_element` fixed (i64 was 4 bytes)
- `ktir_cpu/interpreter.py` — `_ktir_dtype` re-exported from `dtypes` (adds i64)
- `ktir_cpu/ops/memory_ops.py` — `tile_access` fixed (i64 pointer offset)
- `ktir_cpu/dialects/arith_ops.py` — `arith.constant` fixed (f32 → correct dtype)
- `ktir_cpu/dialects/tensor_ops.py` — `tensor.empty` and `tensor.splat` fixed
- **new** `tests/test_dtypes.py` — parametrized coverage for all supported dtypes
- `tests/test_ktir_cpu.py` — updated dtype assertions; added `test_tileref_size_bytes`

## Placeholder dtypes: fp8 / mxfp8

These do not appear in any `examples/` file, so they are registered as
`_PLACEHOLDER_DTYPES`. `to_np_dtype` raises `NotImplementedError` for them —
any future example that uses them will fail `test_examples` immediately, forcing a
proper implementation before merge.

Simulation semantics for fp8/mxfp8 need confirmation from @kiszk and
@Prasanth-Chatarasi before they can be promoted to full support.

## Tests

- Main baseline: 442 passed, 6 xfailed
- This branch: 467 passed, 6 xfailed (+25 new tests, zero regressions)
