### PR TITLE
MLIR Frontend PR 2 — Test mixins + KTIRParserBase ABC

### DIFF
--- a/ktir_cpu/__init__.py
+++ b/ktir_cpu/__init__.py
@@ -22,5 +22,6 @@ __version__ = "0.1.0"
 
 from .interpreter import KTIRInterpreter
 from .latency import HardwareConfig, LatencyReport
+from .parser import KTIRParserBase
 
-__all__ = ["KTIRInterpreter", "HardwareConfig", "LatencyReport"]
+__all__ = ["KTIRInterpreter", "HardwareConfig", "LatencyReport", "KTIRParserBase"]

--- a/ktir_cpu/dialects/arith_ops.py
+++ b/ktir_cpu/dialects/arith_ops.py
@@ -309,13 +309,24 @@ def parse_arith_constant(op_text, parse_ctx):
                 attributes["dtype"] = type_info.get("dtype", "f16")
                 attributes["is_tensor"] = True
     else:
+        # Match unbraced dense<value> followed by `: type`.  Covers:
+        #   dense<0.0> : tensor<4xf16>       (splat tensor constant)
+        #   dense<42> : tensor<1xi32>         (scalar tensor constant)
+        dense_match = re.match(r'dense<([^>]+)>\s*:\s*(.+)$', rest)
         # Match a scalar value followed by `: type`.  Covers:
         #   42 : index              (decimal integer)
         #   0.0 : f32               (float)
         #   -1.5e-3 : f16           (scientific notation)
         #   0xFF800000 : i32        (hex integer, e.g. -inf bit pattern)
         simple_match = re.match(r'(-?(?:0[xX][0-9a-fA-F]+|[\d.eE+\-]+))\s*:\s*(.+)$', rest)
-        if simple_match:
+        if dense_match:
+            value = parse_numeric(dense_match.group(1))
+            result_type = dense_match.group(2).strip()
+            type_info = parse_tensor_type(result_type)
+            attributes["shape"] = type_info["shape"]
+            attributes["dtype"] = type_info["dtype"]
+            attributes["is_tensor"] = True
+        elif simple_match:
             value = parse_numeric(simple_match.group(1))
             result_type = simple_match.group(2).strip()
         else:

--- a/ktir_cpu/interpreter.py
+++ b/ktir_cpu/interpreter.py
@@ -235,6 +235,12 @@ class KTIRInterpreter:
 
         return result
 
+    def arg_names(self, func_name: str) -> List[str]:
+        """Return argument names for a function in declaration order (without %)."""
+        if not self.module:
+            raise RuntimeError("No module loaded. Call load() first.")
+        return self.module.get_function(func_name).arg_names
+
     def tensor_input_output_sizes(self, func_name: str) -> Dict[str, Dict[str, Any]]:
         """Return shape and dtype for each tensor argument of a function.
 

--- a/ktir_cpu/interpreter.py
+++ b/ktir_cpu/interpreter.py
@@ -23,7 +23,7 @@ import numpy as np
 import math
 
 from .ir_types import Operation, IRModule, Tile
-from .parser import KTIRParser
+from .parser import KTIRParser, KTIRParserBase
 from .memory import SpyreMemoryHierarchy
 from .grid import GridExecutor, CoreContext
 from .ops.comm_ops import RingNetwork
@@ -49,7 +49,12 @@ class KTIRInterpreter:
     Loads KTIR MLIR code, sets up execution environment, and executes functions.
     """
 
-    def __init__(self, latency_config: Optional[HardwareConfig] = None, trace_latency: bool = False):
+    def __init__(
+        self,
+        latency_config: Optional[HardwareConfig] = None,
+        trace_latency: bool = False,
+        parser: Optional[KTIRParserBase] = None,
+    ):
         """Create a KTIR interpreter.
 
         Args:
@@ -61,12 +66,16 @@ class KTIRInterpreter:
                 record a per-operation trace in addition to aggregate
                 counters.  Useful for inspecting the cost of individual
                 operations.
+            parser: Parser to use in ``load()``.  Defaults to ``KTIRParser``
+                when ``None``.  Any object satisfying ``KTIRParserBase``
+                (i.e. has ``parse_module(str) -> IRModule``) is accepted.
         """
         self.module: Optional[IRModule] = None
         self.memory: Optional[SpyreMemoryHierarchy] = None
         self.grid_executor: Optional[GridExecutor] = None
         self.ring_network: Optional[RingNetwork] = None
         self._env: Optional[ExecutionEnv] = None
