### PR TITLE
Fix examples for static shapes and block sizes

### DIFF
--- a/examples/ktir/reduce_generic.mlir
+++ b/examples/ktir/reduce_generic.mlir
@@ -1,5 +1,5 @@
 module {
-  func.func @reduce_explicit_region(%arg0: index) attributes {grid = [1, 1]} {
+  func.func @reduce_explicit_region(%arg0: index) attributes {grid = [1]} {
     %c0 = arith.constant 0 : index
     %cst = arith.constant 0.000000e+00 : f16
     %view = ktdp.construct_memory_view %arg0, sizes : [1, 4], strides : [4, 1] {coordinate_set = affine_set<(d0, d1) : (d0 >= 0, -d0 >= 0, d1 >= 0, -d1 + 3 >= 0)>, memory_space = #ktdp.spyre_memory_space<HBM>} : memref<1x4xf16>

--- a/examples/ktir/softmax_wide.mlir
+++ b/examples/ktir/softmax_wide.mlir
@@ -2,7 +2,7 @@ module {
   func.func @softmax_kernel(
       %output_ptr: index,
       %input_ptr: index
-  ) attributes {grid = [1, 1]} {
+  ) attributes {grid = [1]} {
     %core_id = ktdp.get_compute_tile_id : index
     %c_chunk = arith.constant 2 : index  // chunk = ceil(R/K) = ceil(2/1)
     %c_R = arith.constant 2 : index  // R = total rows

--- a/examples/latency/softmax_small.mlir
+++ b/examples/latency/softmax_small.mlir
@@ -2,7 +2,7 @@ module {
   func.func @softmax_kernel_small(
       %output_ptr: index,
       %input_ptr: index
-  ) attributes {grid = [32, 1]} {
+  ) attributes {grid = [32]} {
     %core_id = ktdp.get_compute_tile_id : index
 
     %c0 = arith.constant 0 : index

--- a/examples/latency/softmax_small.mlir
+++ b/examples/latency/softmax_small.mlir
@@ -1,13 +1,17 @@
 module {
   func.func @softmax_kernel_small(
       %output_ptr: index,
-      %input_ptr: index,
-      %n_rows: index // 64
+      %input_ptr: index
   ) attributes {grid = [32, 1]} {
     %core_id = ktdp.get_compute_tile_id : index
 
-    %c32_i32 = arith.constant 32 : index
-    %c0_i32 = arith.constant 0 : index
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c32 = arith.constant 32 : index
+
+    %start_row = arith.muli %core_id, %c2 : index
+    %end_row = arith.addi %start_row, %c2 : index
 
     %input_view = ktdp.construct_memory_view %input_ptr, sizes: [64, 64], strides: [64, 1] {
       coordinate_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 63 >= 0, d1 >= 0, -d1 + 63 >= 0)>, memory_space = #ktdp.spyre_memory_space<HBM>
@@ -17,9 +21,9 @@ module {
       coordinate_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 63 >= 0, d1 >= 0, -d1 + 63 >= 0)>, memory_space = #ktdp.spyre_memory_space<HBM>
     } : memref<64x64xf16>
 
-    scf.for %row = %core_id to %n_rows step %c32_i32 : index {
+    scf.for %row = %start_row to %end_row step %c1 : index {
 
-      %input_acc = ktdp.construct_access_tile %input_view[%row, %c0_i32] {
+      %input_acc = ktdp.construct_access_tile %input_view[%row, %c0] {
         access_tile_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 0 >= 0, d1 >= 0, -d1 + 63 >= 0)>,
         access_tile_order = affine_map<(d0, d1) -> (d0, d1)>
       } : memref<64x64xf16> -> !ktdp.access_tile<1x64xindex>
@@ -33,7 +37,6 @@ module {
         outs(%max_init : tensor<1xf16>)
         dimensions = [1]
 
-      %c0 = arith.constant 0 : index
       %max_scalar = tensor.extract %reduce_max[%c0] : tensor<1xf16>
       %max_row = tensor.splat %max_scalar : tensor<1x64xf16>
 
@@ -53,7 +56,7 @@ module {
 
       %softmax_output = arith.divf %numerator, %denominator_row : tensor<1x64xf16>
 
-      %output_acc = ktdp.construct_access_tile %output_view[%row, %c0_i32] {
+      %output_acc = ktdp.construct_access_tile %output_view[%row, %c0] {
           access_tile_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 0 >= 0, d1 >= 0, -d1 + 63 >= 0)>,
           access_tile_order = affine_map<(d0, d1) -> (d0, d1)>
       } : memref<64x64xf16> -> !ktdp.access_tile<1x64xindex>

--- a/examples/triton-ktir/layernorm_fwd_ktir.mlir
+++ b/examples/triton-ktir/layernorm_fwd_ktir.mlir
@@ -7,7 +7,7 @@ module {
       %Mean: index, // mean 1152xf16
       %Rstd: index, // rstd 1152xf16
       %eps: f16
-  ) attributes {grid = [32, 1]} {
+  ) attributes {grid = [32]} {
     %core_id = ktdp.get_compute_tile_id : index
 
     %c0 = arith.constant 0 : index

--- a/examples/triton-ktir/layernorm_fwd_ktir.mlir
+++ b/examples/triton-ktir/layernorm_fwd_ktir.mlir
@@ -1,57 +1,62 @@
 module {
   func.func @_layer_norm_fwd_fused(
-      %X: index, // input 1151x8192xf16
-      %Y: index, // output 1151x8192xf16
-      %W: index, // weight 1151x8192xf16
-      %B: index, // bias 1151x8192xf16
-      %Mean: index, // mean 1151xf16
-      %Rstd: index, // rstd 1151xf16
-      %N: index, // number of columns in X: 8192
-      %eps: f16,
-      %BLOCK_SIZE: index // 1024
+      %X: index, // input 1152x8192xf16
+      %Y: index, // output 1152x8192xf16
+      %W: index, // weight 1152x8192xf16
+      %B: index, // bias 1152x8192xf16
+      %Mean: index, // mean 1152xf16
+      %Rstd: index, // rstd 1152xf16
+      %eps: f16
   ) attributes {grid = [32, 1]} {
     %core_id = ktdp.get_compute_tile_id : index
 
-    %c0_i32 = arith.constant 0 : index
-    %c1151_i32 = arith.constant 1151 : index
-    %c32_i32 = arith.constant 32 : index
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c32 = arith.constant 32 : index
+    %c36 = arith.constant 36 : index
+    %c1152 = arith.constant 1152 : index
+    %c1024 = arith.constant 1024 : index
+    %c8192 = arith.constant 8192 : index
     %f1_f16 = arith.constant 1.0 : f16
 
-    %X_view = ktdp.construct_memory_view %X, sizes: [1151, 8192], strides: [8192, 1] {
-        coordinate_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 1150 >= 0, d1 >= 0, -d1 + 8191 >= 0)>, memory_space = #ktdp.spyre_memory_space<HBM>
-    } : memref<1151x8192xf16>
+    %start_row = arith.muli %core_id, %c36 : index
+    %end_row = arith.addi %start_row, %c36 : index
 
-    %Y_view = ktdp.construct_memory_view %Y, sizes: [1151, 8192], strides: [8192, 1] {
-        coordinate_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 1150 >= 0, d1 >= 0, -d1 + 8191 >= 0)>, memory_space = #ktdp.spyre_memory_space<HBM>
-    } : memref<1151x8192xf16>
+    %X_view = ktdp.construct_memory_view %X, sizes: [1152, 8192], strides: [8192, 1] {
+        coordinate_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 1151 >= 0, d1 >= 0, -d1 + 8191 >= 0)>, memory_space = #ktdp.spyre_memory_space<HBM>
+    } : memref<1152x8192xf16>
 
-    %W_view = ktdp.construct_memory_view %W, sizes: [1151, 8192], strides: [8192, 1] {
-        coordinate_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 1150 >= 0, d1 >= 0, -d1 + 8191 >= 0)>, memory_space = #ktdp.spyre_memory_space<HBM>
-    } : memref<1151x8192xf16>
+    %Y_view = ktdp.construct_memory_view %Y, sizes: [1152, 8192], strides: [8192, 1] {
+        coordinate_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 1151 >= 0, d1 >= 0, -d1 + 8191 >= 0)>, memory_space = #ktdp.spyre_memory_space<HBM>
+    } : memref<1152x8192xf16>
 
-    %B_view = ktdp.construct_memory_view %B, sizes: [1151, 8192], strides: [8192, 1] {
-        coordinate_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 1150 >= 0, d1 >= 0, -d1 + 8191 >= 0)>, memory_space = #ktdp.spyre_memory_space<HBM>
-    } : memref<1151x8192xf16>
+    %W_view = ktdp.construct_memory_view %W, sizes: [1152, 8192], strides: [8192, 1] {
+        coordinate_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 1151 >= 0, d1 >= 0, -d1 + 8191 >= 0)>, memory_space = #ktdp.spyre_memory_space<HBM>
+    } : memref<1152x8192xf16>
 
-    %Mean_view = ktdp.construct_memory_view %Mean, sizes: [1151], strides: [1] {
-        coordinate_set = affine_set<(d0) : (d0 >= 0, -d0 + 1150 >= 0)>, memory_space = #ktdp.spyre_memory_space<HBM>
-    } : memref<1151xf16>
+    %B_view = ktdp.construct_memory_view %B, sizes: [1152, 8192], strides: [8192, 1] {
+        coordinate_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 1151 >= 0, d1 >= 0, -d1 + 8191 >= 0)>, memory_space = #ktdp.spyre_memory_space<HBM>
+    } : memref<1152x8192xf16>
 
-    %Rstd_view = ktdp.construct_memory_view %Rstd, sizes: [1151], strides: [1] {
-        coordinate_set = affine_set<(d0) : (d0 >= 0, -d0 + 1150 >= 0)>, memory_space = #ktdp.spyre_memory_space<HBM>
-    } : memref<1151xf16>
+    %Mean_view = ktdp.construct_memory_view %Mean, sizes: [1152], strides: [1] {
+        coordinate_set = affine_set<(d0) : (d0 >= 0, -d0 + 1151 >= 0)>, memory_space = #ktdp.spyre_memory_space<HBM>
+    } : memref<1152xf16>
 
-    scf.for %row = %core_id to %c1151_i32 step %c32_i32  : index {
+    %Rstd_view = ktdp.construct_memory_view %Rstd, sizes: [1152], strides: [1] {
+        coordinate_set = affine_set<(d0) : (d0 >= 0, -d0 + 1151 >= 0)>, memory_space = #ktdp.spyre_memory_space<HBM>
+    } : memref<1152xf16>
+
+    scf.for %row = %start_row to %end_row step %c1 : index {
 
         %zero_block = arith.constant dense<0.0> : tensor<1x1024xf16>
 
-        %sum_block = scf.for %col = %c0_i32 to %N step %BLOCK_SIZE
+        %sum_block = scf.for %col = %c0 to %c8192 step %c1024
             iter_args(%sum_iter = %zero_block) -> tensor<1x1024xf16> {
 
             %X_acc = ktdp.construct_access_tile %X_view[%row, %col] {
                 access_tile_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 0 >= 0, d1 >= 0, -d1 + 1023 >= 0)>,
                 access_tile_order = affine_map<(d0, d1) -> (d0, d1)>
-            } : memref<1151x8192xf16> -> !ktdp.access_tile<1x1024xindex>
+            } : memref<1152x8192xf16> -> !ktdp.access_tile<1x1024xindex>
 
             %a = ktdp.load %X_acc : !ktdp.access_tile<1x1024xindex> -> tensor<1x1024xf16>
 
@@ -67,22 +72,21 @@ module {
             outs(%sum_init : tensor<1xf16>)
             dimensions = [1]
 
-        %N_i32 = arith.index_cast %N : index to i32
+        %N_i32 = arith.index_cast %c8192 : index to i32
         %N_f16 = arith.sitofp %N_i32 : i32 to f16
         %N_tensor = tensor.splat %N_f16 : tensor<1xf16>
         %mean = arith.divf %reduce_sum, %N_tensor : tensor<1xf16>
 
-        %c0 = arith.constant 0 : index
         %mean_scalar = tensor.extract %mean[%c0] : tensor<1xf16>
         %mean_block = tensor.splat %mean_scalar : tensor<1x1024xf16>
 
-        %var_block = scf.for %col = %c0_i32 to %N step %BLOCK_SIZE
+        %var_block = scf.for %col = %c0 to %c8192 step %c1024
             iter_args(%var_iter = %zero_block) -> tensor<1x1024xf16> {
 
             %X_acc = ktdp.construct_access_tile %X_view[%row, %col] {
                 access_tile_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 0 >= 0, d1 >= 0, -d1 + 1023 >= 0)>,
                 access_tile_order = affine_map<(d0, d1) -> (d0, d1)>
-            } : memref<1151x8192xf16> -> !ktdp.access_tile<1x1024xindex>
+            } : memref<1152x8192xf16> -> !ktdp.access_tile<1x1024xindex>
 
             %a = ktdp.load %X_acc : !ktdp.access_tile<1x1024xindex> -> tensor<1x1024xf16>
 
@@ -117,32 +121,32 @@ module {
         %Mean_acc = ktdp.construct_access_tile %Mean_view[%row] {
             access_tile_set = affine_set<(d0) : (d0 >= 0, -d0 + 0 >= 0)>,
             access_tile_order = affine_map<(d0) -> (d0)>
-        } : memref<1151xf16> -> !ktdp.access_tile<1xindex>
+        } : memref<1152xf16> -> !ktdp.access_tile<1xindex>
 
         %Rstd_acc = ktdp.construct_access_tile %Rstd_view[%row] {
             access_tile_set = affine_set<(d0) : (d0 >= 0, -d0 + 0 >= 0)>,
             access_tile_order = affine_map<(d0) -> (d0)>
-        } : memref<1151xf16> -> !ktdp.access_tile<1xindex>
+        } : memref<1152xf16> -> !ktdp.access_tile<1xindex>
 
         ktdp.store %mean, %Mean_acc : tensor<1xf16>, !ktdp.access_tile<1xindex>
         ktdp.store %rstd, %Rstd_acc : tensor<1xf16>, !ktdp.access_tile<1xindex>
 
-        scf.for %col = %c0_i32 to %N step %BLOCK_SIZE {
+        scf.for %col = %c0 to %c8192 step %c1024 {
 
             %W_acc = ktdp.construct_access_tile %W_view[%row, %col] {
                 access_tile_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 0 >= 0, d1 >= 0, -d1 + 1023 >= 0)>,
                 access_tile_order = affine_map<(d0, d1) -> (d0, d1)>
-            } : memref<1151x8192xf16> -> !ktdp.access_tile<1x1024xindex>
+            } : memref<1152x8192xf16> -> !ktdp.access_tile<1x1024xindex>
 
             %B_acc = ktdp.construct_access_tile %B_view[%row, %col] {
                 access_tile_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 0 >= 0, d1 >= 0, -d1 + 1023 >= 0)>,
                 access_tile_order = affine_map<(d0, d1) -> (d0, d1)>
-            } : memref<1151x8192xf16> -> !ktdp.access_tile<1x1024xindex>
+            } : memref<1152x8192xf16> -> !ktdp.access_tile<1x1024xindex>
 
             %X_acc = ktdp.construct_access_tile %X_view[%row, %col] {
                 access_tile_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 0 >= 0, d1 >= 0, -d1 + 1023 >= 0)>,
                 access_tile_order = affine_map<(d0, d1) -> (d0, d1)>
-            } : memref<1151x8192xf16> -> !ktdp.access_tile<1x1024xindex>
+            } : memref<1152x8192xf16> -> !ktdp.access_tile<1x1024xindex>
 
             %w = ktdp.load %W_acc : !ktdp.access_tile<1x1024xindex> -> tensor<1x1024xf16>
             %b = ktdp.load %B_acc : !ktdp.access_tile<1x1024xindex> -> tensor<1x1024xf16>
@@ -158,7 +162,7 @@ module {
             %Y_acc = ktdp.construct_access_tile %Y_view[%row, %col] {
                 access_tile_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 0 >= 0, d1 >= 0, -d1 + 1023 >= 0)>,
                 access_tile_order = affine_map<(d0, d1) -> (d0, d1)>
-            } : memref<1151x8192xf16> -> !ktdp.access_tile<1x1024xindex>
+            } : memref<1152x8192xf16> -> !ktdp.access_tile<1x1024xindex>
 
             ktdp.store %y, %Y_acc : tensor<1x1024xf16>, !ktdp.access_tile<1x1024xindex>
 

--- a/examples/triton-ktir/layernorm_fwd_ktir.mlir
+++ b/examples/triton-ktir/layernorm_fwd_ktir.mlir
@@ -1,50 +1,51 @@
 module {
   func.func @_layer_norm_fwd_fused(
-      %X: index, // input 1152x8192xf16
-      %Y: index, // output 1152x8192xf16
-      %W: index, // weight 1152x8192xf16
-      %B: index, // bias 1152x8192xf16
-      %Mean: index, // mean 1152xf16
-      %Rstd: index, // rstd 1152xf16
+      %X: index, // input 1151x8192xf16
+      %Y: index, // output 1151x8192xf16
+      %W: index, // weight 1151x8192xf16
+      %B: index, // bias 1151x8192xf16
+      %Mean: index, // mean 1151xf16
+      %Rstd: index, // rstd 1151xf16
       %eps: f16
   ) attributes {grid = [32]} {
     %core_id = ktdp.get_compute_tile_id : index
 
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index
-    %c32 = arith.constant 32 : index
     %c36 = arith.constant 36 : index
-    %c1152 = arith.constant 1152 : index
+    %c1151 = arith.constant 1151 : index
     %c1024 = arith.constant 1024 : index
     %c8192 = arith.constant 8192 : index
     %f1_f16 = arith.constant 1.0 : f16
 
     %start_row = arith.muli %core_id, %c36 : index
-    %end_row = arith.addi %start_row, %c36 : index
+    %end_row_raw = arith.addi %start_row, %c36 : index
+    %cmp = arith.cmpi slt, %end_row_raw, %c1151 : index
+    %end_row = arith.select %cmp, %end_row_raw, %c1151 : index
 
-    %X_view = ktdp.construct_memory_view %X, sizes: [1152, 8192], strides: [8192, 1] {
-        coordinate_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 1151 >= 0, d1 >= 0, -d1 + 8191 >= 0)>, memory_space = #ktdp.spyre_memory_space<HBM>
-    } : memref<1152x8192xf16>
+    %X_view = ktdp.construct_memory_view %X, sizes: [1151, 8192], strides: [8192, 1] {
+        coordinate_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 1150 >= 0, d1 >= 0, -d1 + 8191 >= 0)>, memory_space = #ktdp.spyre_memory_space<HBM>
+    } : memref<1151x8192xf16>
 
-    %Y_view = ktdp.construct_memory_view %Y, sizes: [1152, 8192], strides: [8192, 1] {
-        coordinate_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 1151 >= 0, d1 >= 0, -d1 + 8191 >= 0)>, memory_space = #ktdp.spyre_memory_space<HBM>
-    } : memref<1152x8192xf16>
+    %Y_view = ktdp.construct_memory_view %Y, sizes: [1151, 8192], strides: [8192, 1] {
+        coordinate_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 1150 >= 0, d1 >= 0, -d1 + 8191 >= 0)>, memory_space = #ktdp.spyre_memory_space<HBM>
+    } : memref<1151x8192xf16>
 
-    %W_view = ktdp.construct_memory_view %W, sizes: [1152, 8192], strides: [8192, 1] {
-        coordinate_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 1151 >= 0, d1 >= 0, -d1 + 8191 >= 0)>, memory_space = #ktdp.spyre_memory_space<HBM>
-    } : memref<1152x8192xf16>
+    %W_view = ktdp.construct_memory_view %W, sizes: [1151, 8192], strides: [8192, 1] {
+        coordinate_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 1150 >= 0, d1 >= 0, -d1 + 8191 >= 0)>, memory_space = #ktdp.spyre_memory_space<HBM>
+    } : memref<1151x8192xf16>
 
