### PR TITLE
[Fix] setup_mlir: separate --hash and --wheel into two distinct options

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,8 @@ jobs:
         run: sudo apt-get install -y ninja-build
 
       # Download setup_mlir.py from upstream ktir-mlir-frontend and resolve MLIR_DIR.
-      # We pass --wheel to use the mlir_wheel fallback (artifact path requires a GitHub
-      # token not available in public CI). --hash pins to the LLVM build tested upstream.
+      # --hash uses the pinned LLVM artifact (recommended); GITHUB_TOKEN provides
+      # cross-repo actions:read access to torch-spyre/ktir-mlir-frontend.
       # Drop-in removal: once ktir-mlir-frontend publishes a wheel to PyPI, delete
       # this step entirely — `uv sync --extra mlir-frontend` will install it directly.
       - name: Set up MLIR
@@ -35,7 +35,8 @@ jobs:
           FRONTEND_COMMIT=$(python -c "import re, pathlib; print(re.search(r'ktir-mlir-frontend@([0-9a-f]{40})', pathlib.Path('pyproject.toml').read_text()).group(1))")
           SETUP_MLIR="https://raw.githubusercontent.com/torch-spyre/ktir-mlir-frontend/$FRONTEND_COMMIT/scripts/setup_mlir.py"
           LLVM_HASH=$(curl -fsSL "https://raw.githubusercontent.com/torch-spyre/ktir-mlir-frontend/$FRONTEND_COMMIT/cmake/llvm-hash.txt")
-          MLIR_DIR=$(curl -fsSL "$SETUP_MLIR" | uv run python - --wheel --hash "$LLVM_HASH")
+          curl -fsSL "$SETUP_MLIR" -o /tmp/setup_mlir.py
+          MLIR_DIR=$(GIT_PAT="${{ secrets.GITHUB_TOKEN }}" uv run python /tmp/setup_mlir.py --hash "$LLVM_HASH")
           uv pip install scikit-build-core "nanobind>=2.12.0"
           echo "CMAKE_ARGS=-DMLIR_DIR=$MLIR_DIR" >> $GITHUB_ENV
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           SETUP_MLIR="https://raw.githubusercontent.com/torch-spyre/ktir-mlir-frontend/$FRONTEND_COMMIT/scripts/setup_mlir.py"
           LLVM_HASH=$(curl -fsSL "https://raw.githubusercontent.com/torch-spyre/ktir-mlir-frontend/$FRONTEND_COMMIT/cmake/llvm-hash.txt")
           curl -fsSL "$SETUP_MLIR" -o /tmp/setup_mlir.py
-          MLIR_DIR=$(GIT_PAT="${{ secrets.GITHUB_TOKEN }}" uv run python /tmp/setup_mlir.py --hash "$LLVM_HASH")
+          MLIR_DIR=$(GIT_PAT="${{ secrets.GITHUB_TOKEN }}" uv run python /tmp/setup_mlir.py --hash "$LLVM_HASH" --repo torch-spyre/ktir-mlir-frontend)
           uv pip install scikit-build-core "nanobind>=2.12.0"
           echo "CMAKE_ARGS=-DMLIR_DIR=$MLIR_DIR" >> $GITHUB_ENV
 

--- a/README.md
+++ b/README.md
@@ -31,21 +31,28 @@ Until a PyPI release is available, build from source:
 Resolve `MLIR_DIR` using one of:
 
 ```bash
-# Option 1: pin to the LLVM hash tested by ktir-mlir-frontend
 # Parse pinned commit from pyproject.toml (python one-liner for macOS/Linux portability)
 FRONTEND_COMMIT=$(python -c "import re, pathlib; print(re.search(r'ktir-mlir-frontend@([0-9a-f]{40})', pathlib.Path('pyproject.toml').read_text()).group(1))")
 SETUP_MLIR="https://raw.githubusercontent.com/torch-spyre/ktir-mlir-frontend/$FRONTEND_COMMIT/scripts/setup_mlir.py"
 LLVM_HASH=$(curl -fsSL "https://raw.githubusercontent.com/torch-spyre/ktir-mlir-frontend/$FRONTEND_COMMIT/cmake/llvm-hash.txt")
-MLIR_DIR=$(curl -fsSL "$SETUP_MLIR" | uv run python - --wheel --hash "$LLVM_HASH")
-
-# Option 2: use the latest mlir_wheel (simplest, no pinned hash)
-uv pip install mlir_wheel --find-links https://llvm.github.io/eudsl
-MLIR_DIR=$(uv run --no-project python -c "import mlir_wheel, pathlib; print(pathlib.Path(mlir_wheel.__file__).parent / 'lib/cmake/mlir')")
+curl -fsSL "$SETUP_MLIR" -o /tmp/setup_mlir.py
 ```
 
-Then build and install:
+**Option 1 (recommended) — pinned LLVM artifact:**
+
+Requires a GitHub token with `actions:read` scope in `GIT_PAT` or `GITHUB_TOKEN`:
 
 ```bash
+MLIR_DIR=$(GIT_PAT=<your-token> uv run python /tmp/setup_mlir.py --hash "$LLVM_HASH")
+CMAKE_ARGS="-DMLIR_DIR=$MLIR_DIR" uv sync --extra mlir-frontend
+```
+
+**Option 2 (dev/testing only) — `mlir_wheel` fallback:**
+
+No token required, but uses a bleeding-edge `mlir_wheel` that may not match the pinned LLVM hash:
+
+```bash
+MLIR_DIR=$(uv run python /tmp/setup_mlir.py --wheel)
 CMAKE_ARGS="-DMLIR_DIR=$MLIR_DIR" uv sync --extra mlir-frontend
 ```
 


### PR DESCRIPTION
## Summary

Follow-up to #24, which switched to downloading the pinned LLVM artifact from `torch-spyre/ktir-mlir-frontend`. That PR inadvertently kept `--wheel --hash` in both the README and CI — but after [ktir-mlir-frontend#14](https://github.com/torch-spyre/ktir-mlir-frontend/pull/14), `--wheel` takes precedence and silently ignores `--hash`, so we were installing the bleeding-edge `mlir_wheel` instead of the pinned artifact.

This PR fixes that:
- CI now calls `--hash "$LLVM_HASH" --repo torch-spyre/ktir-mlir-frontend` (no `--wheel`), using `GITHUB_TOKEN` which has cross-repo `actions:read` within the org — no PAT required.
- README is updated to present two explicit options: Option 1 (recommended, pinned artifact via `--hash`) and Option 2 (dev/testing only, `--wheel` fallback).

## Test plan

- [x] CI passes with `GITHUB_TOKEN` downloading the pinned artifact from `torch-spyre/ktir-mlir-frontend`

🤖 Generated with [Claude Code](https://claude.com/claude-code)