+        self._parser: Optional[KTIRParserBase] = parser
         self._latency_tracker: Optional[LatencyTracker] = (
             LatencyTracker(latency_config, trace=trace_latency)
             if latency_config is not None else None
@@ -76,9 +85,11 @@ class KTIRInterpreter:
         """Load and parse KTIR from a file path or MLIR text.
 
         Args:
-            ktir_source: Path to a KTIR file, or MLIR text directly
+            ktir_source: Path to a KTIR file, or MLIR text directly.
+                File paths are dispatched to ``parse_file``; inline text
+                is dispatched to ``parse_module``.
         """
-        parser = KTIRParser()
+        parser = self._parser if self._parser is not None else KTIRParser()
         if '\n' in ktir_source or ktir_source.lstrip().startswith('module'):
             self.module = parser.parse_module(ktir_source)
         else:

--- a/ktir_cpu/ir_types.py
+++ b/ktir_cpu/ir_types.py
@@ -142,8 +142,10 @@ class IRFunction:
     grid: Tuple[int, int, int]  # Grid shape from function attributes
     return_type: Optional[str] = None
     tensor_sizes: Dict[str, Dict[str, Any]] = field(default_factory=dict, init=False, repr=False)
+    arg_names: List[str] = field(default_factory=list, init=False, repr=False)
 
     def __post_init__(self):
+        self.arg_names = [name.lstrip("%") for name, _ in self.arguments]
         for op in _iter_ops(self.operations):
             if op.op_type == "ktdp.construct_memory_view" and op.operands:
                 arg_name = op.operands[0].lstrip("%")

--- a/ktir_cpu/ir_types.py
+++ b/ktir_cpu/ir_types.py
@@ -142,10 +142,12 @@ class IRFunction:
     grid: Tuple[int, int, int]  # Grid shape from function attributes
     return_type: Optional[str] = None
     tensor_sizes: Dict[str, Dict[str, Any]] = field(default_factory=dict, init=False, repr=False)
-    arg_names: List[str] = field(default_factory=list, init=False, repr=False)
+
+    @property
+    def arg_names(self) -> List[str]:
+        return [name.lstrip("%") for name, _ in self.arguments]
 
     def __post_init__(self):
-        self.arg_names = [name.lstrip("%") for name, _ in self.arguments]
         for op in _iter_ops(self.operations):
             if op.op_type == "ktdp.construct_memory_view" and op.operands:
                 arg_name = op.operands[0].lstrip("%")

--- a/ktir_cpu/parser.py
+++ b/ktir_cpu/parser.py
@@ -21,12 +21,33 @@ and all attribute syntaxes produced by the compiler.
 """
 
 import re
-from typing import Any, Dict, List, Optional, Tuple
+from abc import ABC, abstractmethod
+from typing import Dict, List, Optional, Tuple
 from .ir_types import Operation, IRFunction, IRModule
 from .dialects import dispatch_parser, make_parse_context, ParseContext
 from .parser_utils import parse_attr_block, parse_tensor_type, parse_numeric
 
-class KTIRParser:
+
+class KTIRParserBase(ABC):
+    """Abstract mixin for KTIR parsers.
+
+    Subclasses implement ``parse_module``; ``parse_file`` is provided
+    concretely and reads the file before calling ``parse_module``.
+
+    Concrete implementations:
+        KTIRParser          — regex + custom dialect parsers (this file)
+        MLIRBindingsParser  — mlir.ir walk (ktir_cpu/bindings/parser.py)
+    """
+
+    @abstractmethod
+    def parse_module(self, mlir_text: str) -> IRModule: ...
+
+    def parse_file(self, filepath: str) -> IRModule:
+        with open(filepath) as f:
+            return self.parse_module(f.read())
+
+
+class KTIRParser(KTIRParserBase):
     """KTIR MLIR parser.
 
     Parsing proceeds in three phases:
@@ -59,19 +80,6 @@ class KTIRParser:
       detected by the ``%`` heuristic; any ``{ }`` block that
       contains SSA references is automatically treated as a region.
     """
-
-    def parse_file(self, filepath: str) -> IRModule:
-        """Parse KTIR MLIR file.
-
-        Args:
-            filepath: Path to MLIR file
-
-        Returns:
-            IRModule
-        """
-        with open(filepath, 'r') as f:
-            text = f.read()
-        return self.parse_module(text)
 
     def parse_module(self, mlir_text: str) -> IRModule:
         """Parse KTIR MLIR text into module.

--- a/tests/test_dialects_parse.py
+++ b/tests/test_dialects_parse.py
@@ -73,10 +73,14 @@ class ParseTestMixin:
     def _parse(self, op_text, parse_ctx=None, args=None):
         """Parse a single op and return the resulting Operation.
 
-        ``args`` is an optional schema that declares the SSA arguments the op
-        depends on, as a ``{name: mlir_type}`` mapping.  This is a convenience
-        for single-op testing: it avoids writing a full MLIR module while still
-        providing explicit types for operands with complex types.  Example::
+        ``args`` is an optional ``{name: mlir_type}`` mapping that declares
+        **all** external SSA operands the op depends on — values defined
+        outside the op text that the op references.  Names defined *within*
+        the op (results on the LHS of ``=``, region block args like ``%i``
+        in ``scf.for %i = ...``, and iter-args) should **not** be included.
+
+        This is a convenience for single-op testing: it avoids writing a
+        full MLIR module while still providing explicit types.  Example::
 
             self._parse(
                 "%r = linalg.reduce { arith.maxnumf }"
@@ -86,10 +90,13 @@ class ParseTestMixin:
                 args={"%x": "tensor<1x1024xf16>", "%init": "tensor<1xf16>"},
             )
 
-        The regex parser ignores ``args`` and operates on the op text directly.
-        ``BindingsParseTestMixin`` uses it to build a typed function wrapper.
+        The regex parser ignores ``args`` and operates on the op text
+        directly.  The MLIR frontend adapter uses it to build a typed
+        ``func.func`` wrapper, so **missing operands will cause MLIR
+        verification errors** when the adapter tests run.
 
-        If ``args`` is provided, every name must appear in ``op_text``.
+        If ``args`` is provided, every declared name must appear in
+        ``op_text``.
         """
         args = self._resolve_args(op_text, args)
         ctx = parse_ctx or _parse_ctx()

--- a/tests/test_dialects_parse.py
+++ b/tests/test_dialects_parse.py
@@ -23,6 +23,15 @@ Covers:
 - ktdp dialect parsers: ktdp.get_compute_tile_id, ktdp.construct_memory_view,
                          ktdp.construct_access_tile
 - scf dialect parsers: scf.for, scf.yield
+
+Design rule
+-----------
+The goal of the regex parser is to parse valid MLIR.  All op text examples
+in this file must therefore be valid MLIR.  Non-MLIR syntax forces the
+corresponding test_bindings_adapt.py test to be skipped, which defeats the
+purpose of sharing tests between the two parser backends.
+
+All op text examples have been verified to parse with both backends.
 """
 
 import numpy as np
@@ -39,12 +48,86 @@ def _parse_ctx():
     return make_parse_context(aliases={})
 
 
-def _parse(op_text, parse_ctx=None):
-    """Dispatch-parse a single op line and return the Operation."""
-    ctx = parse_ctx or _parse_ctx()
-    parser_fn = dispatch_parser(op_text)
-    assert parser_fn is not None, f"No parser found for: {op_text!r}"
-    return parser_fn(op_text, ctx)
+class ParseTestMixin:
+    """Mixin that provides _parse and a portable assertion API.
+
+    Subclasses can override _parse to inject a different parser backend
+    (e.g. MLIRBindingsParser).
+
+    Assertion API
+    -------------
+    Use these methods for all op-level checks in base test classes.
+    They define the boundary between parser-agnostic checks (safe to
+    inherit) and parser-specific checks (must be overridden or skipped).
+
+    Parser-agnostic — always use these in base tests:
+        assert_op_type, assert_num_operands, assert_result_type,
+        assert_attribute
+
+    Parser-specific — override in subclasses or avoid in base tests:
+        assert_operand_names: checks exact SSA names; only valid for the
+        regex parser. BindingsParseTestMixin overrides this to a no-op since
+        the bindings parser uses positional %argN names.
+    """
+
+    def _parse(self, op_text, parse_ctx=None, args=None):
+        """Parse a single op and return the resulting Operation.
+
+        ``args`` is an optional schema that declares the SSA arguments the op
+        depends on, as a ``{name: mlir_type}`` mapping.  This is a convenience
+        for single-op testing: it avoids writing a full MLIR module while still
+        providing explicit types for operands with complex types.  Example::
+
+            self._parse(
+                "%r = linalg.reduce { arith.maxnumf }"
+                " ins(%x : tensor<1x1024xf16>)"
+                " outs(%init : tensor<1xf16>)"
+                " dimensions = [1]",
+                args={"%x": "tensor<1x1024xf16>", "%init": "tensor<1xf16>"},
+            )
+
+        The regex parser ignores ``args`` and operates on the op text directly.
+        ``BindingsParseTestMixin`` uses it to build a typed function wrapper.
+
+        If ``args`` is provided, every name must appear in ``op_text``.
+        """
+        args = self._resolve_args(op_text, args)
+        ctx = parse_ctx or _parse_ctx()
+        ops = KTIRParser()._parse_operations(op_text, ctx)
+        assert ops, f"No op parsed from: {op_text!r}"
+        return ops[0]
+
+    def _resolve_args(self, op_text, args):
+        """Normalise and validate the args schema against op_text.
+
+        Returns ``args`` as a ``dict``, defaulting to ``{}`` if not provided.
+        Asserts that every declared name appears in ``op_text``.
+        """
+        args = args or {}
+        for name in args:
+            assert name in op_text, f"arg {name!r} not found in op_text"
+        return args
+
+    def assert_op_type(self, op, expected):
+        assert op.op_type == expected
+
+    def assert_num_operands(self, op, n):
+        assert len(op.operands) == n
+
+    def assert_result_type(self, op, expected):
+        assert op.result_type == expected
+
+    def assert_attribute(self, op, key, value, transform=None):
+        actual = op.attributes[key]
+        if transform is not None:
+            actual = transform(actual)
+        assert actual == value
+
+    def assert_operand_names(self, op, *names):
+        """Regex-parser-specific: checks exact SSA operand names.
+        Override to no-op in bindings subclasses."""
+        for name in names:
+            assert name in op.operands
 
 
 # ---------------------------------------------------------------------------
@@ -132,171 +215,218 @@ class TestModuleParser:
 # arith dialect parsers
 # ---------------------------------------------------------------------------
 
-class TestArithParsers:
+class TestArithParsers(ParseTestMixin):
     def test_constant_scalar(self):
         # scalar integer constant parsed with correct value
-        op = _parse("%c0 = arith.constant 42 : index")
+        op = self._parse("%c0 = arith.constant 42 : index")
         assert op.op_type == "arith.constant"
         assert op.attributes["value"] == 42
 
     def test_constant_dense_tensor(self):
         # dense<0.0> tensor constant sets is_tensor, shape, and dtype
-        op = _parse("%t = arith.constant {dense<0.0>} : tensor<4xf16>")
-        assert op.attributes["is_tensor"] is True
-        assert op.attributes["shape"] == (4,)
-        assert op.attributes["dtype"] == "f16"
+        op = self._parse("%t = arith.constant dense<0.0> : tensor<4xf16>")
+        self.assert_op_type(op, "arith.constant")
+        self.assert_attribute(op, "is_tensor", True)
+        self.assert_attribute(op, "shape", (4,))
+        self.assert_attribute(op, "dtype", "f16")
 
     def test_cmpi_basic(self):
         # cmpi records predicate and both operands
-        op = _parse("%b = arith.cmpi slt, %a, %c0 : index")
-        assert op.op_type == "arith.cmpi"
-        assert op.attributes["predicate"] == "slt"
-        assert "%a" in op.operands
-        assert "%c0" in op.operands
+        op = self._parse(
+            "%b = arith.cmpi slt, %a, %c0 : index",
+            args={"%a": "index", "%c0": "index"},
+        )
+        self.assert_op_type(op, "arith.cmpi")
+        self.assert_attribute(op, "predicate", "slt")
+        self.assert_num_operands(op, 2)
+        self.assert_operand_names(op, "%a", "%c0")
 
     def test_cmpi_all_predicates(self):
         # all six comparison predicates are recognised
         for pred in ("eq", "ne", "slt", "sle", "sgt", "sge"):
-            op = _parse(f"%b = arith.cmpi {pred}, %x, %y : i32")
-            assert op.attributes["predicate"] == pred
+            op = self._parse(
+                f"%b = arith.cmpi {pred}, %x, %y : i32",
+                args={"%x": "i32", "%y": "i32"},
+            )
+            self.assert_attribute(op, "predicate", pred)
 
     def test_sitofp(self):
         # sitofp records operand and target float type
-        op = _parse("%f = arith.sitofp %i : i32 to f16")
-        assert op.op_type == "arith.sitofp"
-        assert op.operands == ["%i"]
-        assert op.result_type == "f16"
+        op = self._parse(
+            "%f = arith.sitofp %i : i32 to f16",
+            args={"%i": "i32"},
+        )
+        self.assert_op_type(op, "arith.sitofp")
+        self.assert_num_operands(op, 1)
+        self.assert_operand_names(op, "%i")
+        self.assert_result_type(op, "f16")
 
 
 # ---------------------------------------------------------------------------
 # linalg dialect parsers
 # ---------------------------------------------------------------------------
 
-class TestLinalgParsers:
+class TestLinalgParsers(ParseTestMixin):
     def test_reduce(self):
         # reduce records reduce_fn, dim, outs_var, and ins operand
-        op = _parse(
+        op = self._parse(
             "%r = linalg.reduce { arith.maxnumf }"
             " ins(%x : tensor<1x1024xf16>)"
             " outs(%init : tensor<1xf16>)"
-            " dimensions = [1]"
+            " dimensions = [1]",
+            args={"%x": "tensor<1x1024xf16>", "%init": "tensor<1xf16>"},
         )
-        assert op.op_type == "linalg.reduce"
-        assert op.attributes["reduce_fn"] == "arith.maxnumf"
-        assert op.attributes["dim"] == 1
-        assert op.attributes["outs_var"] == "%init"
-        assert "%x" in op.operands
+        self.assert_op_type(op, "linalg.reduce")
+        self.assert_attribute(op, "reduce_fn", "arith.maxnumf")
+        self.assert_attribute(op, "dim", 1)
+        self.assert_num_operands(op, 1)
+        self.assert_operand_names(op, "%x")
 
     def test_fill(self):
         # fill records both ins and outs operands
-        op = _parse(
-            "%out = linalg.fill ins(%val : f16) outs(%buf : tensor<4xf16>) -> tensor<4xf16>"
+        op = self._parse(
+            "%out = linalg.fill ins(%val : f16) outs(%buf : tensor<4xf16>) -> tensor<4xf16>",
+            args={"%val": "f16", "%buf": "tensor<4xf16>"},
         )
-        assert op.op_type == "linalg.fill"
-        assert "%val" in op.operands
-        assert "%buf" in op.operands
+        self.assert_op_type(op, "linalg.fill")
+        self.assert_num_operands(op, 2)
+        self.assert_operand_names(op, "%val", "%buf")
 
     def test_broadcast(self):
         # broadcast records dimensions and both ins/outs operands
-        op = _parse(
-            "%out = linalg.broadcast ins(%x : tensor<4xf16>) outs(%buf : tensor<4x8xf16>) dimensions = [1]"
+        op = self._parse(
+            "%out = linalg.broadcast ins(%x : tensor<4xf16>) outs(%buf : tensor<4x8xf16>) dimensions = [1]",
+            args={"%x": "tensor<4xf16>", "%buf": "tensor<4x8xf16>"},
         )
-        assert op.op_type == "linalg.broadcast"
-        assert op.attributes["dimensions"] == [1]
-        assert "%x" in op.operands
-        assert "%buf" in op.operands
+        self.assert_op_type(op, "linalg.broadcast")
+        self.assert_attribute(op, "dimensions", [1])
+        self.assert_num_operands(op, 2)
+        self.assert_operand_names(op, "%x", "%buf")
 
 
 # ---------------------------------------------------------------------------
 # tensor dialect parsers
 # ---------------------------------------------------------------------------
 
-class TestTensorParsers:
+class TestTensorParsers(ParseTestMixin):
     def test_empty(self):
         # tensor.empty records shape and dtype from type annotation
-        op = _parse("%t = tensor.empty() : tensor<1x1024xf16>")
-        assert op.op_type == "tensor.empty"
-        assert op.attributes["shape"] == (1, 1024)
-        assert op.attributes["dtype"] == "f16"
+        op = self._parse("%t = tensor.empty() : tensor<1x1024xf16>")
+        self.assert_op_type(op, "tensor.empty")
+        self.assert_attribute(op, "shape", (1, 1024))
+        self.assert_attribute(op, "dtype", "f16")
 
     def test_splat(self):
         # tensor.splat records scalar operand and target shape
-        op = _parse("%t = tensor.splat %val : tensor<4xf16>")
-        assert op.op_type == "tensor.splat"
-        assert op.operands == ["%val"]
-        assert op.attributes["shape"] == (4,)
+        op = self._parse(
+            "%t = tensor.splat %val : tensor<4xf16>",
+            args={"%val": "f16"},
+        )
+        self.assert_op_type(op, "tensor.splat")
+        self.assert_num_operands(op, 1)
+        self.assert_operand_names(op, "%val")
+        self.assert_attribute(op, "shape", (4,))
 
     def test_extract(self):
         # tensor.extract records tensor operand and index operands
-        op = _parse("%s = tensor.extract %t[%i, %j] : tensor<4x4xf16>")
-        assert op.op_type == "tensor.extract"
-        assert op.operands[0] == "%t"
-        assert "%i" in op.operands
-        assert "%j" in op.operands
+        op = self._parse(
+            "%s = tensor.extract %t[%i, %j] : tensor<4x4xf16>",
+            args={"%t": "tensor<4x4xf16>", "%i": "index", "%j": "index"},
+        )
+        self.assert_op_type(op, "tensor.extract")
+        self.assert_num_operands(op, 3)
+        self.assert_operand_names(op, "%t", "%i", "%j")
 
     def test_expand_shape(self):
         # tensor.expand_shape records source operand and target shape
-        op = _parse("%out = tensor.expand_shape %in into tile<1x1024xf16>")
-        assert op.op_type == "tensor.expand_shape"
-        assert op.operands == ["%in"]
-        assert op.attributes["target_shape"] == (1, 1024)
+        op = self._parse(
+            "%out = tensor.expand_shape %in [[0, 1]] output_shape [1, 1024]"
+            " : tensor<1024xf16> into tensor<1x1024xf16>",
+            args={"%in": "tensor<1024xf16>"},
+        )
+        self.assert_op_type(op, "tensor.expand_shape")
+        self.assert_num_operands(op, 1)
+        self.assert_operand_names(op, "%in")
+        self.assert_attribute(op, "target_shape", (1, 1024))
 
 
 # ---------------------------------------------------------------------------
 # ktdp dialect parsers
 # ---------------------------------------------------------------------------
 
-class TestKtdpParsers:
+class TestKtdpParsers(ParseTestMixin):
     def test_get_compute_tile_id_single(self):
-        # single-result form records num_dims=1 and result name
-        op = _parse("%id = ktdp.get_compute_tile_id : index")
-        assert op.op_type == "ktdp.get_compute_tile_id"
-        assert op.attributes["num_dims"] == 1
-        assert op.result == "%id"
+        # single-result form records num_dims=1 and a scalar result
+        op = self._parse("%id = ktdp.get_compute_tile_id : index")
+        self.assert_op_type(op, "ktdp.get_compute_tile_id")
+        self.assert_attribute(op, "num_dims", 1)
+        assert isinstance(op.result, str)
 
     def test_get_compute_tile_id_multi(self):
         # multi-result form records num_dims=2 and a list result
-        op = _parse("%x, %y = ktdp.get_compute_tile_id : index, index")
-        assert op.op_type == "ktdp.get_compute_tile_id"
-        assert op.attributes["num_dims"] == 2
+        op = self._parse("%x, %y = ktdp.get_compute_tile_id : index, index")
+        self.assert_op_type(op, "ktdp.get_compute_tile_id")
+        self.assert_attribute(op, "num_dims", 2)
         assert isinstance(op.result, list)
 
     def test_construct_memory_view(self):
-        # construct_memory_view records shape, dtype, and pointer operand
-        op = _parse(
-            "%view = ktdp.construct_memory_view %ptr,"
-            " sizes: [1024], strides: [1] : index -> memref<1024xf16>"
+        # construct_memory_view records shape, strides, dtype, memory_space, and pointer operand
+        op = self._parse(
+            "%view = ktdp.construct_memory_view %ptr, sizes: [1024], strides: [1]"
+            " { coordinate_set = affine_set<(d0) : (d0 >= 0, -d0 + 1023 >= 0)>,"
+            " memory_space = #ktdp.spyre_memory_space<HBM> } : memref<1024xf16>",
+            args={"%ptr": "index"},
         )
-        assert op.op_type == "ktdp.construct_memory_view"
-        assert op.attributes["shape"] == (1024,)
-        assert op.attributes["dtype"] == "f16"
-        assert op.operands == ["%ptr"]
+        self.assert_op_type(op, "ktdp.construct_memory_view")
+        self.assert_attribute(op, "shape", (1024,))
+        self.assert_attribute(op, "strides", [1])
+        self.assert_attribute(op, "dtype", "f16")
+        self.assert_attribute(op, "memory_space", "HBM")
+        self.assert_num_operands(op, 1)
+        self.assert_operand_names(op, "%ptr")
 
     def test_construct_access_tile(self):
-        # construct_access_tile records tile shape and base view operand
-        op = _parse(
+        # construct_access_tile records tile shape and all operands
+        op = self._parse(
             "%acc = ktdp.construct_access_tile %view[%c0]"
-            " : memref<1024xf16> -> !ktdp.access_tile<128xindex>"
+            " { access_tile_set = affine_set<(d0) : (d0 >= 0, -d0 + 127 >= 0)>,"
+            " access_tile_order = affine_map<(d0) -> (d0)> }"
+            " : memref<1024xf16> -> !ktdp.access_tile<128xindex>",
+            args={"%view": "memref<1024xf16>", "%c0": "index"},
         )
-        assert op.op_type == "ktdp.construct_access_tile"
-        assert op.attributes["shape"] == (128,)
-        assert "%view" in op.operands
+        self.assert_op_type(op, "ktdp.construct_access_tile")
+        self.assert_attribute(op, "shape", (128,))
+        self.assert_attribute(op, "base_map", "affine_map<(d0) -> (d0)>", transform=lambda x: x.source)
+        self.assert_num_operands(op, 2)
+        self.assert_operand_names(op, "%view", "%c0")
 
     def test_construct_access_tile_non_index_elem_type_rejected(self):
         # Per spec, AccessTileType element type must be 'index'; any other type
         # is a spec violation and must be rejected at parse time.
-        with pytest.raises(ValueError, match="element type must be 'index'"):
-            _parse(
+        # The result type below is !ktdp.access_tile<128xf16> — 'f16' must be 'index'.
+        # regex raises: ValueError "AccessTileType element type must be 'index', got 'f16'"
+        # mlir  raises: MLIRError  "tile element type must be 'index', but got: 'f16'"
+        with pytest.raises(Exception, match=r"element type must be 'index'.*f16"):
+            self._parse(
                 "%acc = ktdp.construct_access_tile %view[%c0]"
-                " : memref<1024xf16> -> !ktdp.access_tile<128xf16>"
+                " { access_tile_set = affine_set<(d0) : (d0 >= 0, -d0 + 127 >= 0)>,"
+                " access_tile_order = affine_map<(d0) -> (d0)> }"
+                " : memref<1024xf16> -> !ktdp.access_tile<128xf16>",
+                args={"%view": "memref<1024xf16>", "%c0": "index"},
             )
 
     def test_construct_access_tile_malformed_type_rejected(self):
-        # A type string with no alphabetic element-type suffix is malformed.
-        with pytest.raises(ValueError, match="Malformed access_tile type"):
-            _parse(
+        # The result type !ktdp.access_tile<128> has no element type (must be <128xindex>).
+        # Both parsers reject the missing 'x<type>' suffix, with different messages:
+        # regex raises: ValueError "Malformed access_tile type '128': expected '<dims>xindex>'"
+        # mlir  raises: MLIRError  "expected 'x' in dimension list"
+        with pytest.raises(Exception, match=r"Malformed access_tile|expected 'x' in dimension"):
+            self._parse(
                 "%acc = ktdp.construct_access_tile %view[%c0]"
-                " : memref<1024xf16> -> !ktdp.access_tile<128>"
+                " { access_tile_set = affine_set<(d0) : (d0 >= 0, -d0 + 127 >= 0)>,"
+                " access_tile_order = affine_map<(d0) -> (d0)> }"
+                " : memref<1024xf16> -> !ktdp.access_tile<128>",
+                args={"%view": "memref<1024xf16>", "%c0": "index"},
             )
 
 
@@ -304,58 +434,91 @@ class TestKtdpParsers:
 # scf dialect parsers
 # ---------------------------------------------------------------------------
 
-class TestScfParsers:
+class TestScfParsers(ParseTestMixin):
     def test_for_basic(self):
         # scf.for records iter_var and lb/ub/step operands in order
-        op = _parse("scf.for %i = %lb to %ub step %step {")
-        assert op.op_type == "scf.for"
-        assert op.attributes["iter_var"] == "%i"
-        assert op.operands[:3] == ["%lb", "%ub", "%step"]
+        op = self._parse(
+            "scf.for %i = %lb to %ub step %step {\n      scf.yield\n    }",
+            args={"%lb": "index", "%ub": "index", "%step": "index"},
+        )
+        self.assert_op_type(op, "scf.for")
+        self.assert_attribute(op, "iter_var", "%i")
+        self.assert_num_operands(op, 3)
+        self.assert_operand_names(op, "%lb", "%ub", "%step")
 
     def test_for_with_result(self):
         # optional result prefix on scf.for is captured
-        op = _parse("%res = scf.for %i = %lb to %ub step %step {")
-        assert op.result == "%res"
-        assert op.attributes["iter_var"] == "%i"
+        op = self._parse(
+            "%res = scf.for %i = %lb to %ub step %step iter_args(%acc = %lb) -> (index) {\n"
+            "      scf.yield %acc : index\n    }",
+            args={"%lb": "index", "%ub": "index", "%step": "index"},
+        )
+        assert isinstance(op.result, str)
+        self.assert_attribute(op, "iter_var", "%i")
 
     def test_for_iter_args(self):
         # iter_args clause records carried variable and init operand
-        op = _parse(
-            "scf.for %i = %lb to %ub step %step iter_args(%acc = %init) {"
+        op = self._parse(
+            "%res = scf.for %i = %lb to %ub step %step iter_args(%acc = %init) -> (f16) {\n"
+            "      scf.yield %acc : f16\n    }",
+            args={"%lb": "index", "%ub": "index", "%step": "index", "%init": "f16"},
         )
-        assert op.attributes["iter_args"] == ["%acc"]
-        assert "%init" in op.operands
+        self.assert_attribute(op, "iter_args", ["%acc"])
+        self.assert_operand_names(op, "%init")
 
     def test_for_multi_result(self):
         # multi-result scf.for records a list of result names
-        op = _parse(
+        op = self._parse(
             "%M, %L, %acc = scf.for %j = %c0 to %n step %c1"
-            " iter_args(%m = %M0, %l = %L0, %a = %A0) {"
+            " iter_args(%m = %M0, %l = %L0, %a = %A0) -> (f16, f16, f16) {\n"
+            "      scf.yield %m, %l, %a : f16, f16, f16\n    }",
+            args={"%c0": "index", "%n": "index", "%c1": "index",
+                  "%M0": "f16", "%L0": "f16", "%A0": "f16"},
         )
-        assert op.op_type == "scf.for"
+        self.assert_op_type(op, "scf.for")
         assert isinstance(op.result, list)
-        assert op.result == ["%M", "%L", "%acc"]
-        assert op.attributes["iter_var"] == "%j"
-        assert op.attributes["iter_args"] == ["%m", "%l", "%a"]
-        assert op.operands[:3] == ["%c0", "%n", "%c1"]
+        assert len(op.result) == 3
+        self.assert_attribute(op, "iter_var", "%j")
+        self.assert_attribute(op, "iter_args", ["%m", "%l", "%a"])
+        # operands = [lb, ub, step, init_m, init_l, init_a]
+        self.assert_num_operands(op, 6)
+        self.assert_operand_names(op, "%c0", "%n", "%c1", "%M0", "%L0", "%A0")
 
     def test_for_multi_result_two(self):
         # two-result variant also produces a list
-        op = _parse("%x, %y = scf.for %i = %lo to %hi step %s {")
+        op = self._parse(
+            "%x, %y = scf.for %i = %lo to %hi step %s"
+            " iter_args(%a = %lo, %b = %hi) -> (index, index) {\n"
+            "      scf.yield %a, %b : index, index\n    }",
+            args={"%lo": "index", "%hi": "index", "%s": "index"},
+        )
         assert isinstance(op.result, list)
-        assert op.result == ["%x", "%y"]
+        assert len(op.result) == 2
 
     def test_yield_single(self):
         # scf.yield with one value records the operand
-        op = _parse("scf.yield %val : f16")
-        assert op.op_type == "scf.yield"
-        assert "%val" in op.operands
+        for_op = self._parse(
+            "%res = scf.for %i = %lb to %ub step %step iter_args(%acc = %val) -> (f16) {\n"
+            "      scf.yield %val : f16\n    }",
+            args={"%lb": "index", "%ub": "index", "%step": "index", "%val": "f16"},
+        )
+        op = for_op.regions[0][0]
+        self.assert_op_type(op, "scf.yield")
+        self.assert_num_operands(op, 1)
+        self.assert_operand_names(op, "%val")
 
     def test_yield_multi(self):
         # scf.yield with two values records both operands
-        op = _parse("scf.yield %a, %b : f16, f16")
-        assert "%a" in op.operands
-        assert "%b" in op.operands
+        for_op = self._parse(
+            "%r, %s = scf.for %i = %lb to %ub step %step"
+            " iter_args(%acc = %a, %acc2 = %b) -> (f16, f16) {\n"
+            "      scf.yield %a, %b : f16, f16\n    }",
+            args={"%lb": "index", "%ub": "index", "%step": "index",
+                  "%a": "f16", "%b": "f16"},
+        )
+        op = for_op.regions[0][0]
+        self.assert_num_operands(op, 2)
+        self.assert_operand_names(op, "%a", "%b")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -63,6 +63,20 @@ class InterpreterTestMixin:
     def _make_interp(self):
         return KTIRInterpreter()
 
+    @staticmethod
+    def _build_kwargs(entry, tensors, overrides=None):
+        """Merge execute_kwargs scalars with tensor args for execute_function.
+
+        Raises AssertionError if any key appears in both scalars and tensors,
+        preventing silent overwrites like the duplicate-n_rows bug.
+        """
+        scalars = {k: v for k, v in entry["execute_kwargs"].items() if v is not None}
+        if overrides:
+            scalars.update(overrides)
+        overlap = scalars.keys() & tensors.keys()
+        assert not overlap, f"duplicate keys in tensors and scalars: {overlap}"
+        return {**scalars, **tensors}
+
 
 # ---------------------------------------------------------------------------
 # Parsing tests — all example files must parse into valid modules
@@ -124,11 +138,8 @@ class TestVectorAddExecution(InterpreterTestMixin):
         y = rng.standard_normal(n).astype(np.float16)
         output = np.zeros(n, dtype=np.float16)
 
-        outputs = interp.execute_function(
-            func_name,
-            **{x_ptr: x, y_ptr: y, output_ptr: output,
-               BLOCK_SIZE: entry["execute_kwargs"]["BLOCK_SIZE"]},
-        )
+        kwargs = self._build_kwargs(entry, {x_ptr: x, y_ptr: y, output_ptr: output})
+        outputs = interp.execute_function(func_name, **kwargs)
 
         result = outputs[output_ptr]
         expected = (x + y).astype(np.float16)
@@ -147,11 +158,8 @@ class TestVectorAddExecution(InterpreterTestMixin):
         y = np.linspace(-10, 10, n, dtype=np.float16)
         output = np.zeros(n, dtype=np.float16)
 
-        outputs = interp.execute_function(
-            func_name,
-            **{x_ptr: x, y_ptr: y, output_ptr: output,
-               BLOCK_SIZE: entry["execute_kwargs"]["BLOCK_SIZE"]},
-        )
+        kwargs = self._build_kwargs(entry, {x_ptr: x, y_ptr: y, output_ptr: output})
+        outputs = interp.execute_function(func_name, **kwargs)
 
         result = outputs[output_ptr]
         expected = (x + y).astype(np.float16)
@@ -180,12 +188,11 @@ class TestSoftmaxExecution(InterpreterTestMixin):
         ).astype(np.float16)
         out = np.zeros((n_rows_val, n_padded_cols), dtype=np.float16)
 
-        kwargs = {k: v for k, v in entry["execute_kwargs"].items() if v is not None}
-        kwargs["n_cols"] = n_real_cols  # fill dynamic kwarg
-
-        outputs = interp.execute_function(
-            func_name, **{**kwargs, output_ptr: out, input_ptr: inp},
+        kwargs = self._build_kwargs(
+            entry, {output_ptr: out, input_ptr: inp},
+            overrides={"n_cols": n_real_cols},
         )
+        outputs = interp.execute_function(func_name, **kwargs)
         result = outputs[output_ptr]
 
         # NumPy reference: softmax per row
@@ -217,12 +224,9 @@ class TestSoftmaxExecution(InterpreterTestMixin):
         inp = rng.standard_normal((n_rows_val, n_cols)).astype(np.float16)
         out = np.zeros((n_rows_val, n_cols), dtype=np.float16)
 
-        kwargs = {k: v for k, v in entry["execute_kwargs"].items() if v is not None}
+        kwargs = self._build_kwargs(entry, {output_ptr: out, input_ptr: inp})
         with pytest.raises(MemoryError, match=entry["exception_msg"]):
-            interp.execute_function(
-                func_name,
-                **{**kwargs, output_ptr: out, input_ptr: inp},
-            )
+            interp.execute_function(func_name, **kwargs)
 
 
 class TestLayerNormExecution(InterpreterTestMixin):
@@ -249,15 +253,11 @@ class TestLayerNormExecution(InterpreterTestMixin):
         Mean_data = np.zeros(n_rows, dtype=np.float16)
         Rstd_data = np.zeros(n_rows, dtype=np.float16)
 
-        kwargs = {k: v for k, v in entry["execute_kwargs"].items() if v is not None}
-        outputs = interp.execute_function(
-            func_name,
-            **{X: X_data, Y: Y_data, W: W_data, B: B_data,
-               Mean: Mean_data, Rstd: Rstd_data,
-               N: kwargs.pop("N"), eps: kwargs.pop("eps"),
-               BLOCK_SIZE: kwargs.pop("BLOCK_SIZE"),
-               **kwargs},  # remaining: stride (body-level)
-        )
+        kwargs = self._build_kwargs(entry, {
+            X: X_data, Y: Y_data, W: W_data, B: B_data,
+            Mean: Mean_data, Rstd: Rstd_data,
+        })
+        outputs = interp.execute_function(func_name, **kwargs)
         result_Y = outputs[Y]
         result_Mean = outputs[Mean]
 
@@ -296,7 +296,8 @@ class TestReduceExplicitRegion(InterpreterTestMixin):
 
         (arg0,) = interp.arg_names(func_name)
         data = np.array([[1, 2, 3, 4]], dtype=np.float16)
-        outputs = interp.execute_function(func_name, **{arg0: data})
+        kwargs = self._build_kwargs(entry, {arg0: data})
+        outputs = interp.execute_function(func_name, **kwargs)
         result = outputs[arg0]
 
         expected = np.full((1, 4), 10.0, dtype=np.float16)
@@ -310,7 +311,8 @@ class TestReduceExplicitRegion(InterpreterTestMixin):
 
         (arg0,) = interp.arg_names(func_name)
         data = np.zeros((1, 4), dtype=np.float16)
-        outputs = interp.execute_function(func_name, **{arg0: data})
+        kwargs = self._build_kwargs(entry, {arg0: data})
+        outputs = interp.execute_function(func_name, **kwargs)
         result = outputs[arg0]
 
         np.testing.assert_allclose(result, np.zeros((1, 4), dtype=np.float16), atol=1e-3)
@@ -326,22 +328,15 @@ class TestMatMulExecution(InterpreterTestMixin):
         interp.load(path)
 
         a_ptr, b_ptr, c_ptr, K, BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = interp.arg_names(func_name)
-        kwargs = {k: v for k, v in entry["execute_kwargs"].items() if v is not None}
-        M, N, K_val = kwargs["M"], kwargs["N"], kwargs["K"]
+        ek = entry["execute_kwargs"]
+        M, N, K_val = ek["M"], ek["N"], ek["K"]
         rng = np.random.default_rng(42)
         A = rng.standard_normal((M, K_val)).astype(np.float16)
         B = rng.standard_normal((K_val, N)).astype(np.float16)
         C = np.zeros((M, N), dtype=np.float16)
 
-        outputs = interp.execute_function(
-            func_name,
-            **{a_ptr: A, b_ptr: B, c_ptr: C,
-               K: kwargs.pop("K"),
-               BLOCK_SIZE_M: kwargs.pop("BLOCK_SIZE_M"),
-               BLOCK_SIZE_N: kwargs.pop("BLOCK_SIZE_N"),
-               BLOCK_SIZE_K: kwargs.pop("BLOCK_SIZE_K"),
-               **kwargs},  # remaining: M, N, stride_* (body-level)
-        )
+        kwargs = self._build_kwargs(entry, {a_ptr: A, b_ptr: B, c_ptr: C})
+        outputs = interp.execute_function(func_name, **kwargs)
         result_C = outputs[c_ptr]
 
         expected = (A.astype(np.float32) @ B.astype(np.float32)).astype(np.float16)
@@ -366,13 +361,11 @@ class TestIndexedAddExecution(InterpreterTestMixin):
         y = rng.standard_normal((2, 32, 8, 128)).astype(np.float16)
         index = np.array([3, 7], dtype=np.int64)
         output = np.zeros((2, 32, 8, 128), dtype=np.float16)
-        kwargs = {k: v for k, v in entry["execute_kwargs"].items() if v is not None}
-        dim1_start_val = kwargs.get("dim1_start", 0)
-        outputs = interp.execute_function(
-            func_name,
-            **{x_ptr: x, y_ptr: y, index_ptr: index,
-               output_ptr: output, dim1_start: dim1_start_val},
-        )
+        dim1_start_val = entry["execute_kwargs"].get("dim1_start", 0)
+        kwargs = self._build_kwargs(entry, {
+            x_ptr: x, y_ptr: y, index_ptr: index, output_ptr: output,
+        })
+        outputs = interp.execute_function(func_name, **kwargs)
         result = outputs[output_ptr]
         assert result.shape == (2, 32, 8, 128)
         assert not np.any(np.isnan(result)), "output contains NaN"
@@ -408,22 +401,16 @@ class TestPagedAttentionExecution(InterpreterTestMixin):
         value_cache = rng.standard_normal((64, 16, 8, 128)).astype(np.float16)
         block_tables = rng.integers(0, 64, size=(1, 16), dtype=np.int32)
         output = np.zeros((8, 32, 128), dtype=np.float16)
-        kwargs = {k: v for k, v in entry["execute_kwargs"].items() if v is not None}
-        scale_val = kwargs.pop("scale")
-        num_tiles_val = kwargs.pop("num_tiles")
-        context_len_val = kwargs.pop("context_len")
-        cur_batch_start_index_val = kwargs.pop("cur_batch_start_index", 0)
-        block_table_offset_val = kwargs.pop("block_table_offset", 0)
-        outputs = interp.execute_function(
-            func_name,
-            **{output_ptr: output, query_ptr: query,
-               key_cache_ptr: key_cache, value_cache_ptr: value_cache,
-               block_tables_ptr: block_tables,
-               cur_batch_start_index: cur_batch_start_index_val,
-               block_table_offset: block_table_offset_val,
-               scale: scale_val, num_tiles: num_tiles_val, context_len: context_len_val,
-               **kwargs},
-        )
+        ek = entry["execute_kwargs"]
+        scale_val = ek["scale"]
+        num_tiles_val = ek["num_tiles"]
+        context_len_val = ek["context_len"]
+        kwargs = self._build_kwargs(entry, {
+            output_ptr: output, query_ptr: query,
+            key_cache_ptr: key_cache, value_cache_ptr: value_cache,
+            block_tables_ptr: block_tables,
+        })
+        outputs = interp.execute_function(func_name, **kwargs)
         result = outputs[output_ptr]
         assert result.shape == (8, 32, 128)
         assert not np.any(np.isnan(result)), "output contains NaN"
@@ -494,9 +481,8 @@ class TestSdpaExecution(InterpreterTestMixin):
         V = rng.standard_normal((n_rows, head_dim)).astype(np.float16)
         output = np.zeros((n_rows, head_dim), dtype=np.float16)
 
-        outputs = interp.execute_function(
-            func_name, **{q_ptr: Q, k_ptr: K, v_ptr: V, output_ptr: output},
-        )
+        kwargs = self._build_kwargs(entry, {q_ptr: Q, k_ptr: K, v_ptr: V, output_ptr: output})
+        outputs = interp.execute_function(func_name, **kwargs)
         result = outputs[output_ptr]
 
         # NumPy reference: scaled dot-product attention (f32 for stability)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -27,6 +27,43 @@ from ktir_cpu import KTIRInterpreter
 from conftest import get_test_params, parse_example
 
 
+class InterpreterTestMixin:
+    """Mixin that provides _make_interp() for injecting alternative parser backends.
+
+    Usage
+    -----
+    Execution test classes inherit this mixin and call ``self._make_interp()``
+    instead of constructing ``KTIRInterpreter()`` directly.  To run the same
+    tests against a different parser backend, subclass the execution test class
+    and override ``_make_interp()``::
+
+        class MyAdaptTests(MyBackendMixin, TestVectorAddExecution):
+            pass
+
+    where ``MyBackendMixin`` overrides ``_make_interp`` to inject the
+    alternative parser.
+
+    Parser-agnostic test hygiene
+    ----------------------------
+    Tests must not hardcode argument names from the MLIR source (e.g.
+    ``"x_ptr"``) because different parser backends may normalise them
+    differently (e.g. the MLIR bindings parser normalises to positional
+    ``arg0``, ``arg1``, ...).  Instead, use ``interp.arg_names(func_name)``
+    to get the names in declaration order and unpack them positionally::
+
+        x_ptr, y_ptr, output_ptr, BLOCK_SIZE = interp.arg_names(func_name)
+        sizes = interp.tensor_input_output_sizes(func_name)
+        (n,) = sizes[x_ptr]["shape"]
+        outputs = interp.execute_function(
+            func_name, **{x_ptr: x, y_ptr: y, output_ptr: out, BLOCK_SIZE: bs}
+        )
+        result = outputs[output_ptr]
+    """
+
+    def _make_interp(self):
+        return KTIRInterpreter()
+
+
 # ---------------------------------------------------------------------------
 # Parsing tests — all example files must parse into valid modules
 # ---------------------------------------------------------------------------
@@ -70,81 +107,86 @@ class TestExampleParsing:
 # Execution tests — run KTIR through the interpreter and check results
 # ---------------------------------------------------------------------------
 
-class TestVectorAddExecution:
+class TestVectorAddExecution(InterpreterTestMixin):
     """End-to-end execution of vector_add MLIR."""
 
     @pytest.mark.parametrize("path,func_name,entry", get_test_params("add_kernel"))
     def test_single_core(self, path, func_name, entry):
         """Run vector add on K cores, verify output = x + y."""
-        interp = KTIRInterpreter()
+        interp = self._make_interp()
         interp.load(path)
 
+        x_ptr, y_ptr, output_ptr, BLOCK_SIZE = interp.arg_names(func_name)
         sizes = interp.tensor_input_output_sizes(func_name)
-        (n,) = sizes["x_ptr"]["shape"]
+        (n,) = sizes[x_ptr]["shape"]
         rng = np.random.default_rng(42)
         x = rng.standard_normal(n).astype(np.float16)
         y = rng.standard_normal(n).astype(np.float16)
         output = np.zeros(n, dtype=np.float16)
 
-        kwargs = {k: v for k, v in entry["execute_kwargs"].items() if v is not None}
         outputs = interp.execute_function(
-            func_name, x_ptr=x, y_ptr=y, output_ptr=output, **kwargs,
+            func_name,
+            **{x_ptr: x, y_ptr: y, output_ptr: output,
+               BLOCK_SIZE: entry["execute_kwargs"]["BLOCK_SIZE"]},
         )
 
-        result = outputs["output_ptr"]
+        result = outputs[output_ptr]
         expected = (x + y).astype(np.float16)
         np.testing.assert_allclose(result, expected, rtol=1e-2, atol=1e-2)
 
     @pytest.mark.parametrize("path,func_name,entry", get_test_params("add_kernel"))
     def test_various_values(self, path, func_name, entry):
         """Vector add with zeros, negatives, and large values."""
-        interp = KTIRInterpreter()
+        interp = self._make_interp()
         interp.load(path)
 
+        x_ptr, y_ptr, output_ptr, BLOCK_SIZE = interp.arg_names(func_name)
         sizes = interp.tensor_input_output_sizes(func_name)
-        (n,) = sizes["x_ptr"]["shape"]
+        (n,) = sizes[x_ptr]["shape"]
         x = np.zeros(n, dtype=np.float16)
         y = np.linspace(-10, 10, n, dtype=np.float16)
         output = np.zeros(n, dtype=np.float16)
 
-        kwargs = {k: v for k, v in entry["execute_kwargs"].items() if v is not None}
         outputs = interp.execute_function(
-            func_name, x_ptr=x, y_ptr=y, output_ptr=output, **kwargs,
+            func_name,
+            **{x_ptr: x, y_ptr: y, output_ptr: output,
+               BLOCK_SIZE: entry["execute_kwargs"]["BLOCK_SIZE"]},
         )
 
-        result = outputs["output_ptr"]
+        result = outputs[output_ptr]
         expected = (x + y).astype(np.float16)
         np.testing.assert_allclose(result, expected, rtol=1e-2, atol=1e-2)
 
 
-class TestSoftmaxExecution:
+class TestSoftmaxExecution(InterpreterTestMixin):
     """End-to-end execution of softmax MLIR."""
 
     @pytest.mark.parametrize("path,func_name,entry", get_test_params("softmax_kernel", filter="triton-ktir"))
     def test_softmax_correct(self, path, func_name, entry):
         """Run softmax on 32 cores, verify against NumPy ground truth."""
-        interp = KTIRInterpreter()
+        interp = self._make_interp()
         interp.load(path)
 
+        output_ptr, input_ptr, n_rows = interp.arg_names(func_name)
         sizes = interp.tensor_input_output_sizes(func_name)
-        n_rows, n_padded_cols = sizes["input_ptr"]["shape"]
+        n_rows_val, n_padded_cols = sizes[input_ptr]["shape"]
         rng = np.random.default_rng(42)
         n_real_cols = int(n_padded_cols * 0.76)  # test with padding: ~76% real data
 
         # Padded input: first n_real_cols are real data, rest is -inf
-        inp = np.full((n_rows, n_padded_cols), float('-inf'), dtype=np.float16)
+        inp = np.full((n_rows_val, n_padded_cols), float('-inf'), dtype=np.float16)
         inp[:, :n_real_cols] = rng.standard_normal(
-            (n_rows, n_real_cols)
+            (n_rows_val, n_real_cols)
         ).astype(np.float16)
-        out = np.zeros((n_rows, n_padded_cols), dtype=np.float16)
+        out = np.zeros((n_rows_val, n_padded_cols), dtype=np.float16)
 
         kwargs = {k: v for k, v in entry["execute_kwargs"].items() if v is not None}
         kwargs["n_cols"] = n_real_cols  # fill dynamic kwarg
 
         outputs = interp.execute_function(
-            func_name, output_ptr=out, input_ptr=inp, **kwargs,
+            func_name, **{**kwargs, output_ptr: out, input_ptr: inp, n_rows: n_rows_val},
         )
-        result = outputs["output_ptr"]
+        result = outputs[output_ptr]
 
         # NumPy reference: softmax per row
         m = np.max(inp, axis=1, keepdims=True)
@@ -165,59 +207,62 @@ class TestSoftmaxExecution:
         This is exactly the scenario that online_rowchunk solves by
         chunking the column dimension.
         """
-        interp = KTIRInterpreter()
+        interp = self._make_interp()
         interp.load(path)
 
+        output_ptr, input_ptr, *_ = interp.arg_names(func_name)
         sizes = interp.tensor_input_output_sizes(func_name)
-        n_rows, n_cols = sizes["input_ptr"]["shape"]
+        n_rows_val, n_cols = sizes[input_ptr]["shape"]
         rng = np.random.default_rng(42)
-        inp = rng.standard_normal((n_rows, n_cols)).astype(np.float16)
-        out = np.zeros((n_rows, n_cols), dtype=np.float16)
+        inp = rng.standard_normal((n_rows_val, n_cols)).astype(np.float16)
+        out = np.zeros((n_rows_val, n_cols), dtype=np.float16)
 
         kwargs = {k: v for k, v in entry["execute_kwargs"].items() if v is not None}
         with pytest.raises(MemoryError, match=entry["exception_msg"]):
             interp.execute_function(
                 func_name,
-                output_ptr=out,
-                input_ptr=inp,
-                **kwargs,
+                **{**kwargs, output_ptr: out, input_ptr: inp},
             )
 
 
-class TestLayerNormExecution:
+class TestLayerNormExecution(InterpreterTestMixin):
     """End-to-end execution of layernorm_fwd_ktir.mlir."""
 
     @pytest.mark.parametrize("path,func_name,entry", get_test_params("_layer_norm_fwd_fused"))
     def test_layernorm_32_cores(self, path, func_name, entry):
         """Run layer norm on 32 cores, verify Y and Mean."""
-        interp = KTIRInterpreter()
+        interp = self._make_interp()
         interp.load(path)
 
+        X, Y, W, B, Mean, Rstd, N, eps, BLOCK_SIZE = interp.arg_names(func_name)
         sizes = interp.tensor_input_output_sizes(func_name)
-        n_rows, n_cols = sizes["X"]["shape"]
+        n_rows, n_cols = sizes[X]["shape"]
         rng = np.random.default_rng(42)
-        X = rng.standard_normal((n_rows, n_cols)).astype(np.float16)
+        X_data = rng.standard_normal((n_rows, n_cols)).astype(np.float16)
         # W and B are 1D weight/bias vectors, but the MLIR construct_memory_view
         # declares them as 2D (n_rows × n_cols) — same row tiled across all rows.
         W_1d = rng.standard_normal(n_cols).astype(np.float16)
         B_1d = rng.standard_normal(n_cols).astype(np.float16)
-        W = np.tile(W_1d, (n_rows, 1))
-        B = np.tile(B_1d, (n_rows, 1))
-        Y = np.zeros((n_rows, n_cols), dtype=np.float16)
-        Mean = np.zeros(n_rows, dtype=np.float16)
-        Rstd = np.zeros(n_rows, dtype=np.float16)
+        W_data = np.tile(W_1d, (n_rows, 1))
+        B_data = np.tile(B_1d, (n_rows, 1))
+        Y_data = np.zeros((n_rows, n_cols), dtype=np.float16)
+        Mean_data = np.zeros(n_rows, dtype=np.float16)
+        Rstd_data = np.zeros(n_rows, dtype=np.float16)
 
         kwargs = {k: v for k, v in entry["execute_kwargs"].items() if v is not None}
         outputs = interp.execute_function(
             func_name,
-            X=X, Y=Y, W=W, B=B, Mean=Mean, Rstd=Rstd,
-            **kwargs,
+            **{X: X_data, Y: Y_data, W: W_data, B: B_data,
+               Mean: Mean_data, Rstd: Rstd_data,
+               N: kwargs.pop("N"), eps: kwargs.pop("eps"),
+               BLOCK_SIZE: kwargs.pop("BLOCK_SIZE"),
+               **kwargs},  # remaining: stride (body-level)
         )
-        result_Y = outputs["Y"]
-        result_Mean = outputs["Mean"]
+        result_Y = outputs[Y]
+        result_Mean = outputs[Mean]
 
         # NumPy reference: standard layer norm
-        X_f32 = X.astype(np.float32)
+        X_f32 = X_data.astype(np.float32)
         W_f32 = W_1d.astype(np.float32)
         B_f32 = B_1d.astype(np.float32)
         mean_ref = np.mean(X_f32, axis=1)
@@ -235,7 +280,7 @@ class TestLayerNormExecution:
         )
 
 