-    %B_view = ktdp.construct_memory_view %B, sizes: [1152, 8192], strides: [8192, 1] {
-        coordinate_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 1151 >= 0, d1 >= 0, -d1 + 8191 >= 0)>, memory_space = #ktdp.spyre_memory_space<HBM>
-    } : memref<1152x8192xf16>
+    %B_view = ktdp.construct_memory_view %B, sizes: [1151, 8192], strides: [8192, 1] {
+        coordinate_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 1150 >= 0, d1 >= 0, -d1 + 8191 >= 0)>, memory_space = #ktdp.spyre_memory_space<HBM>
+    } : memref<1151x8192xf16>
 
-    %Mean_view = ktdp.construct_memory_view %Mean, sizes: [1152], strides: [1] {
-        coordinate_set = affine_set<(d0) : (d0 >= 0, -d0 + 1151 >= 0)>, memory_space = #ktdp.spyre_memory_space<HBM>
-    } : memref<1152xf16>
+    %Mean_view = ktdp.construct_memory_view %Mean, sizes: [1151], strides: [1] {
+        coordinate_set = affine_set<(d0) : (d0 >= 0, -d0 + 1150 >= 0)>, memory_space = #ktdp.spyre_memory_space<HBM>
+    } : memref<1151xf16>
 
