### PR TITLE
latency: account for index tensor HBM traffic in indirect access loads

### DIFF
--- a/docs/latency.md
+++ b/docs/latency.md
@@ -53,7 +53,7 @@ get_latency_report() → LatencyReport
 Key design points:
 
 - **Registry-based dispatch**: Operations are dispatched through a central registry (`dialects/registry.py`). Each dialect module registers its handlers and latency categories at import time via `@register()`.
-- **Post-execution recording**: The tracker runs *after* each op executes, so the result shape is known for accurate size estimation. This means `ktdp.load` costs are derived from the loaded Tile's `nbytes`, not from memref metadata.
+- **Post-execution recording**: The tracker runs *after* each op executes, so the result shape is known for accurate size estimation. For direct loads, `ktdp.load` cost is the result Tile's `nbytes`. For indirect (gather) loads the index tensors are also counted — see [Indirect access memory cost](#indirect-access-memory-cost).
 - **Operand resolution before the try block**: Operands are resolved once into a flat list before the operation's try block. This avoids duplicating resolution logic inside every op branch while keeping the cost negligible (dict lookups on already-populated SSA maps).
 - **Control flow is zero-cost**: `scf.for`, `scf.if`, and `scf.yield` are classified as zero-cost. Child operations inside loops/branches record their own costs naturally via recursive `execute_region` calls, so loop iterations accumulate correctly without the tracker needing to understand control flow.
 - **Memory-space-aware**: LX (on-chip SRAM) load/store is zero-cost. Only HBM transfers incur latency. This reflects the hardware: all live Tiles reside in LX, so an LX load/store is redundant with SSA dataflow — it's just an on-chip copy.
@@ -93,6 +93,26 @@ def arith__addf(op, context, env):
 | **Compute (matmul)** | `COMPUTE_MATMUL` | `2·M·N·K / systolic_flops_per_cycle` |
 | **Compute (integer)** | `COMPUTE_INT` | 1 cycle (scalar) or `elements / simd_elements_per_cycle` (tile) |
 | **Communication** | `COMM` | `bytes / ring_bytes_per_cycle` (`ktdp.reduce` adds `× log2(num_cores)`) |
+
+## Indirect access memory cost
+
+A `ktdp.load` over an `IndirectAccessTile` with N indirect dimensions performs N+1 HBM reads. The tracker counts all HBM-resident transfers; LX-resident index views are free (on-chip):
+
+```
+memory_bytes = result_tile_bytes + Σ(i=1..N) index_view_i_bytes   (HBM views only)
+```
+
+For `indirect-access-copy.mlir` (64×64 gather, all HBM):
+
+```
+X    (f16,  64×64): 64×64 × 2 =  8,192 bytes   ← data tensor
+IDX1 (i32, 64×64): 64×64 × 4 = 16,384 bytes   ┐
+IDX2 (i32, 64×64): 64×64 × 4 = 16,384 bytes   ┘ N=2 index tensors
+                               ─────────────
+Total:                          40,960 bytes
+```
+
+**Open question**: the model applies `hbm_bandwidth_tb_s` uniformly across all dtypes. Whether f16 data tensors and i32 index tensors achieve the same effective HBM bandwidth on Spyre is unconfirmed — if they differ, a separate bandwidth parameter would be needed.
 
 ## Hardware parameters
 

--- a/ktir_cpu/latency.py
+++ b/ktir_cpu/latency.py
@@ -30,7 +30,7 @@ import math
 import numpy as np
 
 from .ir_types import AccessTile, IndirectAccessTile, Tile, TileRef
-from .memory import _bytes_per_elem
+from .dtypes import bytes_per_elem
 
 
 from .dialects.registry import get_latency_category
@@ -293,7 +293,7 @@ class LatencyTracker:
             if isinstance(v, IndirectAccessTile):
                 for iv in v.index_views:
                     if iv.memory_space == "HBM":