-class TestReduceExplicitRegion:
+class TestReduceExplicitRegion(InterpreterTestMixin):
     """End-to-end execution of reduce_generic.mlir.
 
     Verifies that linalg.reduce in the generic MLIR format (explicit combiner
@@ -246,12 +291,13 @@ class TestReduceExplicitRegion:
     @pytest.mark.parametrize("path,func_name,entry", get_test_params("reduce_explicit_region"))
     def test_reduce_sum(self, path, func_name, entry):
         """Reduce [1, 2, 3, 4] along dim 1 — result broadcast to [10, 10, 10, 10]."""
-        interp = KTIRInterpreter()
+        interp = self._make_interp()
         interp.load(path)
 
+        (arg0,) = interp.arg_names(func_name)
         data = np.array([[1, 2, 3, 4]], dtype=np.float16)
-        outputs = interp.execute_function(func_name, arg0=data)
-        result = outputs["arg0"]
+        outputs = interp.execute_function(func_name, **{arg0: data})
+        result = outputs[arg0]
 
         expected = np.full((1, 4), 10.0, dtype=np.float16)
         np.testing.assert_allclose(result, expected, rtol=1e-2, atol=1e-2)
@@ -259,36 +305,44 @@ class TestReduceExplicitRegion:
     @pytest.mark.parametrize("path,func_name,entry", get_test_params("reduce_explicit_region"))
     def test_reduce_zeros(self, path, func_name, entry):
         """Reduce all-zeros — result should be all zeros."""
-        interp = KTIRInterpreter()
+        interp = self._make_interp()
         interp.load(path)
 
+        (arg0,) = interp.arg_names(func_name)
         data = np.zeros((1, 4), dtype=np.float16)
-        outputs = interp.execute_function(func_name, arg0=data)
-        result = outputs["arg0"]
+        outputs = interp.execute_function(func_name, **{arg0: data})
+        result = outputs[arg0]
 
         np.testing.assert_allclose(result, np.zeros((1, 4), dtype=np.float16), atol=1e-3)
 
 
-class TestMatMulExecution:
+class TestMatMulExecution(InterpreterTestMixin):
     """End-to-end execution of matmul_fwd_ktir.mlir."""
 
     @pytest.mark.parametrize("path,func_name,entry", get_test_params("matmul_kernel"))
     def test_matmul(self, path, func_name, entry):
         """Run matmul on the full grid, verify C ≈ A @ B."""
-        interp = KTIRInterpreter()
+        interp = self._make_interp()
         interp.load(path)
 
+        a_ptr, b_ptr, c_ptr, K, BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = interp.arg_names(func_name)
         kwargs = {k: v for k, v in entry["execute_kwargs"].items() if v is not None}
-        M, N, K = kwargs["M"], kwargs["N"], kwargs["K"]
+        M, N, K_val = kwargs["M"], kwargs["N"], kwargs["K"]
         rng = np.random.default_rng(42)
-        A = rng.standard_normal((M, K)).astype(np.float16)
-        B = rng.standard_normal((K, N)).astype(np.float16)
+        A = rng.standard_normal((M, K_val)).astype(np.float16)
+        B = rng.standard_normal((K_val, N)).astype(np.float16)
         C = np.zeros((M, N), dtype=np.float16)
 
         outputs = interp.execute_function(
-            func_name, a_ptr=A, b_ptr=B, c_ptr=C, **kwargs,
+            func_name,
+            **{a_ptr: A, b_ptr: B, c_ptr: C,
+               K: kwargs.pop("K"),
+               BLOCK_SIZE_M: kwargs.pop("BLOCK_SIZE_M"),
+               BLOCK_SIZE_N: kwargs.pop("BLOCK_SIZE_N"),
+               BLOCK_SIZE_K: kwargs.pop("BLOCK_SIZE_K"),
+               **kwargs},  # remaining: M, N, stride_* (body-level)
         )
-        result_C = outputs["c_ptr"]
+        result_C = outputs[c_ptr]
 
         expected = (A.astype(np.float32) @ B.astype(np.float32)).astype(np.float16)
         # K=2048 with BLOCK_SIZE_K=128 → 16 accumulation iterations in f16;
@@ -296,14 +350,16 @@ class TestMatMulExecution:
         np.testing.assert_allclose(result_C, expected, rtol=2e-2, atol=2e-1)
 
 
-class TestIndexedAddExecution:
+class TestIndexedAddExecution(InterpreterTestMixin):
     """End-to-end execution of indexed_add.mlir."""
 
     @pytest.mark.parametrize("path,func_name,entry", get_test_params("indexed_add_kernel"))
     def test_indexed_add(self, path, func_name, entry):
         """Run indexed_add with indirect x access, verify output = x[index[grid0]] + y."""
-        interp = KTIRInterpreter()
+        interp = self._make_interp()
         interp.load(path)
+
+        x_ptr, y_ptr, index_ptr, output_ptr, dim1_start = interp.arg_names(func_name)
         rng = np.random.default_rng(0)
         # x: [128, 64, 8, 128], y: [2, 32, 8, 128], index: [2] (i64), output: [2, 32, 8, 128]
         x = rng.standard_normal((128, 64, 8, 128)).astype(np.float16)
@@ -311,15 +367,13 @@ class TestIndexedAddExecution:
         index = np.array([3, 7], dtype=np.int64)
         output = np.zeros((2, 32, 8, 128), dtype=np.float16)
         kwargs = {k: v for k, v in entry["execute_kwargs"].items() if v is not None}
+        dim1_start_val = kwargs.get("dim1_start", 0)
         outputs = interp.execute_function(
             func_name,
-            x_ptr=x,
-            y_ptr=y,
-            index_ptr=index,
-            output_ptr=output,
-            **kwargs,
+            **{x_ptr: x, y_ptr: y, index_ptr: index,
+               output_ptr: output, dim1_start: dim1_start_val},
         )
-        result = outputs["output_ptr"]
+        result = outputs[output_ptr]
         assert result.shape == (2, 32, 8, 128)
         assert not np.any(np.isnan(result)), "output contains NaN"
         assert not np.any(np.isinf(result)), "output contains Inf"
@@ -328,13 +382,12 @@ class TestIndexedAddExecution:
         #   For each grid0 ∈ {0,1}, grid1 ∈ {0..7}:
         #     x_row = index[grid0]
         #     output[grid0, :, grid1, :] = x[x_row, 0:32, grid1, :] + y[grid0, :, grid1, :]
-        dim1_start = kwargs.get("dim1_start", 0)
         x_rows = x[index.astype(np.intp)]  # (2, 64, 8, 128)
-        expected = (x_rows[:, dim1_start:dim1_start + 32, :, :] + y).astype(np.float16)
+        expected = (x_rows[:, dim1_start_val:dim1_start_val + 32, :, :] + y).astype(np.float16)
         np.testing.assert_allclose(result, expected, rtol=1e-2, atol=1e-2)
 
 
-class TestPagedAttentionExecution:
+class TestPagedAttentionExecution(InterpreterTestMixin):
     """End-to-end execution of paged_attention.mlir."""
 
     @pytest.mark.parametrize("path,func_name,entry", get_test_params("kernel_unified_attention_spyre_2d"))
@@ -344,8 +397,11 @@ class TestPagedAttentionExecution:
         Verifies shape, finiteness, and checks the first query block
         (pid0=0, pid1=0) against a NumPy reference.
         """
