### PR TITLE
Add @lchu6 as a codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,4 +8,4 @@
 # https://help.github.com/en/articles/about-code-owners
 #
 # Default owners (fallback for anything not matched below)
-* @fabianlim @kiszk
+* @fabianlim @kiszk @lchu6


### PR DESCRIPTION
## Summary
- Adds @lchu6 as a default codeowner alongside @fabianlim and @kiszk

## Test plan
- [x] Verify CODEOWNERS syntax is valid after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)