### PR TITLE
Wire CI to build and test mlir_frontend against ktir-mlir-frontend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,5 +55,8 @@ jobs:
       - name: Install project and dependencies
         run: uv sync --extra dev --extra mlir-frontend --no-build-isolation
 
-      - name: Run tests
-        run: uv run pytest -v
+      - name: Run basic tests (with regex parser)
+        run: uv run pytest -v --ignore=tests/mlir_frontend
+
+      - name: Run MLIR frontend parser tests
+        run: uv run pytest tests/mlir_frontend/ -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,34 @@ jobs:
       - name: Set up Python
         run: uv python install ${{ matrix.python-version }}
 
-      - name: Install dependencies
-        run: uv sync --extra dev
+      - name: Install build tools
+        run: sudo apt-get install -y ninja-build
+
+      # Temporary: download setup_mlir.py from the pinned ktir-mlir-frontend commit
+      # and run it to obtain MLIR_DIR.  We pass --wheel to explicitly activate the
+      # mlir_wheel fallback — the artifact-based path (keyed by LLVM_HASH) requires a
+      # GitHub token not available in public CI.  --hash is still passed so the intent
+      # is explicit; remove --wheel once the artifact is publicly accessible and this
+      # will automatically use the pinned LLVM build instead.
+      # CMAKE_ARGS is written to $GITHUB_ENV so uv sync inherits it automatically
+      # in the next step without needing an explicit prefix on the command line.
+      # Drop-in removal: once ktir-mlir-frontend publishes a wheel to PyPI, delete
+      # this step entirely — CMAKE_ARGS will be unset and `uv sync --extra mlir-frontend`
+      # will install the wheel directly without a source build.
+      - name: Set up MLIR
+        env:
+          KTIR_MLIR_REPO: fabianlim
+          KTIR_MLIR_FRONTEND_COMMIT: 55a8a7eaf3a3344d95c2e8793da0bc220c62d9c0
+          LLVM_HASH: e9846648fd6183ee6d8cbdb4502213fcf902a211
+        run: |
+          curl -fsSL \
+            "https://raw.githubusercontent.com/$KTIR_MLIR_REPO/ktir-mlir-frontend/$KTIR_MLIR_FRONTEND_COMMIT/scripts/setup_mlir.py" \
+            -o /tmp/setup_mlir.py
+          MLIR_DIR=$(uv run python /tmp/setup_mlir.py --wheel --hash "$LLVM_HASH")
+          echo "CMAKE_ARGS=-DMLIR_DIR=$MLIR_DIR" >> $GITHUB_ENV
+
+      - name: Install project and dependencies
+        run: uv sync --extra dev --extra mlir-frontend
 
       - name: Run tests
         run: uv run pytest -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,10 +45,15 @@ jobs:
             "https://raw.githubusercontent.com/$KTIR_MLIR_REPO/ktir-mlir-frontend/$KTIR_MLIR_FRONTEND_COMMIT/scripts/setup_mlir.py" \
             -o /tmp/setup_mlir.py
           MLIR_DIR=$(uv run python /tmp/setup_mlir.py --wheel --hash "$LLVM_HASH")
+          # Pre-install build-system deps for ktir-mlir-frontend so the source build
+          # can run with --no-build-isolation (mlir_wheel is not on PyPI so uv cannot
+          # resolve build-system.requires in an isolated env; scikit-build-core and
+          # nanobind are on PyPI and safe to install here).
+          uv pip install scikit-build-core "nanobind>=2.12.0"
           echo "CMAKE_ARGS=-DMLIR_DIR=$MLIR_DIR" >> $GITHUB_ENV
 
       - name: Install project and dependencies
-        run: uv sync --extra dev --extra mlir-frontend
+        run: uv sync --extra dev --extra mlir-frontend --no-build-isolation
 
       - name: Run tests
         run: uv run pytest -v

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,13 @@ Thank you for your interest in contributing! This project is an experimental KTI
 uv sync --extra dev
 ```
 
+## MLIR Frontend Bindings (optional)
+
+The `tests/mlir_frontend/` tests require the optional `mlir-frontend` dependency.
+See [README.md — MLIR frontend bindings](README.md#mlir-frontend-bindings-optional)
+for install instructions; the setup will simplify to a single `uv sync --extra mlir-frontend`
+once wheels are available.
+
 ## Running Tests
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -17,7 +17,39 @@ This works in practice because ktir_cpu is **fast**, **actionable**, and **deter
 ## Setup
 
 ```bash