-        interp = KTIRInterpreter()
+        interp = self._make_interp()
         interp.load(path)
+        (output_ptr, query_ptr, key_cache_ptr, value_cache_ptr,
+         block_tables_ptr, cur_batch_start_index, block_table_offset,
+         num_tiles, context_len, scale) = interp.arg_names(func_name)
         rng = np.random.default_rng(42)
         query = rng.standard_normal((8, 32, 128)).astype(np.float16)
         key_cache = rng.standard_normal((64, 16, 8, 128)).astype(np.float16)
@@ -353,16 +409,22 @@ class TestPagedAttentionExecution:
         block_tables = rng.integers(0, 64, size=(1, 16), dtype=np.int32)
         output = np.zeros((8, 32, 128), dtype=np.float16)
         kwargs = {k: v for k, v in entry["execute_kwargs"].items() if v is not None}
+        scale_val = kwargs.pop("scale")
+        num_tiles_val = kwargs.pop("num_tiles")
+        context_len_val = kwargs.pop("context_len")
+        cur_batch_start_index_val = kwargs.pop("cur_batch_start_index", 0)
+        block_table_offset_val = kwargs.pop("block_table_offset", 0)
         outputs = interp.execute_function(
             func_name,
-            output_ptr=output,
-            query_ptr=query,
-            key_cache_ptr=key_cache,
-            value_cache_ptr=value_cache,
-            block_tables_ptr=block_tables,
-            **kwargs,
+            **{output_ptr: output, query_ptr: query,
+               key_cache_ptr: key_cache, value_cache_ptr: value_cache,
+               block_tables_ptr: block_tables,
+               cur_batch_start_index: cur_batch_start_index_val,
+               block_table_offset: block_table_offset_val,
+               scale: scale_val, num_tiles: num_tiles_val, context_len: context_len_val,
+               **kwargs},
         )