-                        total += int(np.prod(iv.shape)) * _bytes_per_elem(iv.dtype)
+                        total += int(np.prod(iv.shape)) * bytes_per_elem(iv.dtype)
             elif isinstance(v, Tile):
                 if result is not None:
                     raise ValueError(

--- a/ktir_cpu/latency.py
+++ b/ktir_cpu/latency.py
@@ -77,6 +77,8 @@ class HardwareConfig:
             costs ``2·M·N·K / systolic_flops_per_cycle`` cycles.
         transcendental_penalty: Multiplier for transcendental ops vs elementwise (estimated).
     """
+    # TODO: add gather_bandwidth_tb_s if Spyre scatter/gather BW differs from
+    # sequential HBM BW. Until confirmed by hardware team, both share hbm_bandwidth_tb_s.
     num_cores: int = 32
     clock_ghz: float = 1.0
     hbm_bandwidth_tb_s: float = 1.0

--- a/ktir_cpu/latency.py
+++ b/ktir_cpu/latency.py
@@ -274,9 +274,9 @@ class LatencyTracker:
             if isinstance(v, AccessTile):
                 return v.parent_ref.memory_space
             if isinstance(v, IndirectAccessTile):
-                if any(iv.memory_space == "HBM" for iv in v.index_views):
-                    return "HBM"
-                return v.parent_ref.memory_space
+                all_lx = (v.parent_ref.memory_space == "LX" and
+                          all(iv.memory_space == "LX" for iv in v.index_views))
+                return "LX" if all_lx else "HBM"
         return "HBM"
 
     @staticmethod

--- a/ktir_cpu/latency.py
+++ b/ktir_cpu/latency.py
@@ -272,6 +272,8 @@ class LatencyTracker:
             if isinstance(v, AccessTile):
                 return v.parent_ref.memory_space
             if isinstance(v, IndirectAccessTile):
+                if any(iv.memory_space == "HBM" for iv in v.index_views):
+                    return "HBM"
                 return v.parent_ref.memory_space
         return "HBM"
 
@@ -291,10 +293,11 @@ class LatencyTracker:
                     if iv.memory_space == "HBM":
                         total += int(np.prod(iv.shape)) * _bytes_per_elem(iv.dtype)
             elif isinstance(v, Tile):
-                assert result is None, (
-                    f"_data_size: Tile in operands but result is also a Tile ({type(result)}); "
-                    "no ktdp op should produce both"
-                )
+                if result is not None:
+                    raise ValueError(
+                        f"_data_size: Tile in operands but result is also a Tile ({type(result)}); "
+                        "no ktdp op should produce both"
+                    )
                 total += v.data.nbytes
         return total
 

--- a/ktir_cpu/latency.py
+++ b/ktir_cpu/latency.py
@@ -29,7 +29,8 @@ from typing import Any, Dict, List, Optional, Tuple
 import math
 import numpy as np
 
-from .ir_types import AccessTile, Tile, TileRef
+from .ir_types import AccessTile, IndirectAccessTile, Tile, TileRef
+from .memory import _bytes_per_elem
 
 
 from .dialects.registry import get_latency_category
@@ -270,20 +271,32 @@ class LatencyTracker:
                 return v.memory_space
             if isinstance(v, AccessTile):
                 return v.parent_ref.memory_space
+            if isinstance(v, IndirectAccessTile):
+                return v.parent_ref.memory_space
         return "HBM"
 
     @staticmethod
     def _data_size(result: Any, operands: List[Any]) -> int:
         """Estimate bytes transferred by a memory operation.
 
-        Checks result first (covers loads), then operands (covers stores).
+        Counts result bytes (loads), operand Tile bytes (stores), and
+        index tensor bytes (indirect access loads and scatter stores).
         """
+        total = 0
         if isinstance(result, Tile):
-            return result.data.nbytes
+            total += result.data.nbytes
         for v in operands:
-            if isinstance(v, Tile):
-                return v.data.nbytes
-        return 0
+            if isinstance(v, IndirectAccessTile):
+                for iv in v.index_views:
+                    if iv.memory_space == "HBM":
+                        total += int(np.prod(iv.shape)) * _bytes_per_elem(iv.dtype)
+            elif isinstance(v, Tile):
+                assert result is None, (
+                    f"_data_size: Tile in operands but result is also a Tile ({type(result)}); "
+                    "no ktdp op should produce both"
+                )
+                total += v.data.nbytes
+        return total
 
     @staticmethod
     def _num_elements(result: Any, operands: List[Any]) -> int:

--- a/tests/test_latency.py
+++ b/tests/test_latency.py
@@ -622,8 +622,16 @@ class TestIndirectAccessLatency:
 
         sizes = interp.tensor_input_output_sizes(func_name)
         _dtype_map = {"f16": np.float16, "i32": np.int32, "f32": np.float32}
-        # Addresses are arith.constant values baked into indirect-access-copy.mlir.
-        _addr_map = {"X_addr": 0, "IDX1_addr": 8192, "IDX2_addr": 16384, "Y_addr": 24576}
+
+        # Derive addresses from parsed module so the test stays correct if
+        # indirect-access-copy.mlir changes its arith.constant values.
+        func = interp.module.get_function(func_name)
+        constants = {
+            op.result.lstrip("%"): op.attributes["value"]
+            for op in func.operations
+            if op.op_type == "arith.constant" and op.result
+        }
+        _addr_map = {name: constants[name] for name in sizes}
 
         _orig = interp._prepare_execution
         def _prepare_and_seed(grid_shape):
@@ -653,6 +661,4 @@ class TestIndirectAccessLatency:
         assert counters.total_bytes == expected_total_bytes, (
             f"total_bytes={counters.total_bytes}, expected={expected_total_bytes}"
         )
-        assert abs(counters.memory_cycles - expected_memory_cycles) < 1.0, (
-            f"memory_cycles={counters.memory_cycles}, expected={expected_memory_cycles}"
-        )
+        assert counters.memory_cycles == pytest.approx(expected_memory_cycles, rel=1e-3)

--- a/tests/test_latency.py
+++ b/tests/test_latency.py
@@ -596,3 +596,63 @@ class TestLatencyEdgeCases:
         assert report.bottleneck == "none"
         assert report.kernel_cycles == 0.0
         assert report.kernel_time_us == 0.0
+
+
+class TestIndirectAccessLatency:
+    """Verify that indirect access loads account for index tensor HBM traffic."""
+
+    @pytest.mark.parametrize("path,func_name,_entry", get_test_params("indirect_access_copy"))
+    def test_indirect_load_includes_index_tensor_bytes(self, path, func_name, _entry):
+        """memory_cycles should reflect index tensor reads, not just the result tile.
+
+        indirect-access-copy.mlir does a 2-D gather: Y[m,k] = X[IDX1[m,k], IDX2[m,k]]
+        with 64x64 tiles. A single ktdp.load on the IndirectAccessTile should cost:
+          result (X gather):  64*64*2 (f16) =  8,192 bytes
+          IDX1:               64*64*4 (i32) = 16,384 bytes
+          IDX2:               64*64*4 (i32) = 16,384 bytes
+          total = 40,960 bytes
+
+        With default HardwareConfig (1 core, 1 TB/s HBM BW):
+          hbm_bytes_per_cycle_per_core = 1e12 / 1e9 / 1 = 1000
+          expected memory_cycles for one load = 40,960 / 1000 = 40.96
+        """
+        cfg = HardwareConfig(num_cores=1)
+        interp = KTIRInterpreter(latency_config=cfg)
+        interp.load(path)
+
+        sizes = interp.tensor_input_output_sizes(func_name)
+        _dtype_map = {"f16": np.float16, "i32": np.int32, "f32": np.float32}
+        # Addresses are arith.constant values baked into indirect-access-copy.mlir.
+        _addr_map = {"X_addr": 0, "IDX1_addr": 8192, "IDX2_addr": 16384, "Y_addr": 24576}
+
+        _orig = interp._prepare_execution
+        def _prepare_and_seed(grid_shape):
+            _orig(grid_shape)
+            hbm = interp.memory.hbm
+            for name, info in sizes.items():
+                n_elements = int(np.prod(info["shape"]))
+                hbm.write(_addr_map[name], np.zeros(n_elements, dtype=_dtype_map[info["dtype"]]))
+        interp._prepare_execution = _prepare_and_seed
+
+        interp.execute_function(func_name)
+        report = interp.get_latency_report()
+
+        # With 1 core, all work is on core 0.
+        counters = report.counters[0]
+
+        # The kernel does 1 indirect load (X via IDX1+IDX2) + 1 regular store (Y).
+        def _nbytes(name):
+            info = sizes[name]
+            return int(np.prod(info["shape"])) * np.dtype(_dtype_map[info["dtype"]]).itemsize
+        expected_load_bytes = _nbytes("X_addr") + _nbytes("IDX1_addr") + _nbytes("IDX2_addr")
+        expected_store_bytes = _nbytes("Y_addr")
+        expected_total_bytes = expected_load_bytes + expected_store_bytes
+        bw = cfg.hbm_bytes_per_cycle_per_core
+        expected_memory_cycles = expected_total_bytes / bw
+
+        assert counters.total_bytes == expected_total_bytes, (
+            f"total_bytes={counters.total_bytes}, expected={expected_total_bytes}"
+        )
+        assert abs(counters.memory_cycles - expected_memory_cycles) < 1.0, (
+            f"memory_cycles={counters.memory_cycles}, expected={expected_memory_cycles}"
+        )

--- a/tests/test_latency.py
+++ b/tests/test_latency.py
@@ -589,6 +589,27 @@ class TestLatencyEdgeCases:
         n_elems = LatencyTracker._num_elements(zero_tile, [])
         assert n_elems == 0
 
+    def test_lx_index_views_excluded_from_hbm_bytes(self):
+        """_data_size() ignores LX index views; _memory_space() falls back to parent."""
+        from ktir_cpu.latency import LatencyTracker
+        from ktir_cpu.ir_types import IndirectAccessTile, Tile, TileRef
+        from ktir_cpu.parser_ast import parse_affine_set
+
+        vss = parse_affine_set("(d0, d1) : (d0 >= 0, d1 >= 0)")
+        lx_idx = TileRef(base_ptr=0, shape=(4, 4), strides=[4, 1],
+                         memory_space="LX", dtype="i32")
+        parent = TileRef(base_ptr=0, shape=(4, 4), strides=[4, 1],
+                         memory_space="HBM", dtype="f16")
+        iat = IndirectAccessTile(
+            parent_ref=parent, shape=(4, 4), dim_subscripts=[],
+            index_views=[lx_idx, lx_idx],
+            variables_space_set=vss, variables_space_order=None,
+        )
+        result = Tile(np.zeros((4, 4), dtype=np.float16), "f16", (4, 4))
+
+        assert LatencyTracker._data_size(result, [iat]) == result.data.nbytes
+        assert LatencyTracker._memory_space([iat]) == "HBM"
+
     def test_empty_counters_bottleneck(self):
         """LatencyReport with no counters reports bottleneck='none'."""
         from ktir_cpu.latency import LatencyReport


### PR DESCRIPTION
## Summary

The latency tracker underestimates `ktdp.load` cost when operating over an `IndirectAccessTile` — it only counted the result tensor bytes, ignoring the HBM reads for the index tensors that drive the gather. Hardware team confirmed each `ind(...)` dimension in `construct_indirect_access_tile` is a real HBM load at runtime, not free metadata.

**Concrete undercount for `indirect-access-copy.mlir` (64×64 tiles, 2×i32 index tensors):**

| HBM traffic | Bytes | Previously tracked |
|---|---|---|
| Read X (result, f16) | 64×64×2 = 8,192 | Yes |
| Read IDX1 (i32) | 64×64×4 = 16,384 | No |
| Read IDX2 (i32) | 64×64×4 = 16,384 | No |
| **Total** | **40,960** | **8,192 (5× undercount)** |

## Changes

**`ktir_cpu/latency.py`**
- `_memory_space()`: add explicit `IndirectAccessTile` branch — previously fell through to `"HBM"` fallback by accident (correct, but fragile)
- `_data_size()`: restructured to accumulate a running total; for `IndirectAccessTile` operands, sums bytes of all `index_views` in HBM; uses `elif isinstance(v, Tile)` + assert to handle future scatter stores correctly (when scatter store `NotImplementedError` is removed, both index bytes and data tile bytes will be counted without silent undercounting)

**`tests/test_latency.py`**
- Add `TestIndirectAccessLatency`: verifies `total_bytes` (49,152) and `memory_cycles` for `indirect-access-copy.mlir`; uses `tensor_input_output_sizes` for shape/dtype info

## Open question

Does gather access on Spyre require different bandwidth parameters than dense transfer? If yes, a follow-up PR will add per-element gather penalty modeling and a `gather_bandwidth` hardware parameter. If no, this PR is the complete solution for index-tensor latency modeling.

cc @fabianlim 