-uv sync 
+uv sync
+```
+
+### MLIR frontend bindings (optional)
+
+The `tests/mlir_frontend/` tests use `mlir_ktdp` from
+[ktir-mlir-frontend](https://github.com/torch-spyre/ktir-mlir-frontend).
+Until a PyPI release is available, build from source:
+
+**Prerequisites:** CMake ≥ 3.20, Ninja, C++17 compiler.
+
+```bash
+KTIR_MLIR_FRONTEND_COMMIT=55a8a7eaf3a3344d95c2e8793da0bc220c62d9c0
+LLVM_HASH=e9846648fd6183ee6d8cbdb4502213fcf902a211
+
+# Fetch setup_mlir.py from the pinned commit
+curl -fsSL \
+  "https://raw.githubusercontent.com/fabianlim/ktir-mlir-frontend/$KTIR_MLIR_FRONTEND_COMMIT/scripts/setup_mlir.py" \
+  -o /tmp/setup_mlir.py
+
+# Resolve MLIR — --wheel activates the mlir_wheel fallback (no GitHub token needed);
+# --hash records the targeted LLVM build (drop --wheel once artifacts are public)
+MLIR_DIR=$(uv run python /tmp/setup_mlir.py --wheel --hash "$LLVM_HASH")
+
+# Build and install
+CMAKE_ARGS="-DMLIR_DIR=$MLIR_DIR" uv sync --extra mlir-frontend
+```
+
+Once [torch-spyre/ktir-mlir-frontend#12](https://github.com/torch-spyre/ktir-mlir-frontend/issues/12)
+is resolved and wheels are published, this will simplify to:
+
+```bash
+uv sync --extra mlir-frontend
 ```
 
 ## Quick start

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,11 @@ dev = [
     "pytest>=7.0",
     "pytest-cov>=4.0",
 ]
+# No PyPI release yet; built from source via setup_mlir.py (see CONTRIBUTING.md).
+# Update this commit when torch-spyre/ktir-mlir-frontend#14 is merged.
+mlir-frontend = [
+    "ktir-mlir-frontend @ git+https://github.com/fabianlim/ktir-mlir-frontend@55a8a7eaf3a3344d95c2e8793da0bc220c62d9c0",
+]
 
 [tool.setuptools_scm]
 


### PR DESCRIPTION
> [!IMPORTANT]
>  To be merged either before or after #10. So that we can trigger the mlir frontend tests 

## Summary

`tests/mlir_frontend/` was always skipped in CI because `mlir_ktdp` was never
installed. This PR pins `ktir-mlir-frontend` as an optional dependency, adds a
CI step that builds it from source using `setup_mlir.py`, and documents the
manual install path for contributors.

## This PR — add `mlir-frontend` optional dep and CI build step

`tests/mlir_frontend/conftest.py` skips the entire suite at module level when
`mlir_ktdp` is not importable. Because `ktir-mlir-frontend` has no PyPI release
and was never installed in CI, these tests have never run in CI.

- **`pyproject.toml`**: add `mlir-frontend` optional dependency pinned to
  `fabianlim/ktir-mlir-frontend@55a8a7ea` (tracks LLVM `e9846648`,
  llvmorg-22.1.3). Will move to `torch-spyre/ktir-mlir-frontend` once
  [torch-spyre/ktir-mlir-frontend#14](https://github.com/torch-spyre/ktir-mlir-frontend/pull/14)
  merges.

- **`.github/workflows/ci.yml`**: replace the single `uv sync --extra dev` step
  with three steps:
  - *Install build tools* — `apt-get install ninja-build` (required by
    scikit-build-core).
  - *Set up MLIR* — `curl` down `scripts/setup_mlir.py` from the pinned commit
    and run it with `--wheel --hash $LLVM_HASH`. `--wheel` activates the
    `mlir_wheel` fallback (no GitHub token needed in public CI); `--hash` makes
    the targeted LLVM build explicit so removing `--wheel` is the only change
    needed once artifacts are public. `CMAKE_ARGS` is written to `$GITHUB_ENV`
    so `uv sync` inherits it automatically in the next step.
  - *Install project and dependencies* — `uv sync --extra dev --extra
    mlir-frontend --no-build-isolation`.

- **`README.md`**: add *MLIR frontend bindings* subsection under Setup with the
  full manual install recipe and a note that the preamble goes away once
  [torch-spyre/ktir-mlir-frontend#12](https://github.com/torch-spyre/ktir-mlir-frontend/issues/12)
  is resolved.

- **`CONTRIBUTING.md`**: add a short pointer to the README section; kept
  general so it stays accurate after the wheel transition.

## Build strategy: why we build `ktir-mlir-frontend` from source

The `mlir-frontend` dep is pinned to a commit on `ktir-mlir-frontend@main`, not
a release tag. This is intentional: `ktir-mlir-frontend` is under active
development and has no PyPI releases yet, so CI must build from source in order
to test against unreleased upstream changes.

A future option is to download a pre-packaged wheel of `ktir-mlir-frontend`
once it publishes releases. However, switching to released wheels would mean CI
can only test against stable snapshots — it would no longer catch breaking
changes introduced on `ktir-mlir-frontend@main` before they reach a release.
Nightly wheel infrastructure for `ktir-mlir-frontend` would be needed to close
that gap, which is overhead that lives in that repo, not here.

**Decision for now:** keep the build-from-source approach. The cost is more CI
bandwidth and build time (downloading LLVM + compiling the extension). The
benefit is that updating `KTIR_MLIR_FRONTEND_COMMIT` in `ci.yml` is sufficient
to test any commit of `ktir-mlir-frontend`, including unreleased work. Revisit
once `ktir-mlir-frontend` adopts a release cadence with wheels.

> **Note:** `--wheel` / `--hash` in `setup_mlir.py` refer to how the
> **LLVM/MLIR** dependency is resolved (stable `mlir_wheel` vs. a pinned
> nightly artifact), not to packaging of `ktir-mlir-frontend` itself.

## What is NOT changing

- All existing tests and their pass/fail status are unaffected.
- The `uv sync` (no extras) path for end users is unchanged.
- `tests/mlir_frontend/` still skips gracefully if `mlir_ktdp` is absent
  (local dev without the optional dep).