-        result = outputs["output_ptr"]
+        result = outputs[output_ptr]
         assert result.shape == (8, 32, 128)
         assert not np.any(np.isnan(result)), "output contains NaN"
         assert not np.any(np.isinf(result)), "output contains Inf"
@@ -374,26 +436,23 @@ class TestPagedAttentionExecution:
         #                    V = value_cache[block_tables[0,j], :, 0, :] → (16, 128)
         #   Causal mask: seq_offset(j,col) = j*16+col; mask where > context_len + query_pos
         #   output = softmax(Q @ K^T * scale, masked) @ V, then reshape to (2, 4, 128)
-        scale = kwargs["scale"]
-        num_tiles = kwargs["num_tiles"]
-        context_len = kwargs["context_len"]
         pid0 = 0
         Q = query[0:2, 0:4, :].reshape(8, 128).astype(np.float32)
         K_full = np.concatenate([
-            key_cache[block_tables[0, j], :, 0, :] for j in range(num_tiles)
+            key_cache[block_tables[0, j], :, 0, :] for j in range(num_tiles_val)
         ], axis=0).astype(np.float32)  # (num_tiles*16, 128)
         V_full = np.concatenate([
-            value_cache[block_tables[0, j], :, 0, :] for j in range(num_tiles)
+            value_cache[block_tables[0, j], :, 0, :] for j in range(num_tiles_val)
         ], axis=0).astype(np.float32)
 
