### PR TITLE
Rewind lx.next_ptr on pop_scope (fixes #26)

### DIFF
--- a/ktir_cpu/grid.py
+++ b/ktir_cpu/grid.py
@@ -76,7 +76,7 @@ class CoreContext:
         self.hbm = hbm  # Shared HBM
         self._scope_stack: List[Dict[str, Any]] = [{}]  # bottom = function body
         self._lx_bytes: Dict[str, int] = {}  # SSA name -> LX bytes (single source of truth)
-        self._lx_next_ptr_stack: List[int] = []  # watermarks saved on push_scope, restored on pop_scope (#26)
+        self._lx_next_ptr_stack: List[int] = []  # watermarks for lx.next_ptr rewind on pop_scope
 
     def get_grid_id(self, dim: int) -> int:
         """Get grid ID for dimension.
@@ -91,16 +91,38 @@ class CoreContext:
 
     # ------------------------------------------------------------------
     # Region scoping
+    # LX allocation model: scope-watermark bump allocator
+    # LX address space is managed as a bump allocator with scope-level watermarks.
+    # push_scope snapshots lx.next_ptr; pop_scope rewinds it. This is the
+    # most aggressive deallocation strategy the IR permits without liveness analysis:
+
+    # 1). SSA values are immutable bindings with scope-lifetime semantics. A value
+    # that is "in scope" is reachable — there is no point in the IR where a value
+    # is dead but still in scope. So scope-exit is the earliest safe deallocation
+    # point.
+
+    # 2). Intra-scope reuse is not possible because all tiles produced within a scope
+    # coexist simultaneously in LX until the scope pops. Peak LX usage within a
+    # scope equals the sum of all tiles produced in that scope, even if some are
+    # logically "consumed" by a downstream op and never read again.
+
+    # 3). A free-list or explicit dealloc op would require liveness analysis or
+    # last-use annotations, neither of which exist in KTIR's current model
+    # (compute uses standard MLIR dialects; SCF regions define lifetime).
+
+    # The watermark stack stays in lockstep with _scope_stack — the invariant
+    # len(_lx_next_ptr_stack) == len(_scope_stack) - 1 holds by construction.
     # ------------------------------------------------------------------
 
     def push_scope(self):
         """Enter a new region scope (scf.for body, scf.if branch).
 
         Snapshots ``lx.next_ptr`` so ``pop_scope`` can rewind it and
-        keep the bump-pointer in lockstep with ``lx.used`` (see #26).
+        keep the bump-pointer in lockstep with ``lx.used``.
         """
         self._lx_next_ptr_stack.append(self.lx.next_ptr)
         self._scope_stack.append({})
+        assert len(self._lx_next_ptr_stack) == len(self._scope_stack) - 1
 
     def pop_scope(self):
         """Exit the current region scope.
@@ -116,6 +138,7 @@ class CoreContext:
         for name in scope:
             self.untrack_lx(name)
         self.lx.next_ptr = self._lx_next_ptr_stack.pop()
+        assert len(self._lx_next_ptr_stack) == len(self._scope_stack) - 1
 
     # ------------------------------------------------------------------
     # SSA value access

--- a/ktir_cpu/grid.py
+++ b/ktir_cpu/grid.py
@@ -76,6 +76,7 @@ class CoreContext:
         self.hbm = hbm  # Shared HBM
         self._scope_stack: List[Dict[str, Any]] = [{}]  # bottom = function body
         self._lx_bytes: Dict[str, int] = {}  # SSA name -> LX bytes (single source of truth)
+        self._lx_next_ptr_stack: List[int] = []  # watermarks saved on push_scope, restored on pop_scope (#26)
 
     def get_grid_id(self, dim: int) -> int:
         """Get grid ID for dimension.
@@ -93,20 +94,28 @@ class CoreContext:
     # ------------------------------------------------------------------
 
     def push_scope(self):
-        """Enter a new region scope (scf.for body, scf.if branch)."""
+        """Enter a new region scope (scf.for body, scf.if branch).
+
+        Snapshots ``lx.next_ptr`` so ``pop_scope`` can rewind it and
+        keep the bump-pointer in lockstep with ``lx.used`` (see #26).
+        """
+        self._lx_next_ptr_stack.append(self.lx.next_ptr)
         self._scope_stack.append({})
 
     def pop_scope(self):
         """Exit the current region scope.
 
-        Discards all SSA values in the topmost scope and frees their
-        LX via ``untrack_lx``.
+        Discards all SSA values in the topmost scope, frees their LX
+        via ``untrack_lx``, and rewinds ``lx.next_ptr`` to its
+        pre-push value so the bump-pointer reclaims address space
+        alongside the byte counter.
         """
         if len(self._scope_stack) <= 1:
             raise RuntimeError("Cannot pop the function-body scope")
         scope = self._scope_stack.pop()
         for name in scope:
             self.untrack_lx(name)
+        self.lx.next_ptr = self._lx_next_ptr_stack.pop()
 
     # ------------------------------------------------------------------
     # SSA value access
@@ -148,6 +157,7 @@ class CoreContext:
         """Clear all scopes and LX (for next round of execution)."""
         self._scope_stack = [{}]
         self._lx_bytes.clear()
+        self._lx_next_ptr_stack.clear()
         self.lx.clear()
 
     # ------------------------------------------------------------------

--- a/tests/test_lx_scoping.py
+++ b/tests/test_lx_scoping.py
@@ -24,6 +24,7 @@ import pytest
 from ktir_cpu.grid import CoreContext
 from ktir_cpu.memory import LXScratchpad, HBMSimulator
 from ktir_cpu.ir_types import Tile
+from ktir_cpu.ops.memory_ops import MemoryOps
 
 
 def _make_context(lx_size_mb: int = 2) -> CoreContext:
@@ -235,3 +236,121 @@ class TestIterArgsPersistence:
             ctx.set_value("%acc", new_acc)
             ctx.track_lx("%acc", new_acc.size_bytes())
             assert ctx.lx.used == 8  # back to steady state
+
+
+# ---------------------------------------------------------------------------
+# next_ptr rewind on pop_scope (issue #26)
+# ---------------------------------------------------------------------------
+
+class TestNextPtrRewind:
+    """Regression tests for issue #26: lx.next_ptr must be rewound on
+    pop_scope so it stays in lockstep with lx.used.
+    """
+
+    def test_issue_26_reproducer_next_ptr_bounded_in_loop(self):
+        """The exact failure mode from issue #26.
+
+        Before the fix, next_ptr advanced by 2048 (tile size, stick-aligned)
+        every iteration and crossed the 128 KB LX capacity at iter 64 while
+        lx.used stayed 0. After the fix, both return to 0 on every pop.
+        """
+        lx = LXScratchpad(size_mb=0.125, core_id=0)  # 128 KB
+        hbm = HBMSimulator()
+        ctx = CoreContext(core_id=0, grid_pos=(0, 0, 0), lx=lx, hbm=hbm)
+
+        for i in range(100):
+            ctx.push_scope()
+
+            # Mirrors the interpreter's _execute_operation sequence for a
+            # load op: write into LX, set the SSA value in the scope, track
+            # its bytes. pop_scope then frees it via untrack_lx.
+            tile_data = np.zeros((4, 256), dtype=np.float16)  # 2 KB
+            MemoryOps._write_to_lx(ctx, tile_data)
+            name = f"%tile_iter{i}"
+            ctx.set_value(name, Tile(tile_data, "f16", tile_data.shape))
+            ctx.track_lx(name, tile_data.nbytes)
+
+            ctx.pop_scope()
+
+            # Strong invariant: both accountants return to their pre-push
+            # values. Catches divergence at iter 0, not just overflow at 64.
+            assert ctx.lx.used == 0, f"iter {i}: lx.used={ctx.lx.used}"
+            assert ctx.lx.next_ptr == 0, (
+                f"iter {i}: lx.next_ptr={ctx.lx.next_ptr}"
+            )
+
+    def test_next_ptr_restored_on_pop_single_level(self):
+        """A single push/allocate/pop cycle restores next_ptr exactly."""
+        ctx = _make_context()
+        assert ctx.lx.next_ptr == 0
+
+        ctx.push_scope()
+        MemoryOps._write_to_lx(ctx, np.zeros((128,), dtype=np.float16))  # 256 B
+        assert ctx.lx.next_ptr == 256
+        ctx.pop_scope()
+        assert ctx.lx.next_ptr == 0
+
+    def test_next_ptr_restored_on_pop_with_outer_allocation(self):
+        """Outer-scope allocations are preserved; only inner ones are reclaimed.
+
+        This is the nested-scope discipline: push saves the current watermark,
+        pop restores to it, so whatever the outer scope allocated survives.
+        """
+        ctx = _make_context()
+
+        # Outer-scope allocation at the function level.
+        MemoryOps._write_to_lx(ctx, np.zeros((128,), dtype=np.float16))  # 256 B
+        outer_ptr = ctx.lx.next_ptr
+        assert outer_ptr == 256
+
+        ctx.push_scope()
+        MemoryOps._write_to_lx(ctx, np.zeros((1024,), dtype=np.float16))  # 2 KB
+        assert ctx.lx.next_ptr == 256 + 2048
+        ctx.pop_scope()
+
+        # Inner allocation reclaimed; outer watermark preserved.
+        assert ctx.lx.next_ptr == outer_ptr
+
+    def test_nested_scopes_rewind_lifo(self):
+        """Three-level nesting (fn / for-body / if-body) restores each level."""
+        ctx = _make_context()
+
+        # Function-level allocation.
+        MemoryOps._write_to_lx(ctx, np.zeros((128,), dtype=np.float16))  # A
+        wm_fn = ctx.lx.next_ptr
+
+        ctx.push_scope()                                                   # for-body
+        MemoryOps._write_to_lx(ctx, np.zeros((512,), dtype=np.float16))   # B
+        wm_for = ctx.lx.next_ptr
+
+        ctx.push_scope()                                                   # if-body
+        MemoryOps._write_to_lx(ctx, np.zeros((1024,), dtype=np.float16))  # C
+        assert ctx.lx.next_ptr > wm_for
+
+        ctx.pop_scope()                                                    # pop if
+        assert ctx.lx.next_ptr == wm_for   # C reclaimed, B/A live
+
+        ctx.pop_scope()                                                    # pop for
+        assert ctx.lx.next_ptr == wm_fn    # B reclaimed, A live
+
+    def test_legitimate_overflow_still_raises(self):
+        """The fix must not hide genuine LX exhaustion within a single scope."""
+        ctx = _make_context(lx_size_mb=0.125)  # 128 KB cap
+
+        # Try to track more than capacity in one scope — track_lx should raise.
+        with pytest.raises(MemoryError, match="LX scratchpad overflow"):
+            for i in range(100):
+                data = np.zeros((1024,), dtype=np.float16)  # 2 KB each
+                MemoryOps._write_to_lx(ctx, data)
+                ctx.track_lx(f"%t{i}", data.nbytes)  # eventually exceeds 128 KB
+
+    def test_clear_values_resets_watermark_stack(self):
+        """clear_values must also clear the watermark stack."""
+        ctx = _make_context()
+        ctx.push_scope()
+        ctx.push_scope()
+        assert len(ctx._lx_next_ptr_stack) == 2
+        ctx.clear_values()
+        assert ctx._lx_next_ptr_stack == []
+        assert ctx.lx.next_ptr == 0
+        assert ctx.lx.used == 0


### PR DESCRIPTION
## Summary

Fixes #26.

`LXScratchpad` tracked byte usage (`lx.used`) and the bump-pointer
allocation address (`lx.next_ptr`) independently. `pop_scope`
decremented `lx.used` via `untrack_lx` but never touched `next_ptr`,
so any loop that loaded tiles drifted the bump-pointer past capacity
while `lx.used` stayed small — the hardware capacity constraint that
LX is supposed to model was silently bypassed. The issue's reproducer
overflows a 128 KB LX at iter 64 with `lx.used=0`.

## Fix 

`CoreContext` now holds a watermark stack. `push_scope` snapshots
`lx.next_ptr`; `pop_scope` restores it after freeing the scope's
tracked values. `clear_values` also clears the stack so fresh function
invocations start clean.

Four small edits in `ktir_cpu/grid.py`, ~5 lines of production code.
`LXScratchpad`, `_write_to_lx`, the scf/linalg region handlers, and
the interpreter are all untouched — the fix is transparent to them.

## Tests

New `TestNextPtrRewind` in `tests/test_lx_scoping.py`:

- `test_issue_26_reproducer_next_ptr_bounded_in_loop` — the exact
  failure mode from #26. Asserts the strong invariant
  (`lx.used == 0 and lx.next_ptr == 0` after every pop), so
  divergence is caught at iter 0 rather than overflow at iter 64.
- `test_next_ptr_restored_on_pop_single_level`
- `test_next_ptr_restored_on_pop_with_outer_allocation` — outer
  allocations preserved, only inner ones reclaimed.
- `test_nested_scopes_rewind_lifo` — three-level nesting.
- `test_legitimate_overflow_still_raises` — fix must not hide genuine
  LX exhaustion.
- `test_clear_values_resets_watermark_stack`.