-    %Rstd_view = ktdp.construct_memory_view %Rstd, sizes: [1152], strides: [1] {
-        coordinate_set = affine_set<(d0) : (d0 >= 0, -d0 + 1151 >= 0)>, memory_space = #ktdp.spyre_memory_space<HBM>
-    } : memref<1152xf16>
+    %Rstd_view = ktdp.construct_memory_view %Rstd, sizes: [1151], strides: [1] {
+        coordinate_set = affine_set<(d0) : (d0 >= 0, -d0 + 1150 >= 0)>, memory_space = #ktdp.spyre_memory_space<HBM>
+    } : memref<1151xf16>
 
     scf.for %row = %start_row to %end_row step %c1 : index {
 
@@ -56,7 +57,7 @@ module {
             %X_acc = ktdp.construct_access_tile %X_view[%row, %col] {
                 access_tile_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 0 >= 0, d1 >= 0, -d1 + 1023 >= 0)>,
                 access_tile_order = affine_map<(d0, d1) -> (d0, d1)>
-            } : memref<1152x8192xf16> -> !ktdp.access_tile<1x1024xindex>
+            } : memref<1151x8192xf16> -> !ktdp.access_tile<1x1024xindex>
 
             %a = ktdp.load %X_acc : !ktdp.access_tile<1x1024xindex> -> tensor<1x1024xf16>
 