-        scores = Q @ K_full.T * scale  # (8, num_tiles*16)
+        scores = Q @ K_full.T * scale_val  # (8, num_tiles*16)
 
         # Causal mask: query_pos[row] = pid0*2 + row//4
         #              query_abs_pos = context_len + query_pos
         #              seq_offset[col] = col  (flattened across tiles)
         for row in range(8):
-            query_abs_pos = context_len + pid0 * 2 + row // 4
-            for col in range(num_tiles * 16):
+            query_abs_pos = context_len_val + pid0 * 2 + row // 4
+            for col in range(num_tiles_val * 16):
                 if col > query_abs_pos:
                     scores[row, col] = -np.inf
 
@@ -401,7 +460,7 @@ class TestPagedAttentionExecution:
         M_ref = np.full(8, -np.inf, dtype=np.float32)
         L_ref = np.ones(8, dtype=np.float32)
         acc_ref = np.zeros((8, 128), dtype=np.float32)
-        for j in range(num_tiles):
+        for j in range(num_tiles_val):
             S_j = scores[:, j*16:(j+1)*16]
             m_j = np.maximum(M_ref, S_j.max(axis=1))
             P_j = np.exp(S_j - m_j[:, None])
@@ -417,17 +476,18 @@ class TestPagedAttentionExecution:
         np.testing.assert_allclose(actual, expected, rtol=5e-2, atol=5e-2)
 
 
-class TestSdpaExecution:
+class TestSdpaExecution(InterpreterTestMixin):
     """End-to-end execution of sdpa_2d.mlir."""
 
     @pytest.mark.parametrize("path,func_name,entry", get_test_params("sdpa_kernel_2d"))
     def test_sdpa(self, path, func_name, entry):
         """Run SDPA on 1 core, verify output ≈ softmax(Q @ K^T * scale) @ V."""
-        interp = KTIRInterpreter()
+        interp = self._make_interp()
         interp.load(path)
 
+        q_ptr, k_ptr, v_ptr, output_ptr = interp.arg_names(func_name)
         sizes = interp.tensor_input_output_sizes(func_name)
-        n_rows, head_dim = sizes["q_ptr"]["shape"]
+        n_rows, head_dim = sizes[q_ptr]["shape"]
         rng = np.random.default_rng(42)
         Q = rng.standard_normal((n_rows, head_dim)).astype(np.float16)
         K = rng.standard_normal((n_rows, head_dim)).astype(np.float16)
@@ -435,9 +495,9 @@ class TestSdpaExecution:
         output = np.zeros((n_rows, head_dim), dtype=np.float16)
 
         outputs = interp.execute_function(
-            func_name, q_ptr=Q, k_ptr=K, v_ptr=V, output_ptr=output,
+            func_name, **{q_ptr: Q, k_ptr: K, v_ptr: V, output_ptr: output},
         )