@@ -86,7 +87,7 @@ module {
             %X_acc = ktdp.construct_access_tile %X_view[%row, %col] {
                 access_tile_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 0 >= 0, d1 >= 0, -d1 + 1023 >= 0)>,
                 access_tile_order = affine_map<(d0, d1) -> (d0, d1)>
-            } : memref<1152x8192xf16> -> !ktdp.access_tile<1x1024xindex>
+            } : memref<1151x8192xf16> -> !ktdp.access_tile<1x1024xindex>
 
             %a = ktdp.load %X_acc : !ktdp.access_tile<1x1024xindex> -> tensor<1x1024xf16>
 
@@ -121,12 +122,12 @@ module {
         %Mean_acc = ktdp.construct_access_tile %Mean_view[%row] {
             access_tile_set = affine_set<(d0) : (d0 >= 0, -d0 + 0 >= 0)>,
             access_tile_order = affine_map<(d0) -> (d0)>
-        } : memref<1152xf16> -> !ktdp.access_tile<1xindex>
+        } : memref<1151xf16> -> !ktdp.access_tile<1xindex>
 
         %Rstd_acc = ktdp.construct_access_tile %Rstd_view[%row] {
             access_tile_set = affine_set<(d0) : (d0 >= 0, -d0 + 0 >= 0)>,
             access_tile_order = affine_map<(d0) -> (d0)>
-        } : memref<1152xf16> -> !ktdp.access_tile<1xindex>
+        } : memref<1151xf16> -> !ktdp.access_tile<1xindex>
 
         ktdp.store %mean, %Mean_acc : tensor<1xf16>, !ktdp.access_tile<1xindex>
         ktdp.store %rstd, %Rstd_acc : tensor<1xf16>, !ktdp.access_tile<1xindex>
@@ -136,17 +137,17 @@ module {
             %W_acc = ktdp.construct_access_tile %W_view[%row, %col] {
                 access_tile_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 0 >= 0, d1 >= 0, -d1 + 1023 >= 0)>,
                 access_tile_order = affine_map<(d0, d1) -> (d0, d1)>
-            } : memref<1152x8192xf16> -> !ktdp.access_tile<1x1024xindex>
+            } : memref<1151x8192xf16> -> !ktdp.access_tile<1x1024xindex>
 
             %B_acc = ktdp.construct_access_tile %B_view[%row, %col] {
                 access_tile_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 0 >= 0, d1 >= 0, -d1 + 1023 >= 0)>,
                 access_tile_order = affine_map<(d0, d1) -> (d0, d1)>
-            } : memref<1152x8192xf16> -> !ktdp.access_tile<1x1024xindex>
+            } : memref<1151x8192xf16> -> !ktdp.access_tile<1x1024xindex>
 
             %X_acc = ktdp.construct_access_tile %X_view[%row, %col] {
                 access_tile_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 0 >= 0, d1 >= 0, -d1 + 1023 >= 0)>,
                 access_tile_order = affine_map<(d0, d1) -> (d0, d1)>
-            } : memref<1152x8192xf16> -> !ktdp.access_tile<1x1024xindex>
+            } : memref<1151x8192xf16> -> !ktdp.access_tile<1x1024xindex>
 
             %w = ktdp.load %W_acc : !ktdp.access_tile<1x1024xindex> -> tensor<1x1024xf16>
             %b = ktdp.load %B_acc : !ktdp.access_tile<1x1024xindex> -> tensor<1x1024xf16>
@@ -162,7 +163,7 @@ module {
             %Y_acc = ktdp.construct_access_tile %Y_view[%row, %col] {
                 access_tile_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 0 >= 0, d1 >= 0, -d1 + 1023 >= 0)>,
                 access_tile_order = affine_map<(d0, d1) -> (d0, d1)>
-            } : memref<1152x8192xf16> -> !ktdp.access_tile<1x1024xindex>
+            } : memref<1151x8192xf16> -> !ktdp.access_tile<1x1024xindex>
 
             ktdp.store %y, %Y_acc : tensor<1x1024xf16>, !ktdp.access_tile<1x1024xindex>
 