-        result = outputs["output_ptr"]
+        result = outputs[output_ptr]
 
         # NumPy reference: scaled dot-product attention (f32 for stability)
         scale = np.float32(0.125)  # 1/sqrt(64), matches MLIR constant

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -184,7 +184,7 @@ class TestSoftmaxExecution(InterpreterTestMixin):
         kwargs["n_cols"] = n_real_cols  # fill dynamic kwarg
 
         outputs = interp.execute_function(
-            func_name, **{**kwargs, output_ptr: out, input_ptr: inp, n_rows: n_rows_val},
+            func_name, **{**kwargs, output_ptr: out, input_ptr: inp},
         )
         result = outputs[output_ptr]
 


### PR DESCRIPTION
  > [!IMPORTANT]
  >  To be merged after #5 

## Roadmap

> MLIR frontend parser series: add `MLIRFrontendParser` as a swappable
> alternative to the regex-based `KTIRParser`.

**PR 1 — Decouple parser**: Make the tokenizer and region detector fully
structural so they require zero dialect-specific metadata. Pure
refactoring — no new API, no new features.

**PR 2 — Test mixins + KTIRParserBase ABC**: Introduce the
`KTIRParserBase` abstract base class and refactor both test suites to use
mixins that decouple test assertions from parser implementation. This is
the infrastructure that enables any future parser backend to reuse all
existing tests.

**PR 3 — MLIRFrontendParser**: Implement `MLIRFrontendParser` in
`ktir_cpu/mlir_frontend/` using `mlir_ktdp.ir` structural walk with
`MLIRTypeAdapter` (30+ per-op handlers). Add adapter test suites that
reuse all existing tests via the mixin infrastructure from PR 2.

---

- PR 1 — Decouple parser from dialect-specific logic
- **→ PR 2 — Test mixins + KTIRParserBase ABC**
- PR 3 — MLIRFrontendParser + adapter test suite

## Goal

Enable any future parser backend to reuse all existing tests without
modification. Introduce the `KTIRParserBase` contract and refactor both
test suites (`test_dialects_parse.py`, `test_examples.py`) into a mixin
architecture that separates test logic from parser implementation.

## Background

To support alternative parser backends (e.g. MLIR frontend parser, C++
dialect extensions), the interpreter needs a swappable parser contract,
and tests must not be coupled to the regex parser's behaviour. In
particular, tests must not hardcode SSA argument names from MLIR source
because different backends may normalise them differently (e.g. the MLIR
frontend parser normalises to positional `arg0`, `arg1`, ...).

## Changes

### `ktir_cpu/parser.py` — `KTIRParserBase` ABC

```python
class KTIRParserBase(ABC):
    @abstractmethod
    def parse_module(self, mlir_text: str) -> IRModule: ...

    def parse_file(self, filepath: str) -> IRModule:
        with open(filepath) as f:
            return self.parse_module(f.read())
```

Any object satisfying this interface can be injected into the interpreter.
`KTIRParser` inherits from it — existing usage unchanged.

### `ktir_cpu/interpreter.py` — injectable parser

Add `parser: Optional[KTIRParserBase]` to `KTIRInterpreter.__init__()`.
When `None` (default), falls back to `KTIRParser()`. Existing call sites
(`KTIRInterpreter()`, `KTIRInterpreter(latency_config=cfg)`) unchanged.

### `tests/test_dialects_parse.py` — `ParseTestMixin`

Portable assertion API that decouples test logic from parser implementation:

```
ParseTestMixin
├── _parse(op_text, parse_ctx, args)   # override per backend
├── assert_op_type(op, expected)       # parser-agnostic
├── assert_num_operands(op, n)         # parser-agnostic
├── assert_result_type(op, expected)   # parser-agnostic
├── assert_attribute(op, key, value)   # parser-agnostic
└── assert_operand_names(op, *names)   # parser-specific — override in adapters
```

All 5 parse test classes (`TestArithParsers`, `TestLinalgParsers`,
`TestTensorParsers`, `TestKtdpParsers`, `TestScfParsers`) refactored to
inherit `ParseTestMixin` and use the assertion API.

All op text examples fixed to be valid MLIR (parseable by both regex and
MLIR frontend backends).

### `tests/test_examples.py` — `InterpreterTestMixin`

Factory mixin for execution tests:

```python
class InterpreterTestMixin:
    def _make_interp(self):
        return KTIRInterpreter()
```

All 8 execution test classes refactored to use `self._make_interp()` and
`interp.arg_names(func_name)` instead of hardcoded MLIR argument names.

### Design methodology: extending tests for a new parser backend

Documented in `test_dialects_parse.py` module docstring:

1. Create a mixin that overrides `_parse()` to construct ops via your
   backend
2. Override `assert_operand_names()` if your backend normalises SSA names
3. Override `assert_attribute()` for keys whose representation differs
4. For each `TestXxxParsers` class, create:
   `class TestXxxMyBackend(MyMixin, TestXxxParsers): pass`
5. Run the full suite — inherited tests are the correctness oracle

### Other file changes

| File | Change |
|------|--------|
| `ktir_cpu/ir_types.py` | Add `arg_names` helper to `IRFunction` |
| `ktir_cpu/dialects/arith_ops.py` | Add unbraced `dense<...>` branch for `arith.constant` |
| `ktir_cpu/dialects/ktdp_ops.py` | Fix `intermediate_variables\s*\(` whitespace in regex |
| `ktir_cpu/dialects/ktdp_helpers.py` | Minor refactor for regex parser path |

## Test plan

- [x] All existing tests pass (`uv run pytest tests/ -v`)
- [x] `KTIRInterpreter(parser=None)` falls back to `KTIRParser()` (backwards compatible)
- [x] `ParseTestMixin` assertion API covers: op_type, num_operands, result_type, attribute, operand_names
- [x] All 5 parse test classes inherit `ParseTestMixin`
- [x] All 8 execution test classes inherit `InterpreterTestMixin` and use `arg_names()`