--- a/examples/triton-ktir/matmul_fwd_ktir.mlir
+++ b/examples/triton-ktir/matmul_fwd_ktir.mlir
@@ -2,16 +2,16 @@ module {
   func.func @matmul_kernel(
       %a_ptr: index, // [M, K]
       %b_ptr: index, // [K, N]
-      %c_ptr: index, // [M, N]
-      %K: index, // 2048
-      %BLOCK_SIZE_M: index, // 32
-      %BLOCK_SIZE_N: index, // 512
-      %BLOCK_SIZE_K: index  // 128
+      %c_ptr: index  // [M, N]
   ) attributes {grid = [2, 16]} {
     %pid_m, %pid_n = ktdp.get_compute_tile_id : index, index
   
-    %c0_i32 = arith.constant 0 : i32
     %c0 = arith.constant 0 : index
+    %c0_i32 = arith.constant 0 : i32
+    %K = arith.constant 2048 : index
+    %BLOCK_SIZE_M = arith.constant 32 : index
+    %BLOCK_SIZE_N = arith.constant 512 : index
+    %BLOCK_SIZE_K = arith.constant 128 : index
 
     %a_view = ktdp.construct_memory_view %a_ptr, sizes: [64, 2048], strides: [2048, 1] {
       coordinate_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 63 >= 0, d1 >= 0, -d1 + 2047 >= 0)>, memory_space = #ktdp.spyre_memory_space<HBM>

--- a/examples/triton-ktir/softmax_fwd_ktir.mlir
+++ b/examples/triton-ktir/softmax_fwd_ktir.mlir
@@ -1,13 +1,15 @@
 module {
   func.func @softmax_kernel(
       %output_ptr: index,
-      %input_ptr: index,
-      %n_rows: index // 4096
+      %input_ptr: index
   ) attributes {grid = [32, 1]} {
     %core_id = ktdp.get_compute_tile_id : index
 
-    %c32_i32 = arith.constant 32 : index
-    %c0_i32 = arith.constant 0 : index
+    %c0 = arith.constant 0 : index
+    %c32 = arith.constant 32 : index
+    %c128 = arith.constant 128 : index
+    %start_row = arith.muli %core_id, %c128 : index
+    %end_row = arith.addi %start_row, %c128 : index
 
     %input_view = ktdp.construct_memory_view %input_ptr, sizes: [4096, 1024], strides: [1024, 1] {
       coordinate_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 4095 >= 0, d1 >= 0, -d1 + 1023 >= 0)>, memory_space = #ktdp.spyre_memory_space<HBM>
@@ -17,9 +19,9 @@ module {
       coordinate_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 4095 >= 0, d1 >= 0, -d1 + 1023 >= 0)>, memory_space = #ktdp.spyre_memory_space<HBM>
     } : memref<4096x1024xf16>
 
-    scf.for %row = %core_id to %n_rows step %c32_i32  : index {
+    scf.for %row = %start_row to %end_row step %c32  : index {
 
-      %input_acc = ktdp.construct_access_tile %input_view[%row, %c0_i32] {
+      %input_acc = ktdp.construct_access_tile %input_view[%row, %c0] {
         access_tile_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 0 >= 0, d1 >= 0, -d1 + 1023 >= 0)>,
         access_tile_order = affine_map<(d0, d1) -> (d0, d1)>
       } : memref<4096x1024xf16> -> !ktdp.access_tile<1x1024xindex>
@@ -33,7 +35,6 @@ module {
         outs(%max_init : tensor<1xf16>)
         dimensions = [1]
 
-      %c0 = arith.constant 0 : index
       %max_scalar = tensor.extract %reduce_max[%c0] : tensor<1xf16>
       %max_row = tensor.splat %max_scalar : tensor<1x1024xf16>
 
@@ -53,7 +54,7 @@ module {
 
       %softmax_output = arith.divf %numerator, %denominator_row : tensor<1x1024xf16>
 
-      %output_acc = ktdp.construct_access_tile %output_view[%row, %c0_i32] {
+      %output_acc = ktdp.construct_access_tile %output_view[%row, %c0] {
           access_tile_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 0 >= 0, d1 >= 0, -d1 + 1023 >= 0)>,
           access_tile_order = affine_map<(d0, d1) -> (d0, d1)>
       } : memref<4096x1024xf16> -> !ktdp.access_tile<1x1024xindex>

--- a/examples/triton-ktir/softmax_fwd_ktir.mlir
+++ b/examples/triton-ktir/softmax_fwd_ktir.mlir
@@ -6,7 +6,7 @@ module {
     %core_id = ktdp.get_compute_tile_id : index
 
     %c0 = arith.constant 0 : index
-    %c32 = arith.constant 32 : index
+    %c1 = arith.constant 1 : index
     %c128 = arith.constant 128 : index
     %start_row = arith.muli %core_id, %c128 : index
     %end_row = arith.addi %start_row, %c128 : index
@@ -19,7 +19,7 @@ module {
       coordinate_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 4095 >= 0, d1 >= 0, -d1 + 1023 >= 0)>, memory_space = #ktdp.spyre_memory_space<HBM>
     } : memref<4096x1024xf16>
 
-    scf.for %row = %start_row to %end_row step %c32  : index {
+    scf.for %row = %start_row to %end_row step %c1 : index {
 
       %input_acc = ktdp.construct_access_tile %input_view[%row, %c0] {
         access_tile_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 0 >= 0, d1 >= 0, -d1 + 1023 >= 0)>,

--- a/examples/triton-ktir/softmax_fwd_ktir.mlir
+++ b/examples/triton-ktir/softmax_fwd_ktir.mlir
@@ -2,7 +2,7 @@ module {
   func.func @softmax_kernel(
       %output_ptr: index,
       %input_ptr: index
-  ) attributes {grid = [32, 1]} {
+  ) attributes {grid = [32]} {
     %core_id = ktdp.get_compute_tile_id : index
 
     %c0 = arith.constant 0 : index

--- a/examples/triton-ktir/vector_add_ktir.mlir
+++ b/examples/triton-ktir/vector_add_ktir.mlir
@@ -3,7 +3,7 @@ module {
       %x_ptr: index,
       %y_ptr: index,
       %output_ptr: index
-  ) attributes {grid = [32, 1]} {
+  ) attributes {grid = [32]} {
     %c128 = arith.constant 128 : index
     %core_id = ktdp.get_compute_tile_id : index
     %offset = arith.muli %core_id, %c128 : index

--- a/examples/triton-ktir/vector_add_ktir.mlir
+++ b/examples/triton-ktir/vector_add_ktir.mlir
@@ -2,11 +2,11 @@ module {
   func.func @add_kernel(
       %x_ptr: index,
       %y_ptr: index,
-      %output_ptr: index,
-      %BLOCK_SIZE: index
+      %output_ptr: index
   ) attributes {grid = [32, 1]} {
+    %c128 = arith.constant 128 : index
     %core_id = ktdp.get_compute_tile_id : index
-    %offset = arith.muli %core_id, %BLOCK_SIZE : index
+    %offset = arith.muli %core_id, %c128 : index
 
     %x_view = ktdp.construct_memory_view %x_ptr, sizes: [4096], strides: [1] {
       coordinate_set = affine_set<(d0) : (d0 >= 0, -d0 + 4095 >= 0)>, memory_space = #ktdp.spyre_memory_space<HBM>

--- a/ktir_cpu/parser.py
+++ b/ktir_cpu/parser.py
@@ -194,11 +194,11 @@ class KTIRParser(KTIRParserBase):
         Returns:
             (x, y, z) grid dimensions
         """
-        # Pattern: grid = [X, Y, Z] or grid = [X, Y]
-        grid_match = re.search(r'grid\s*=\s*\[(\d+),\s*(\d+)(?:,\s*(\d+))?\]', func_header)
+        # Pattern: grid = [X, Y, Z] or grid = [X, Y] or grid = [X]
+        grid_match = re.search(r'grid\s*=\s*\[(\d+)(?:,\s*(\d+)(?:,\s*(\d+))?)?\]', func_header)
         if grid_match:
             x = int(grid_match.group(1))
-            y = int(grid_match.group(2))
+            y = int(grid_match.group(2)) if grid_match.group(2) else 1
             z = int(grid_match.group(3)) if grid_match.group(3) else 1
             return (x, y, z)
         return (1, 1, 1)  # Default: single-core when no grid attribute is present

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -102,9 +102,8 @@ EXAMPLE_PARAMS: dict[str, list[dict]] = {
     "_layer_norm_fwd_fused": [
         {
             "path": "triton-ktir/layernorm_fwd_ktir.mlir",
-            # sizes match construct_memory_view: [1152, 8192]
-            # TODO: 1151→1152 change papers over non-divisible grid partition;
-            # see torch-spyre/ktir-cpu#15 review point 2.
+            # sizes match construct_memory_view: [1151, 8192]
+            # 1151 is not divisible by 32 cores; the MLIR uses a min-clamp on end_row.
             "execute_kwargs": {"eps": 1e-5},
         },
     ],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -75,38 +75,19 @@ EXAMPLE_PARAMS: dict[str, list[dict]] = {
     "add_kernel": [
         {
             "path": "triton-ktir/vector_add_ktir.mlir",
-            # n_elements matches construct_memory_view sizes: [4096]
-            # BLOCK_SIZE matches access tile: !ktdp.access_tile<128xindex>
-            "execute_kwargs": {"n_elements": 4096, "BLOCK_SIZE": 128},
+            "execute_kwargs": {},
         },
     ],
     "softmax_kernel_small": [
         {
             "path": "latency/softmax_small.mlir",
-            # sizes match construct_memory_view: [64, 64]
-            # grid = [32, 1], n_cols filled dynamically at call site
-            "execute_kwargs": {
-                "input_row_stride": 64,
-                "output_row_stride": 64,
-                "n_rows": 64,
-                "BLOCK_SIZE": 64,
-                "n_cols": None,  # filled from sizes at call site
-            },
+            "execute_kwargs": {},
         },
     ],
     "softmax_kernel": [
         {
             "path": "triton-ktir/softmax_fwd_ktir.mlir",
-            # row_stride matches construct_memory_view strides: [1024, 1]
-            # n_rows and BLOCK_SIZE match the MLIR constants
-            # n_cols is filled dynamically at call site (varies per test)
-            "execute_kwargs": {
-                "input_row_stride": 1024,
-                "output_row_stride": 1024,
-                "n_rows": 4096,
-                "BLOCK_SIZE": 1024,
-                "n_cols": None,  # filled from sizes at call site
-            },
+            "execute_kwargs": {},
         },
         {
             "path": "ktir/softmax_wide.mlir",
@@ -121,22 +102,21 @@ EXAMPLE_PARAMS: dict[str, list[dict]] = {
     "_layer_norm_fwd_fused": [
         {
             "path": "triton-ktir/layernorm_fwd_ktir.mlir",
-            # stride and N match construct_memory_view sizes: [1151, 8192]
-            # BLOCK_SIZE matches the MLIR constant
-            "execute_kwargs": {"stride": 8192, "N": 8192, "eps": 1e-5, "BLOCK_SIZE": 1024},
+            # sizes match construct_memory_view: [1152, 8192]
+            # TODO: 1151→1152 change papers over non-divisible grid partition;
+            # see torch-spyre/ktir-cpu#15 review point 2.
+            "execute_kwargs": {"eps": 1e-5},
         },
     ],
     "matmul_kernel": [
         {
             "path": "triton-ktir/matmul_fwd_ktir.mlir",
-            # M, N, K match construct_memory_view sizes: [64,2048], [2048,8192], [64,8192]
-            # strides match the memory view strides
-            # BLOCK_SIZE_* match the MLIR tile constants
+            # M, N, K, BLOCK_SIZE_* are not function args in this MLIR (baked as
+            # constants), but _run_matmul passes them as dead kwargs because it
+            # also serves matmul_kernel_small which takes them as function args.
+            # test_matmul_flops and test_work_splitting_matmul read these values.
             "execute_kwargs": {
                 "M": 64, "N": 8192, "K": 2048,
-                "stride_am": 2048, "stride_ak": 1,
-                "stride_bk": 8192, "stride_bn": 1,
-                "stride_cm": 8192, "stride_cn": 1,
                 "BLOCK_SIZE_M": 32, "BLOCK_SIZE_N": 512, "BLOCK_SIZE_K": 128,
             },
         },
@@ -144,13 +124,10 @@ EXAMPLE_PARAMS: dict[str, list[dict]] = {
     "matmul_kernel_small": [
         {
             "path": "latency/matmul_small.mlir",
-            # M, N, K match construct_memory_view sizes: [16,64], [64,64], [16,64]
-            # grid = [2, 2], BLOCK_SIZE_* match the MLIR tile constants
+            # M=16, N=64, K=64 match construct_memory_view sizes
+            # grid = [2, 2], BLOCK_SIZE_* match the MLIR function args
             "execute_kwargs": {
                 "M": 16, "N": 64, "K": 64,
-                "stride_am": 64, "stride_ak": 1,
-                "stride_bk": 64, "stride_bn": 1,
-                "stride_cm": 64, "stride_cn": 1,
                 "BLOCK_SIZE_M": 8, "BLOCK_SIZE_N": 32, "BLOCK_SIZE_K": 32,
             },
         },

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -151,7 +151,7 @@ class TestVectorAddExecution(InterpreterTestMixin):
         interp = self._make_interp()
         interp.load(path)
 
-        x_ptr, y_ptr, output_ptr, BLOCK_SIZE = interp.arg_names(func_name)
+        x_ptr, y_ptr, output_ptr = interp.arg_names(func_name)
         sizes = interp.tensor_input_output_sizes(func_name)
         (n,) = sizes[x_ptr]["shape"]
         rng = np.random.default_rng(42)
@@ -161,7 +161,6 @@ class TestVectorAddExecution(InterpreterTestMixin):
 
         outputs = interp.execute_function(func_name, **{
             x_ptr: x, y_ptr: y, output_ptr: output,
-            BLOCK_SIZE: entry["execute_kwargs"]["BLOCK_SIZE"],
         })
 
         result = outputs[output_ptr]
@@ -174,7 +173,7 @@ class TestVectorAddExecution(InterpreterTestMixin):
         interp = self._make_interp()
         interp.load(path)
 
-        x_ptr, y_ptr, output_ptr, BLOCK_SIZE = interp.arg_names(func_name)
+        x_ptr, y_ptr, output_ptr = interp.arg_names(func_name)
         sizes = interp.tensor_input_output_sizes(func_name)
         (n,) = sizes[x_ptr]["shape"]
         x = np.zeros(n, dtype=np.float16)
@@ -183,7 +182,6 @@ class TestVectorAddExecution(InterpreterTestMixin):
 
         outputs = interp.execute_function(func_name, **{
             x_ptr: x, y_ptr: y, output_ptr: output,
-            BLOCK_SIZE: entry["execute_kwargs"]["BLOCK_SIZE"],
         })
 
         result = outputs[output_ptr]
@@ -200,7 +198,7 @@ class TestSoftmaxExecution(InterpreterTestMixin):
         interp = self._make_interp()
         interp.load(path)
 
-        output_ptr, input_ptr, n_rows = interp.arg_names(func_name)
+        output_ptr, input_ptr = interp.arg_names(func_name)
         sizes = interp.tensor_input_output_sizes(func_name)
         n_rows_val, n_padded_cols = sizes[input_ptr]["shape"]
         rng = np.random.default_rng(42)
@@ -215,7 +213,6 @@ class TestSoftmaxExecution(InterpreterTestMixin):
 
         outputs = interp.execute_function(func_name, **{
             output_ptr: out, input_ptr: inp,
-            n_rows: entry["execute_kwargs"]["n_rows"],
         })
         result = outputs[output_ptr]
 
@@ -262,7 +259,7 @@ class TestLayerNormExecution(InterpreterTestMixin):
         interp = self._make_interp()
         interp.load(path)
 
-        X, Y, W, B, Mean, Rstd, N, eps, BLOCK_SIZE = interp.arg_names(func_name)
+        X, Y, W, B, Mean, Rstd, eps = interp.arg_names(func_name)
         sizes = interp.tensor_input_output_sizes(func_name)
         n_rows, n_cols = sizes[X]["shape"]
         rng = np.random.default_rng(42)
@@ -281,7 +278,7 @@ class TestLayerNormExecution(InterpreterTestMixin):
         outputs = interp.execute_function(func_name, **{
             X: X_data, Y: Y_data, W: W_data, B: B_data,
             Mean: Mean_data, Rstd: Rstd_data,
-            N: ek["N"], eps: ek["eps"], BLOCK_SIZE: ek["BLOCK_SIZE"],
+            eps: ek["eps"],
         })
         result_Y = outputs[Y]
         result_Mean = outputs[Mean]
@@ -352,7 +349,7 @@ class TestMatMulExecution(InterpreterTestMixin):
         interp = self._make_interp()
         interp.load(path)
 
-        a_ptr, b_ptr, c_ptr, K, BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = interp.arg_names(func_name)
+        a_ptr, b_ptr, c_ptr = interp.arg_names(func_name)
         ek = entry["execute_kwargs"]
         M, N, K_val = ek["M"], ek["N"], ek["K"]
         rng = np.random.default_rng(42)
@@ -362,10 +359,6 @@ class TestMatMulExecution(InterpreterTestMixin):
 
         outputs = interp.execute_function(func_name, **{
             a_ptr: A, b_ptr: B, c_ptr: C,
-            K: ek["K"],
-            BLOCK_SIZE_M: ek["BLOCK_SIZE_M"],
-            BLOCK_SIZE_N: ek["BLOCK_SIZE_N"],
-            BLOCK_SIZE_K: ek["BLOCK_SIZE_K"],
         })
         result_C = outputs[c_ptr]
 

--- a/tests/test_latency.py
+++ b/tests/test_latency.py
@@ -41,9 +41,8 @@ def _run_vector_add(path, func_name, entry, cfg, trace=False):
     x = rng.standard_normal(n).astype(np.float16)
     y = rng.standard_normal(n).astype(np.float16)
     out = np.zeros(n, dtype=np.float16)
-    kwargs = {k: v for k, v in entry["execute_kwargs"].items() if v is not None}
     outputs = interp.execute_function(
-        func_name, x_ptr=x, y_ptr=y, output_ptr=out, **kwargs
+        func_name, x_ptr=x, y_ptr=y, output_ptr=out,
     )
     return interp.get_latency_report(), outputs
 
@@ -63,12 +62,9 @@ def _run_softmax(path, func_name, entry, cfg, trace=False):
         (n_rows, n_real_cols)
     ).astype(np.float16)
     out = np.zeros((n_rows, n_padded_cols), dtype=np.float16)
-    kwargs = {k: v for k, v in entry["execute_kwargs"].items() if v is not None}
-    kwargs["n_cols"] = n_real_cols  # fill dynamic kwarg from actual sizes
     interp.execute_function(
         func_name,
         output_ptr=out, input_ptr=inp,
-        **kwargs,
     )
     return interp.get_latency_report()
 
@@ -78,16 +74,18 @@ def _run_matmul(path, func_name, entry, cfg, trace=False):
     interp = KTIRInterpreter(latency_config=cfg, trace_latency=trace)
     interp.load(path)
 
-    kwargs = {k: v for k, v in entry["execute_kwargs"].items() if v is not None}
-    M, N, K = kwargs["M"], kwargs["N"], kwargs["K"]
+    ek = entry["execute_kwargs"]
+    M, N, K = ek["M"], ek["N"], ek["K"]
     rng = np.random.default_rng(42)
     A = rng.standard_normal((M, K)).astype(np.float16)
     B = rng.standard_normal((K, N)).astype(np.float16)
     C = np.zeros((M, N), dtype=np.float16)
+    scalar_kwargs = {k: v for k, v in ek.items()
+                     if not isinstance(v, np.ndarray) and v is not None}
     interp.execute_function(
         func_name,
         a_ptr=A, b_ptr=B, c_ptr=C,
-        **kwargs,
+        **scalar_kwargs,
     )
     return interp.get_latency_report()
 


### PR DESCRIPTION
This PR fixes the inconsistency between shapes and indexes (offsets).

This PR will cover [a ktir-mlir-frontend issue](https://github.com/torch-spyre/ktir-mlir-frontend/issues/15).