### PR TITLE
[Refactor] Shared dispatch helpers + full arith dialect coverage 

### DIFF
--- a/ktir_cpu/dialects/_helpers.py
+++ b/ktir_cpu/dialects/_helpers.py
@@ -1,0 +1,82 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared dispatch helpers for dialect op handlers.
+
+These helpers eliminate the repetitive Tile-vs-scalar branching that
+appears across arith_ops.py, math_ops.py, and other dialect files.
+See issue #23 for motivation.
+
+Public API
+----------
+_is_scalar(v)                  — True if v is a numeric scalar (not Tile)
+_float_binop(op, context, fn)  — fetch two operands, dispatch float binop
+_int_binop(op, context, fn)    — fetch two operands, dispatch int binop
+_unary(op, context, tile_fn, scalar_fn) — fetch one operand, dispatch unary
+"""
+
+import numpy as np
+
+from ..ir_types import Tile
+
+
+def _is_scalar(v) -> bool:
+    return isinstance(v, (int, float, np.integer, np.floating))
+
+
+def _float_binop(op, context, fn):
+    """Fetch two operands and apply a float element-wise function.
+
+    *fn* receives two numpy arrays (or scalars coerced to np.float16) and
+    returns a numpy array.  Handles scalar/scalar, Tile/Tile, and mixed cases.
+    """
+    a = context.get_value(op.operands[0])
+    b = context.get_value(op.operands[1])
+    if _is_scalar(a) and _is_scalar(b):
+        result = fn(np.float16(a), np.float16(b))
+        return np.float16(result) if not isinstance(result, np.float16) else result
+    if isinstance(a, Tile) and isinstance(b, Tile):
+        return Tile(fn(a.data, b.data), a.dtype, a.shape)
+    if isinstance(a, Tile):
+        return Tile(fn(a.data, np.float16(b)), a.dtype, a.shape)
+    return Tile(fn(np.float16(a), b.data), b.dtype, b.shape)
+
+
+def _int_binop(op, context, fn):
+    """Fetch two operands and apply an integer element-wise function.
+
+    *fn* receives two numpy arrays (or Python ints) and returns a numpy
+    array or int.  Scalars are broadcast into Tiles when one operand is a Tile.
+    """
+    a = context.get_value(op.operands[0])
+    b = context.get_value(op.operands[1])
+    if isinstance(a, Tile) or isinstance(b, Tile):
+        if isinstance(a, Tile) and isinstance(b, Tile):
+            return Tile(fn(a.data, b.data), a.dtype, a.shape)
+        if isinstance(a, Tile):
+            return Tile(fn(a.data, int(b)), a.dtype, a.shape)
+        return Tile(fn(int(a), b.data), b.dtype, b.shape)
+    return fn(a, b)
+
+
+def _unary(op, context, tile_fn, scalar_fn=None):
+    """Fetch one operand and apply a unary function.
+
+    *tile_fn* is called when the operand is a Tile.
+    *scalar_fn* is called for scalars; defaults to *tile_fn* if omitted.
+    """
+    val = context.get_value(op.operands[0])
+    if isinstance(val, Tile):
+        return tile_fn(val)
+    return (scalar_fn or tile_fn)(val)

--- a/ktir_cpu/dialects/arith_ops.py
+++ b/ktir_cpu/dialects/arith_ops.py
@@ -145,9 +145,19 @@ def arith__divui(op, context, env):
     return _int_binop(op, context, operator.floordiv)
 
 
+def _truncdiv(a, b):
+    # MLIR divsi truncates toward zero; Python // floors toward -inf.
+    return np.trunc(a / b).astype(np.asarray(a).dtype)
+
+
+def _truncrem(a, b):
+    # MLIR remsi is remainder after truncating division: a - (a/b)*b.
+    return np.asarray(a) - _truncdiv(a, b) * np.asarray(b)
+
+
 @register("arith.divsi", latency_category=LC.COMPUTE_INT)
 def arith__divsi(op, context, env):
-    return _int_binop(op, context, operator.floordiv)
+    return _int_binop(op, context, _truncdiv)
 
 
 @register("arith.ceildivsi", latency_category=LC.COMPUTE_INT)
@@ -169,7 +179,7 @@ def arith__remui(op, context, env):
 
 @register("arith.remsi", latency_category=LC.COMPUTE_INT)
 def arith__remsi(op, context, env):
-    return _int_binop(op, context, operator.mod)
+    return _int_binop(op, context, _truncrem)
 
 
 @register("arith.minsi", latency_category=LC.COMPUTE_INT)
@@ -351,9 +361,8 @@ def arith__trunci(op, context, env):
 
 @register("arith.sitofp")
 def arith__sitofp(op, context, env):
-    return _unary(op, context,
-                  lambda t: Tile(t.data.astype(np.float32), "f32", t.shape),
-                  np.float32)
+    dtype = op.result_type or "f32"
+    return _unary(op, context, lambda v: ArithOps.sitofp(v, dtype))
 
 
 @register("arith.uitofp")

--- a/ktir_cpu/dialects/arith_ops.py
+++ b/ktir_cpu/dialects/arith_ops.py
@@ -14,6 +14,7 @@
 
 """Arith dialect handlers — arithmetic on scalars and tiles."""
 
+import operator
 import re
 
 import numpy as np
@@ -21,24 +22,13 @@ import numpy as np
 from ..dtypes import to_np_dtype
 from ..ir_types import Operation, Tile
 from ..latency import LatencyCategory as LC
-from ..ops.arith_ops import ArithOps, arith_cast
+from ..ops.arith_ops import ArithOps
+from ._helpers import _float_binop, _int_binop, _unary
 from .registry import register, register_parser
 
 
 def _bool_not(x):
     return ~x if isinstance(x, np.ndarray) else not x
-
-
-def _is_scalar(v):
-    """Return True if *v* is a scalar numeric value (not a Tile)."""
-    return isinstance(v, (int, float, np.integer, np.floating))
-
-
-def _scalar_binop(a, b, py_op):
-    """Perform *py_op* on two scalars, preserving np.float16 when possible."""
-    if isinstance(a, (np.float16, np.floating)) or isinstance(b, (np.float16, np.floating)):
-        return np.float16(py_op(float(a), float(b)))
-    return py_op(float(a), float(b))
 
 
 
@@ -48,201 +38,214 @@ def _scalar_binop(a, b, py_op):
 
 @register("arith.addf", latency_category=LC.COMPUTE_FLOAT)
 def arith__addf(op, context, env):
-    a = context.get_value(op.operands[0])
-    b = context.get_value(op.operands[1])
-    if _is_scalar(a) and _is_scalar(b):
-        return _scalar_binop(a, b, lambda x, y: x + y)
-    if _is_scalar(a) and isinstance(b, Tile):
-        return Tile(np.float16(a) + b.data, b.dtype, b.shape)
-    if isinstance(a, Tile) and _is_scalar(b):
-        return Tile(a.data + np.float16(b), a.dtype, a.shape)
-    return ArithOps.addf(a, b)
+    return _float_binop(op, context, operator.add)
 
 
 @register("arith.subf", latency_category=LC.COMPUTE_FLOAT)
 def arith__subf(op, context, env):
-    a = context.get_value(op.operands[0])
-    b = context.get_value(op.operands[1])
-    if _is_scalar(a) and _is_scalar(b):
-        return _scalar_binop(a, b, lambda x, y: x - y)
-    if isinstance(a, Tile) and isinstance(b, Tile):
-        return ArithOps.subf(a, b)
-    if isinstance(a, Tile):
-        return Tile(a.data - np.float16(b), a.dtype, a.shape)
-    return Tile(np.float16(a) - b.data, b.dtype, b.shape)
+    return _float_binop(op, context, operator.sub)
 
 
 @register("arith.mulf", latency_category=LC.COMPUTE_FLOAT)
 def arith__mulf(op, context, env):
-    a = context.get_value(op.operands[0])
-    b = context.get_value(op.operands[1])
-    if _is_scalar(a) and _is_scalar(b):
-        return _scalar_binop(a, b, lambda x, y: x * y)
-    if isinstance(a, Tile) and isinstance(b, Tile):
-        return ArithOps.mulf(a, b)
-    if isinstance(a, Tile):
-        return Tile(a.data * np.float16(b), a.dtype, a.shape)
-    return Tile(np.float16(a) * b.data, b.dtype, b.shape)
+    return _float_binop(op, context, operator.mul)
 
 
 @register("arith.divf", latency_category=LC.COMPUTE_FLOAT)
 def arith__divf(op, context, env):
-    a = context.get_value(op.operands[0])
-    b = context.get_value(op.operands[1])
-    if _is_scalar(a) and _is_scalar(b):
-        return _scalar_binop(a, b, lambda x, y: x / y)
-    if isinstance(a, Tile) and isinstance(b, Tile):
-        return ArithOps.divf(a, b)
-    if isinstance(a, Tile):
-        return Tile(a.data / np.float16(b), a.dtype, a.shape)
-    return Tile(np.float16(a) / b.data, b.dtype, b.shape)
+    return _float_binop(op, context, operator.truediv)
+
+
+@register("arith.remf", latency_category=LC.COMPUTE_FLOAT)
+def arith__remf(op, context, env):
+    return _float_binop(op, context, operator.mod)
 
 
 # ---------------------------------------------------------------------------
-# Integer ops
+# Float unary ops
 # ---------------------------------------------------------------------------
 
-@register("arith.addi", latency_category=LC.COMPUTE_INT)
-def arith__addi(op, context, env):
-    val1 = context.get_value(op.operands[0])
-    val2 = context.get_value(op.operands[1])
-    if isinstance(val1, Tile) or isinstance(val2, Tile):
-        t1 = val1 if isinstance(val1, Tile) else Tile(np.full(val2.shape, val1, dtype=val2.data.dtype), val2.dtype, val2.shape)
-        t2 = val2 if isinstance(val2, Tile) else Tile(np.full(val1.shape, val2, dtype=val1.data.dtype), val1.dtype, val1.shape)
-        return Tile(t1.data + t2.data, t1.dtype, t1.shape)
-    return ArithOps.addi(val1, val2)
+@register("arith.negf", latency_category=LC.COMPUTE_FLOAT)
+def arith__negf(op, context, env):
+    return _unary(op, context, ArithOps.negf)
 
 
-@register("arith.subi", latency_category=LC.COMPUTE_INT)
-def arith__subi(op, context, env):
-    val1 = context.get_value(op.operands[0])
-    val2 = context.get_value(op.operands[1])
-    return ArithOps.subi(val1, val2)
-
-
-@register("arith.muli", latency_category=LC.COMPUTE_INT)
-def arith__muli(op, context, env):
-    val1 = context.get_value(op.operands[0])
-    val2 = context.get_value(op.operands[1])
-    if isinstance(val1, Tile) or isinstance(val2, Tile):
-        t1 = val1 if isinstance(val1, Tile) else Tile(np.full(val2.shape, val1, dtype=val2.data.dtype), val2.dtype, val2.shape)
-        t2 = val2 if isinstance(val2, Tile) else Tile(np.full(val1.shape, val2, dtype=val1.data.dtype), val1.dtype, val1.shape)
-        return Tile(t1.data * t2.data, t1.dtype, t1.shape)
-    return ArithOps.muli(val1, val2)
-
-
-@register("arith.divui", latency_category=LC.COMPUTE_INT)
-def arith__divui(op, context, env):
-    val1 = context.get_value(op.operands[0])
-    val2 = context.get_value(op.operands[1])
-    return ArithOps.divui(val1, val2)
-
-
-@register("arith.remui", latency_category=LC.COMPUTE_INT)
-def arith__remui(op, context, env):
-    val1 = context.get_value(op.operands[0])
-    val2 = context.get_value(op.operands[1])
-    return ArithOps.remui(val1, val2)
+@register("arith.absf", latency_category=LC.COMPUTE_FLOAT)
+def arith__absf(op, context, env):
+    return _unary(op, context, ArithOps.absf)
 
 
 # ---------------------------------------------------------------------------
-# Constants & casts
+# Float min/max
 # ---------------------------------------------------------------------------
-
-@register("arith.constant")
-def arith__constant(op, context, env):
-    value = op.attributes.get("value", 0)
-    if op.attributes.get("is_tensor"):
-        shape = op.attributes["shape"]
-        dtype_str = op.attributes.get("dtype", "f16")
-        np_dtype = to_np_dtype(dtype_str)
-        return Tile(np.full(shape, value, dtype=np_dtype), dtype_str, shape)
-    return value
-
 
 # TODO: consider deprecating arith.maxf / arith.minf aliases — these were
 # renamed to arith.maximumf / arith.minimumf in upstream MLIR.
 @register("arith.maxf", "arith.maximumf", latency_category=LC.COMPUTE_FLOAT)
 def arith__maxf(op, context, env):
-    tile1 = context.get_value(op.operands[0])
-    tile2 = context.get_value(op.operands[1])
-    return ArithOps.maxf(tile1, tile2)
+    a = context.get_value(op.operands[0])
+    b = context.get_value(op.operands[1])
+    return ArithOps.maxf(a, b)
 
 
 @register("arith.maxnumf", latency_category=LC.COMPUTE_FLOAT)
 def arith__maxnumf(op, context, env):
-    tile1 = context.get_value(op.operands[0])
-    tile2 = context.get_value(op.operands[1])
-    return ArithOps.maxnumf(tile1, tile2)
+    a = context.get_value(op.operands[0])
+    b = context.get_value(op.operands[1])
+    return ArithOps.maxnumf(a, b)
 
 
 @register("arith.minf", "arith.minimumf", latency_category=LC.COMPUTE_FLOAT)
 def arith__minf(op, context, env):
-    tile1 = context.get_value(op.operands[0])
-    tile2 = context.get_value(op.operands[1])
-    return ArithOps.minf(tile1, tile2)
+    a = context.get_value(op.operands[0])
+    b = context.get_value(op.operands[1])
+    return ArithOps.minf(a, b)
 
 
 @register("arith.minnumf", latency_category=LC.COMPUTE_FLOAT)
 def arith__minnumf(op, context, env):
-    tile1 = context.get_value(op.operands[0])
-    tile2 = context.get_value(op.operands[1])
-    return ArithOps.minnumf(tile1, tile2)
+    a = context.get_value(op.operands[0])
+    b = context.get_value(op.operands[1])
+    return ArithOps.minnumf(a, b)
 
 
-@register("arith.extf")
-def arith__extf(op, context, env):
-    return ArithOps.extf(context.get_value(op.operands[0]))
+# ---------------------------------------------------------------------------
+# Float comparison
+# ---------------------------------------------------------------------------
+
+@register("arith.cmpf", latency_category=LC.COMPUTE_FLOAT)
+def arith__cmpf(op, context, env):
+    a = context.get_value(op.operands[0])
+    b = context.get_value(op.operands[1])
+    predicate = op.attributes.get("predicate", "oeq")
+    return ArithOps.cmpf(a, b, predicate)
 
 
-@register("arith.truncf")
-def arith__truncf(op, context, env):
-    return ArithOps.truncf(context.get_value(op.operands[0]))
+# ---------------------------------------------------------------------------
+# Integer binary ops
+# ---------------------------------------------------------------------------
+
+@register("arith.addi", latency_category=LC.COMPUTE_INT)
+def arith__addi(op, context, env):
+    return _int_binop(op, context, operator.add)
 
 
-@register("arith.bitcast")
-def arith__bitcast(op, context, env):
-    """Reinterpret bits between integer and float types of the same width."""
-    val = context.get_value(op.operands[0])
-    dst_type = op.attributes.get("dst_type", "f32")
-    if isinstance(val, Tile):
-        if dst_type == "f32":
-            return Tile(val.data.view(np.float32), "f32", val.shape)
-        if dst_type in ("i32", "si32"):
-            return Tile(val.data.view(np.int32), "i32", val.shape)
-        raise NotImplementedError(f"arith.bitcast: unsupported dst_type '{dst_type}' for Tile")
-    # Scalar path — convert via raw bytes to handle both signed and unsigned
-    # integer inputs (e.g. 0xFF800000 from regex as unsigned, -8388608 from
-    # MLIR frontend as signed — both represent the same bit pattern).
-    if dst_type == "f32":
-        return float(np.frombuffer(int(val).to_bytes(4, "little", signed=(val < 0)),
-                                   dtype=np.float32)[0])
-    if dst_type in ("i32", "si32"):
-        return int(np.frombuffer(np.float32(val).tobytes(), dtype=np.int32)[0])
-    raise NotImplementedError(f"arith.bitcast: unsupported dst_type '{dst_type}' for scalar")
+@register("arith.subi", latency_category=LC.COMPUTE_INT)
+def arith__subi(op, context, env):
+    return _int_binop(op, context, operator.sub)
 
 
-@register("arith.extsi")
-def arith__extsi(op, context, env):
-    """Sign-extend integer (e.g., i32 -> i64). In Python, ints have arbitrary precision."""
-    return int(context.get_value(op.operands[0]))
+@register("arith.muli", latency_category=LC.COMPUTE_INT)
+def arith__muli(op, context, env):
+    return _int_binop(op, context, operator.mul)
 
 
-@register("arith.index_cast")
-def arith__index_cast(op, context, env):
-    return arith_cast(
-        context.get_value(op.operands[0]), np.int32,
-        expect_floating=False, op_name="index_cast",
-    )
+@register("arith.divui", latency_category=LC.COMPUTE_INT)
+def arith__divui(op, context, env):
+    return _int_binop(op, context, operator.floordiv)
 
 
-@register("arith.sitofp")
-def arith__sitofp(op, context, env):
-    return arith_cast(
-        context.get_value(op.operands[0]), np.float16,
-        expect_floating=False, op_name="sitofp",
-    )
+@register("arith.divsi", latency_category=LC.COMPUTE_INT)
+def arith__divsi(op, context, env):
+    return _int_binop(op, context, operator.floordiv)
 
+
+@register("arith.ceildivsi", latency_category=LC.COMPUTE_INT)
+def arith__ceildivsi(op, context, env):
+    val1 = context.get_value(op.operands[0])
+    val2 = context.get_value(op.operands[1])
+    return ArithOps.ceildivsi(val1, val2)
+
+
+@register("arith.floordivsi", latency_category=LC.COMPUTE_INT)
+def arith__floordivsi(op, context, env):
+    return _int_binop(op, context, operator.floordiv)
+
+
+@register("arith.remui", latency_category=LC.COMPUTE_INT)
+def arith__remui(op, context, env):
+    return _int_binop(op, context, operator.mod)
+
+
+@register("arith.remsi", latency_category=LC.COMPUTE_INT)
+def arith__remsi(op, context, env):
+    return _int_binop(op, context, operator.mod)
+
+
+@register("arith.minsi", latency_category=LC.COMPUTE_INT)
+def arith__minsi(op, context, env):
+    a = context.get_value(op.operands[0])
+    b = context.get_value(op.operands[1])
+    return ArithOps.minsi(a, b)
+
+
+@register("arith.maxsi", latency_category=LC.COMPUTE_INT)
+def arith__maxsi(op, context, env):
+    a = context.get_value(op.operands[0])
+    b = context.get_value(op.operands[1])
+    return ArithOps.maxsi(a, b)
+
+
+@register("arith.minui", latency_category=LC.COMPUTE_INT)
+def arith__minui(op, context, env):
+    a = context.get_value(op.operands[0])
+    b = context.get_value(op.operands[1])
+    return ArithOps.minui(a, b)
+
+
+@register("arith.maxui", latency_category=LC.COMPUTE_INT)
+def arith__maxui(op, context, env):
+    a = context.get_value(op.operands[0])
+    b = context.get_value(op.operands[1])
+    return ArithOps.maxui(a, b)
+
+
+@register("arith.ceildivui", latency_category=LC.COMPUTE_INT)
+def arith__ceildivui(op, context, env):
+    a = context.get_value(op.operands[0])
+    b = context.get_value(op.operands[1])
+    return ArithOps.ceildivui(a, b)
+
+
+# ---------------------------------------------------------------------------
+# Integer bitwise ops
+# ---------------------------------------------------------------------------
+
+@register("arith.andi", latency_category=LC.COMPUTE_INT)
+def arith__andi(op, context, env):
+    return _int_binop(op, context, operator.and_)
+
+
+@register("arith.ori", latency_category=LC.COMPUTE_INT)
+def arith__ori(op, context, env):
+    return _int_binop(op, context, operator.or_)
+
+
+@register("arith.xori", latency_category=LC.COMPUTE_INT)
+def arith__xori(op, context, env):
+    return _int_binop(op, context, operator.xor)
+
+
+@register("arith.shli", latency_category=LC.COMPUTE_INT)
+def arith__shli(op, context, env):
+    return _int_binop(op, context, operator.lshift)
+
+
+@register("arith.shrsi", latency_category=LC.COMPUTE_INT)
+def arith__shrsi(op, context, env):
+    return _int_binop(op, context, operator.rshift)
+
+
+@register("arith.shrui", latency_category=LC.COMPUTE_INT)
+def arith__shrui(op, context, env):
+    val1 = context.get_value(op.operands[0])
+    val2 = context.get_value(op.operands[1])
+    return ArithOps.shrui(val1, val2)
+
+
+# ---------------------------------------------------------------------------
+# Integer comparison
+# ---------------------------------------------------------------------------
 
 @register("arith.cmpi", latency_category=LC.COMPUTE_FLOAT)
 def arith__cmpi(op, context, env):
@@ -305,6 +308,109 @@ def arith__cmpf(op, context, env):
     result = cmp_ops[predicate]()
     return Tile(result, "i1", result.shape) if is_tile else result
 
+
+# ---------------------------------------------------------------------------
+# Constants & casts
+# ---------------------------------------------------------------------------
+
+@register("arith.constant")
+def arith__constant(op, context, env):
+    value = op.attributes.get("value", 0)
+    if op.attributes.get("is_tensor"):
+        shape = op.attributes["shape"]
+        dtype_str = op.attributes.get("dtype", "f16")
+        np_dtype = to_np_dtype(dtype_str)
+        return Tile(np.full(shape, value, dtype=np_dtype), dtype_str, shape)
+    return value
+
+
+@register("arith.extf")
+def arith__extf(op, context, env):
+    return _unary(op, context, ArithOps.extf, np.float32)
+
+
+@register("arith.truncf")
+def arith__truncf(op, context, env):
+    return _unary(op, context, ArithOps.truncf)
+
+
+@register("arith.extsi")
+def arith__extsi(op, context, env):
+    return _unary(op, context, lambda t: Tile(t.data.astype(np.int64), "i64", t.shape), int)
+
+
+@register("arith.extui")
+def arith__extui(op, context, env):
+    return _unary(op, context, ArithOps.extui, int)
+
+
+@register("arith.trunci")
+def arith__trunci(op, context, env):
+    return _unary(op, context, ArithOps.trunci, int)
+
+
+@register("arith.sitofp")
+def arith__sitofp(op, context, env):
+    return _unary(op, context,
+                  lambda t: Tile(t.data.astype(np.float32), "f32", t.shape),
+                  np.float32)
+
+
+@register("arith.uitofp")
+def arith__uitofp(op, context, env):
+    return _unary(op, context, ArithOps.uitofp, float)
+
+
+@register("arith.fptosi")
+def arith__fptosi(op, context, env):
+    return _unary(op, context, ArithOps.fptosi, int)
+
+
+@register("arith.fptoui")
+def arith__fptoui(op, context, env):
+    return _unary(op, context, ArithOps.fptoui, int)
+
+
+@register("arith.index_cast")
+def arith__index_cast(op, context, env):
+    return int(context.get_value(op.operands[0]))
+
+
+@register("arith.index_castui")
+def arith__index_castui(op, context, env):
+    return int(context.get_value(op.operands[0]))
+
+
+@register("arith.convertf")
+def arith__convertf(op, context, env):
+    return _unary(op, context, ArithOps.convertf)
+
+
+@register("arith.bitcast")
+def arith__bitcast(op, context, env):
+    """Reinterpret bits between integer and float types of the same width."""
+    val = context.get_value(op.operands[0])
+    dst_type = op.attributes.get("dst_type", "f32")
+    if isinstance(val, Tile):
+        if dst_type == "f32":
+            return Tile(val.data.view(np.float32), "f32", val.shape)
+        if dst_type in ("i32", "si32"):
+            return Tile(val.data.view(np.int32), "i32", val.shape)
+        raise NotImplementedError(f"arith.bitcast: unsupported dst_type '{dst_type}' for Tile")
+    # Scalar path — convert via raw bytes to handle both signed and unsigned
+    # integer inputs (e.g. 0xFF800000 from regex as unsigned, -8388608 from
+    # MLIR frontend as signed — both represent the same bit pattern).
+    if dst_type == "f32":
+        return float(np.frombuffer(int(val).to_bytes(4, "little", signed=(val < 0)),
+                                   dtype=np.float32)[0])
+    if dst_type in ("i32", "si32"):
+        return int(np.frombuffer(np.float32(val).tobytes(), dtype=np.int32)[0])
+    raise NotImplementedError(f"arith.bitcast: unsupported dst_type '{dst_type}' for scalar")
+
+
+# ---------------------------------------------------------------------------
+# Select
+# ---------------------------------------------------------------------------
 
 @register("arith.select", latency_category=LC.COMPUTE_FLOAT)
 def arith__select(op, context, env):
@@ -474,7 +580,7 @@ def parse_arith_cmpf(op_text, parse_ctx):
     result_name = result_match.group(1)
 
     pred_match = re.search(
-        r'arith\.cmpf\s+(oeq|one|olt|ole|ogt|oge|ueq|une|ult|ule|ugt|uge|ord|uno)', op_text)
+        r'arith\.cmpf\s+(oeq|ogt|oge|olt|ole|one|ord|ueq|ugt|uge|ult|ule|une|uno)', op_text)
     if not pred_match:
         raise ValueError(f"arith.cmpf: no valid predicate found in: {op_text!r}")
     predicate = pred_match.group(1)
@@ -482,7 +588,7 @@ def parse_arith_cmpf(op_text, parse_ctx):
     operands = re.findall(r'%\w+', op_text)
     operands = [o for o in operands if o != result_name]
 
-    result_type = "unknown"
+    result_type = "i1"
     type_match = re.search(r':\s*(.+)$', op_text)
     if type_match:
         result_type = type_match.group(1).strip()
@@ -521,7 +627,6 @@ def parse_arith_sitofp(op_text, parse_ctx):
 
 @register_parser("arith.bitcast")
 def parse_arith_bitcast(op_text, parse_ctx):
-    # %result = arith.bitcast %src : src_type to dst_type
     result_match = re.match(r'(%\w+)\s*=\s*arith\.bitcast\s+(%\w+)', op_text)
     if not result_match:
         return None

--- a/ktir_cpu/dialects/arith_ops.py
+++ b/ktir_cpu/dialects/arith_ops.py
@@ -589,7 +589,7 @@ def parse_arith_cmpf(op_text, parse_ctx):
     result_name = result_match.group(1)
 
     pred_match = re.search(
-        r'arith\.cmpf\s+(oeq|ogt|oge|olt|ole|one|ord|ueq|ugt|uge|ult|ule|une|uno)', op_text)
+        r'arith\.cmpf\s+(true|false|oeq|ogt|oge|olt|ole|one|ord|ueq|ugt|uge|ult|ule|une|uno)', op_text)
     if not pred_match:
         raise ValueError(f"arith.cmpf: no valid predicate found in: {op_text!r}")
     predicate = pred_match.group(1)

--- a/ktir_cpu/dialects/math_ops.py
+++ b/ktir_cpu/dialects/math_ops.py
@@ -17,119 +17,78 @@
 from ..ir_types import Tile
 from ..latency import LatencyCategory as LC
 from ..ops.math_ops import MathOps
+from ._helpers import _unary
 from .registry import register
 
 
 @register("math.exp", latency_category=LC.COMPUTE_TRANSCENDENTAL)
 def math__exp(op, context, env):
-    operand = context.get_value(op.operands[0])
-    if isinstance(operand, Tile):
-        return MathOps.exp(operand)
-    return MathOps.exp_scalar(operand)
+    return _unary(op, context, MathOps.exp, MathOps.exp_scalar)
 
 
 @register("math.sqrt", latency_category=LC.COMPUTE_TRANSCENDENTAL)
 def math__sqrt(op, context, env):
-    operand = context.get_value(op.operands[0])
-    if isinstance(operand, Tile):
-        return MathOps.sqrt(operand)
-    return MathOps.sqrt_scalar(operand)
+    return _unary(op, context, MathOps.sqrt, MathOps.sqrt_scalar)
 
 
 @register("math.rsqrt", latency_category=LC.COMPUTE_TRANSCENDENTAL)
 def math__rsqrt(op, context, env):
-    operand = context.get_value(op.operands[0])
-    if isinstance(operand, Tile):
-        return MathOps.rsqrt(operand)
-    return MathOps.rsqrt_scalar(operand)
+    return _unary(op, context, MathOps.rsqrt, MathOps.rsqrt_scalar)
 
 
 @register("math.log", latency_category=LC.COMPUTE_TRANSCENDENTAL)
 def math__log(op, context, env):
-    operand = context.get_value(op.operands[0])
-    if isinstance(operand, Tile):
-        return MathOps.log(operand)
-    return MathOps.log_scalar(operand)
+    return _unary(op, context, MathOps.log, MathOps.log_scalar)
 
 
 @register("math.log2", latency_category=LC.COMPUTE_TRANSCENDENTAL)
 def math__log2(op, context, env):
-    operand = context.get_value(op.operands[0])
-    if isinstance(operand, Tile):
-        return MathOps.log2(operand)
-    return MathOps.log2_scalar(operand)
+    return _unary(op, context, MathOps.log2, MathOps.log2_scalar)
 
 
 @register("math.log1p", latency_category=LC.COMPUTE_TRANSCENDENTAL)
 def math__log1p(op, context, env):
-    operand = context.get_value(op.operands[0])
-    if isinstance(operand, Tile):
-        return MathOps.log1p(operand)
-    return MathOps.log1p_scalar(operand)
+    return _unary(op, context, MathOps.log1p, MathOps.log1p_scalar)
 
 
 @register("math.tanh", latency_category=LC.COMPUTE_TRANSCENDENTAL)
 def math__tanh(op, context, env):
-    operand = context.get_value(op.operands[0])
-    if isinstance(operand, Tile):
-        return MathOps.tanh(operand)
-    return MathOps.tanh_scalar(operand)
+    return _unary(op, context, MathOps.tanh, MathOps.tanh_scalar)
 
 
 @register("math.sin", latency_category=LC.COMPUTE_TRANSCENDENTAL)
 def math__sin(op, context, env):
-    operand = context.get_value(op.operands[0])
-    if isinstance(operand, Tile):
-        return MathOps.sin(operand)
-    return MathOps.sin_scalar(operand)
+    return _unary(op, context, MathOps.sin, MathOps.sin_scalar)
 
 
 @register("math.cos", latency_category=LC.COMPUTE_TRANSCENDENTAL)
 def math__cos(op, context, env):
-    operand = context.get_value(op.operands[0])
-    if isinstance(operand, Tile):
-        return MathOps.cos(operand)
-    return MathOps.cos_scalar(operand)
+    return _unary(op, context, MathOps.cos, MathOps.cos_scalar)
 
 
 @register("math.absf", latency_category=LC.COMPUTE_FLOAT)
 def math__absf(op, context, env):
-    operand = context.get_value(op.operands[0])
-    if isinstance(operand, Tile):
-        return MathOps.absf(operand)
-    return MathOps.absf_scalar(operand)
+    return _unary(op, context, MathOps.absf, MathOps.absf_scalar)
 
 
 @register("math.absi", latency_category=LC.COMPUTE_FLOAT)
 def math__absi(op, context, env):
-    operand = context.get_value(op.operands[0])
-    if isinstance(operand, Tile):
-        return MathOps.absi(operand)
-    return MathOps.absi_scalar(operand)
+    return _unary(op, context, MathOps.absi, MathOps.absi_scalar)
 
 
 @register("math.ceil", latency_category=LC.COMPUTE_FLOAT)
 def math__ceil(op, context, env):
-    operand = context.get_value(op.operands[0])
-    if isinstance(operand, Tile):
-        return MathOps.ceil(operand)
-    return MathOps.ceil_scalar(operand)
+    return _unary(op, context, MathOps.ceil, MathOps.ceil_scalar)
 
 
 @register("math.floor", latency_category=LC.COMPUTE_FLOAT)
 def math__floor(op, context, env):
-    operand = context.get_value(op.operands[0])
-    if isinstance(operand, Tile):
-        return MathOps.floor(operand)
-    return MathOps.floor_scalar(operand)
+    return _unary(op, context, MathOps.floor, MathOps.floor_scalar)
 
 
 @register("math.erf", latency_category=LC.COMPUTE_TRANSCENDENTAL)
 def math__erf(op, context, env):
-    operand = context.get_value(op.operands[0])
-    if isinstance(operand, Tile):
-        return MathOps.erf(operand)
-    return MathOps.erf_scalar(operand)
+    return _unary(op, context, MathOps.erf, MathOps.erf_scalar)
 
 
 @register("math.powf", latency_category=LC.COMPUTE_TRANSCENDENTAL)

--- a/ktir_cpu/mlir_frontend/parser.py
+++ b/ktir_cpu/mlir_frontend/parser.py
@@ -159,21 +159,33 @@ MLIRTypeAdapter.install(
     "linalg.matmul",
     "linalg.yield",
     "scf.yield",
-    "arith.addf", "arith.addi",
-    "arith.subf", "arith.subi",
-    "arith.mulf", "arith.muli",
-    "arith.divf", "arith.divsi", "arith.divui",
-    "arith.sitofp",
+    # float binary
+    "arith.addf", "arith.subf", "arith.mulf", "arith.divf", "arith.remf",
+    # float unary
+    "arith.negf", "arith.absf",
+    # float min/max
+    "arith.maxf", "arith.maximumf", "arith.maxnumf",
+    "arith.minf", "arith.minimumf", "arith.minnumf",
+    # integer binary
+    "arith.addi", "arith.subi", "arith.muli",
+    "arith.divsi", "arith.divui",
+    "arith.ceildivsi", "arith.floordivsi",
+    "arith.remsi", "arith.remui",
+    # integer bitwise
+    "arith.andi", "arith.ori", "arith.xori",
+    "arith.shli", "arith.shrsi", "arith.shrui",
+    # casts
+    "arith.sitofp", "arith.uitofp",
+    "arith.fptosi", "arith.fptoui",
+    "arith.extf", "arith.truncf",
+    "arith.extsi", "arith.extui", "arith.trunci",
     "arith.index_cast",
     "arith.maxnumf",
     "arith.maximumf",
     "arith.minimumf",
     "arith.minnumf",
     "tensor.yield",
-    "arith.extf",
-    "arith.truncf",
     "arith.bitcast",
-    "arith.fptosi",
     "arith.select",
     "math.exp",
     "math.sqrt",
@@ -482,6 +494,21 @@ def _adapt_linalg_generic(mlir_op, attributes, result_type, operands):
     # Block arguments are the bb0 names; stored in attributes for the executor fallback
     block = mlir_op.regions[0].blocks[0]
     attributes["bb0_names"] = [arg.get_name() for arg in block.arguments]
+
+
+@MLIRTypeAdapter.install("arith.cmpf")
+def _adapt_arith_cmpf(mlir_op, attributes, result_type, operands):
+    """Normalize MLIR float predicate encoding → string the executor expects."""
+    # MLIR CmpFPredicateAttr integer encoding (matches mlir::arith::CmpFPredicate)
+    _pred_map = {
+        0: "false", 1: "oeq", 2: "ogt", 3: "oge", 4: "olt", 5: "ole",
+        6: "one", 7: "ord", 8: "ueq", 9: "ugt", 10: "uge", 11: "ult",
+        12: "ule", 13: "une", 14: "uno", 15: "true",
+    }
+    pred_int = IntegerAttr(mlir_op.attributes["predicate"]).value
+    if pred_int not in _pred_map:
+        raise ValueError(f"arith.cmpf: unknown predicate integer {pred_int}")
+    attributes["predicate"] = _pred_map[pred_int]
 
 
 @MLIRTypeAdapter.install("arith.cmpi")

--- a/ktir_cpu/mlir_frontend/parser.py
+++ b/ktir_cpu/mlir_frontend/parser.py
@@ -171,6 +171,8 @@ MLIRTypeAdapter.install(
     "arith.divsi", "arith.divui",
     "arith.ceildivsi", "arith.floordivsi",
     "arith.remsi", "arith.remui",
+    "arith.minsi", "arith.maxsi",
+    "arith.minui", "arith.maxui",
     # integer bitwise
     "arith.andi", "arith.ori", "arith.xori",
     "arith.shli", "arith.shrsi", "arith.shrui",

--- a/ktir_cpu/ops/arith_ops.py
+++ b/ktir_cpu/ops/arith_ops.py
@@ -21,7 +21,7 @@ used by dialect handlers in ``ktir_cpu.dialects``.
 
 import numpy as np
 from ..ir_types import Tile
-from ..dtypes import _REVERSE_MAP
+from ..dtypes import _REVERSE_MAP, to_np_dtype
 
 
 def arith_cast(value, target_np_dtype, expect_floating, op_name):
@@ -483,6 +483,15 @@ class ArithOps:
         if isinstance(value, Tile):
             return Tile(value.data.astype(np.int32), "i32", value.shape)
         return int(value)
+
+    @staticmethod
+    def sitofp(value, dtype: str = "f32"):
+        """Convert signed integer to float, respecting the target dtype."""
+        np_dtype = to_np_dtype(dtype)
+        scalar_type = np.dtype(np_dtype).type
+        if isinstance(value, Tile):
+            return Tile(value.data.astype(np_dtype), dtype, value.shape)
+        return scalar_type(value)
 
     @staticmethod
     def uitofp(value):

--- a/ktir_cpu/ops/arith_ops.py
+++ b/ktir_cpu/ops/arith_ops.py
@@ -333,6 +333,43 @@ class ArithOps:
         return Tile(result_data, tile1.dtype, tile1.shape)
 
     @staticmethod
+    def divsi(val1, val2):
+        """Signed integer floor division. Works on both scalars and Tiles."""
+        if isinstance(val1, Tile) and isinstance(val2, Tile):
+            result_data = val1.data // val2.data
+            return Tile(result_data, val1.dtype, result_data.shape)
+        elif isinstance(val1, Tile):
+            result_data = val1.data // int(val2)
+            return Tile(result_data, val1.dtype, result_data.shape)
+        elif isinstance(val2, Tile):
+            result_data = int(val1) // val2.data
+            return Tile(result_data, val2.dtype, result_data.shape)
+        else:
+            return int(val1) // int(val2)
+
+    @staticmethod
+    def remsi(val1, val2):
+        """Signed integer remainder. Works on both scalars and Tiles."""
+        if isinstance(val1, Tile) and isinstance(val2, Tile):
+            result_data = val1.data % val2.data
+            return Tile(result_data, val1.dtype, result_data.shape)
+        elif isinstance(val1, Tile):
+            result_data = val1.data % int(val2)
+            return Tile(result_data, val1.dtype, result_data.shape)
+        elif isinstance(val2, Tile):
+            result_data = int(val1) % val2.data
+            return Tile(result_data, val2.dtype, result_data.shape)
+        else:
+            return int(val1) % int(val2)
+
+    @staticmethod
+    def fptosi(value):
+        """Convert float to signed integer (truncation toward zero)."""
+        if isinstance(value, Tile):
+            return Tile(value.data.astype(np.int32), "i32", value.shape)
+        return int(value)
+
+    @staticmethod
     def divui(val1, val2):
         """Unsigned integer floor division. Works on both scalars and Tiles."""
         if isinstance(val1, Tile) and isinstance(val2, Tile):
@@ -380,3 +417,243 @@ class ArithOps:
         result_data = np.matmul(tile_a.data, tile_b.data).astype(tile_a.data.dtype)
         result_shape = (tile_a.shape[0], tile_b.shape[1])
         return Tile(result_data, tile_a.dtype, result_shape)
+
+    # -----------------------------------------------------------------------
+    # Float unary
+    # -----------------------------------------------------------------------
+
+    @staticmethod
+    def negf(value):
+        """Element-wise float negation."""
+        if isinstance(value, Tile):
+            return Tile(-value.data, value.dtype, value.shape)
+        return -value
+
+    @staticmethod
+    def absf(value):
+        """Element-wise float absolute value."""
+        if isinstance(value, Tile):
+            return Tile(np.abs(value.data), value.dtype, value.shape)
+        return abs(value)
+
+    @staticmethod
+    def cmpf(val1, val2, predicate: str = "oeq"):
+        """Floating-point comparison. Returns bool scalar or i1 Tile."""
+        cmp_ops = {
+            "oeq": lambda a, b: a == b,
+            "ogt": lambda a, b: a > b,
+            "oge": lambda a, b: a >= b,
+            "olt": lambda a, b: a < b,
+            "ole": lambda a, b: a <= b,
+            "one": lambda a, b: a != b,
+            "ord": lambda a, b: ~(np.isnan(a) | np.isnan(b)),
+            "ueq": lambda a, b: a == b,
+            "ugt": lambda a, b: a > b,
+            "uge": lambda a, b: a >= b,
+            "ult": lambda a, b: a < b,
+            "ule": lambda a, b: a <= b,
+            "une": lambda a, b: a != b,
+            "uno": lambda a, b: np.isnan(a) | np.isnan(b),
+        }
+        fn = cmp_ops.get(predicate)
+        if fn is None:
+            raise NotImplementedError(f"arith.cmpf: unsupported predicate '{predicate}'")
+        if isinstance(val1, Tile) or isinstance(val2, Tile):
+            lhs = val1.data if isinstance(val1, Tile) else val1
+            rhs = val2.data if isinstance(val2, Tile) else val2
+            result = fn(lhs, rhs)
+            ref = val1 if isinstance(val1, Tile) else val2
+            return Tile(result, ref.dtype, result.shape)
+        return bool(fn(val1, val2))
+
+    # -----------------------------------------------------------------------
+    # Integer unary / cast
+    # -----------------------------------------------------------------------
+
+    @staticmethod
+    def extui(value):
+        """Zero-extend integer (e.g. i32 -> i64). Python ints are arbitrary-precision."""
+        if isinstance(value, Tile):
+            return Tile(value.data.astype(np.int64), "i64", value.shape)
+        return int(value)
+
+    @staticmethod
+    def trunci(value):
+        """Truncate integer to a narrower type (e.g. i64 -> i32)."""
+        if isinstance(value, Tile):
+            return Tile(value.data.astype(np.int32), "i32", value.shape)
+        return int(value)
+
+    @staticmethod
+    def uitofp(value):
+        """Convert unsigned integer to float."""
+        if isinstance(value, Tile):
+            return Tile(value.data.astype(np.float32), "f32", value.shape)
+        return float(value)
+
+    @staticmethod
+    def fptoui(value):
+        """Convert float to unsigned integer (truncation toward zero)."""
+        if isinstance(value, Tile):
+            return Tile(value.data.astype(np.uint32), "ui32", value.shape)
+        return int(value)
+
+    # -----------------------------------------------------------------------
+    # Integer binary — signed and bitwise
+    # -----------------------------------------------------------------------
+
+    @staticmethod
+    def ceildivsi(val1, val2):
+        """Signed integer ceiling division."""
+        import math
+        if isinstance(val1, Tile) and isinstance(val2, Tile):
+            return Tile(np.ceil(val1.data / val2.data).astype(val1.data.dtype), val1.dtype, val1.shape)
+        if isinstance(val1, Tile):
+            return Tile(np.ceil(val1.data / int(val2)).astype(val1.data.dtype), val1.dtype, val1.shape)
+        if isinstance(val2, Tile):
+            return Tile(np.ceil(int(val1) / val2.data).astype(val2.data.dtype), val2.dtype, val2.shape)
+        return math.ceil(val1 / val2)
+
+    @staticmethod
+    def floordivsi(val1, val2):
+        """Signed integer floor division (same as divsi for negative numbers in Python)."""
+        if isinstance(val1, Tile) and isinstance(val2, Tile):
+            return Tile(val1.data // val2.data, val1.dtype, val1.shape)
+        if isinstance(val1, Tile):
+            return Tile(val1.data // int(val2), val1.dtype, val1.shape)
+        if isinstance(val2, Tile):
+            return Tile(int(val1) // val2.data, val2.dtype, val2.shape)
+        return val1 // val2
+
+    @staticmethod
+    def andi(val1, val2):
+        """Bitwise AND."""
+        if isinstance(val1, Tile) and isinstance(val2, Tile):
+            return Tile(val1.data & val2.data, val1.dtype, val1.shape)
+        if isinstance(val1, Tile):
+            return Tile(val1.data & int(val2), val1.dtype, val1.shape)
+        if isinstance(val2, Tile):
+            return Tile(int(val1) & val2.data, val2.dtype, val2.shape)
+        return int(val1) & int(val2)
+
+    @staticmethod
+    def ori(val1, val2):
+        """Bitwise OR."""
+        if isinstance(val1, Tile) and isinstance(val2, Tile):
+            return Tile(val1.data | val2.data, val1.dtype, val1.shape)
+        if isinstance(val1, Tile):
+            return Tile(val1.data | int(val2), val1.dtype, val1.shape)
+        if isinstance(val2, Tile):
+            return Tile(int(val1) | val2.data, val2.dtype, val2.shape)
+        return int(val1) | int(val2)
+
+    @staticmethod
+    def xori(val1, val2):
+        """Bitwise XOR."""
+        if isinstance(val1, Tile) and isinstance(val2, Tile):
+            return Tile(val1.data ^ val2.data, val1.dtype, val1.shape)
+        if isinstance(val1, Tile):
+            return Tile(val1.data ^ int(val2), val1.dtype, val1.shape)
+        if isinstance(val2, Tile):
+            return Tile(int(val1) ^ val2.data, val2.dtype, val2.shape)
+        return int(val1) ^ int(val2)
+
+    @staticmethod
+    def shli(val1, val2):
+        """Left shift."""
+        if isinstance(val1, Tile) and isinstance(val2, Tile):
+            return Tile(val1.data << val2.data, val1.dtype, val1.shape)
+        if isinstance(val1, Tile):
+            return Tile(val1.data << int(val2), val1.dtype, val1.shape)
+        if isinstance(val2, Tile):
+            return Tile(int(val1) << val2.data, val2.dtype, val2.shape)
+        return int(val1) << int(val2)
+
+    @staticmethod
+    def shrsi(val1, val2):
+        """Arithmetic (signed) right shift."""
+        if isinstance(val1, Tile) and isinstance(val2, Tile):
+            return Tile(val1.data >> val2.data, val1.dtype, val1.shape)
+        if isinstance(val1, Tile):
+            return Tile(val1.data >> int(val2), val1.dtype, val1.shape)
+        if isinstance(val2, Tile):
+            return Tile(int(val1) >> val2.data, val2.dtype, val2.shape)
+        return int(val1) >> int(val2)
+
+    @staticmethod
+    def shrui(val1, val2):
+        """Logical (unsigned) right shift."""
+        if isinstance(val1, Tile) and isinstance(val2, Tile):
+            return Tile(val1.data.view(np.uint32) >> val2.data, val1.dtype, val1.shape)
+        if isinstance(val1, Tile):
+            return Tile(val1.data.view(np.uint32) >> int(val2), val1.dtype, val1.shape)
+        if isinstance(val2, Tile):
+            return Tile(np.uint32(val1) >> val2.data, val2.dtype, val2.shape)
+        return int(np.uint32(val1) >> np.uint32(val2))
+
+    @staticmethod
+    def minsi(val1, val2):
+        """Signed integer minimum."""
+        if isinstance(val1, Tile) and isinstance(val2, Tile):
+            return Tile(np.minimum(val1.data, val2.data), val1.dtype, val1.shape)
+        if isinstance(val1, Tile):
+            return Tile(np.minimum(val1.data, int(val2)), val1.dtype, val1.shape)
+        if isinstance(val2, Tile):
+            return Tile(np.minimum(int(val1), val2.data), val2.dtype, val2.shape)
+        return min(int(val1), int(val2))
+
+    @staticmethod
+    def maxsi(val1, val2):
+        """Signed integer maximum."""
+        if isinstance(val1, Tile) and isinstance(val2, Tile):
+            return Tile(np.maximum(val1.data, val2.data), val1.dtype, val1.shape)
+        if isinstance(val1, Tile):
+            return Tile(np.maximum(val1.data, int(val2)), val1.dtype, val1.shape)
+        if isinstance(val2, Tile):
+            return Tile(np.maximum(int(val1), val2.data), val2.dtype, val2.shape)
+        return max(int(val1), int(val2))
+
+    @staticmethod
+    def minui(val1, val2):
+        """Unsigned integer minimum."""
+        if isinstance(val1, Tile) and isinstance(val2, Tile):
+            return Tile(np.minimum(val1.data, val2.data), val1.dtype, val1.shape)
+        if isinstance(val1, Tile):
+            return Tile(np.minimum(val1.data, int(val2)), val1.dtype, val1.shape)
+        if isinstance(val2, Tile):
+            return Tile(np.minimum(int(val1), val2.data), val2.dtype, val2.shape)
+        return min(int(val1), int(val2))
+
+    @staticmethod
+    def maxui(val1, val2):
+        """Unsigned integer maximum."""
+        if isinstance(val1, Tile) and isinstance(val2, Tile):
+            return Tile(np.maximum(val1.data, val2.data), val1.dtype, val1.shape)
+        if isinstance(val1, Tile):
+            return Tile(np.maximum(val1.data, int(val2)), val1.dtype, val1.shape)
+        if isinstance(val2, Tile):
+            return Tile(np.maximum(int(val1), val2.data), val2.dtype, val2.shape)
+        return max(int(val1), int(val2))
+
+    @staticmethod
+    def ceildivui(val1, val2):
+        """Unsigned integer ceiling division."""
+        import math
+        if isinstance(val1, Tile) and isinstance(val2, Tile):
+            return Tile(np.ceil(val1.data / val2.data).astype(val1.data.dtype), val1.dtype, val1.shape)
+        if isinstance(val1, Tile):
+            return Tile(np.ceil(val1.data / int(val2)).astype(val1.data.dtype), val1.dtype, val1.shape)
+        if isinstance(val2, Tile):
+            return Tile(np.ceil(int(val1) / val2.data).astype(val2.data.dtype), val2.dtype, val2.shape)
+        return math.ceil(int(val1) / int(val2))
+
+    @staticmethod
+    def convertf(value):
+        """Float-to-float conversion (direction inferred from input dtype)."""
+        if isinstance(value, Tile):
+            if np.issubdtype(value.data.dtype, np.float16):
+                return Tile(value.data.astype(np.float32), "f32", value.shape)
+            return Tile(value.data.astype(np.float16), "f16", value.shape)
+        if isinstance(value, np.float16):
+            return np.float32(value)
+        return np.float16(value)

--- a/tests/test_dialects_exec.py
+++ b/tests/test_dialects_exec.py
@@ -235,6 +235,200 @@ class TestArithInt:
         ctx = _ctx_with(**{"%a": 10, "%b": 3})
         assert _call("arith.remui", ctx, _make_env(), operands=["%a", "%b"]) == 1
 
+    def test_divsi_scalar(self):
+        ctx = _ctx_with(**{"%a": 7, "%b": 2})
+        assert _call("arith.divsi", ctx, _make_env(), operands=["%a", "%b"]) == 3
+
+    def test_remsi_scalar(self):
+        ctx = _ctx_with(**{"%a": 7, "%b": 3})
+        assert _call("arith.remsi", ctx, _make_env(), operands=["%a", "%b"]) == 1
+
+    def test_ceildivsi_scalar(self):
+        ctx = _ctx_with(**{"%a": 7, "%b": 2})
+        assert _call("arith.ceildivsi", ctx, _make_env(), operands=["%a", "%b"]) == 4
+
+    def test_ceildivui_scalar(self):
+        ctx = _ctx_with(**{"%a": 7, "%b": 2})
+        assert _call("arith.ceildivui", ctx, _make_env(), operands=["%a", "%b"]) == 4
+
+    def test_minsi_scalar(self):
+        ctx = _ctx_with(**{"%a": 3, "%b": 7})
+        assert _call("arith.minsi", ctx, _make_env(), operands=["%a", "%b"]) == 3
+
+    def test_minsi_negative(self):
+        ctx = _ctx_with(**{"%a": -5, "%b": 2})
+        assert _call("arith.minsi", ctx, _make_env(), operands=["%a", "%b"]) == -5
+
+    def test_maxsi_scalar(self):
+        ctx = _ctx_with(**{"%a": 3, "%b": 7})
+        assert _call("arith.maxsi", ctx, _make_env(), operands=["%a", "%b"]) == 7
+
+    def test_minsi_tiles(self):
+        ctx = _ctx_with(**{
+            "%a": Tile(np.array([1, 5, 3], dtype=np.int32), "i32", (3,)),
+            "%b": Tile(np.array([4, 2, 6], dtype=np.int32), "i32", (3,)),
+        })
+        result = _call("arith.minsi", ctx, _make_env(), operands=["%a", "%b"])
+        assert np.array_equal(result.data, np.array([1, 2, 3], dtype=np.int32))
+
+    def test_maxsi_tiles(self):
+        ctx = _ctx_with(**{
+            "%a": Tile(np.array([1, 5, 3], dtype=np.int32), "i32", (3,)),
+            "%b": Tile(np.array([4, 2, 6], dtype=np.int32), "i32", (3,)),
+        })
+        result = _call("arith.maxsi", ctx, _make_env(), operands=["%a", "%b"])
+        assert np.array_equal(result.data, np.array([4, 5, 6], dtype=np.int32))
+
+    def test_minui_scalar(self):
+        ctx = _ctx_with(**{"%a": 3, "%b": 7})
+        assert _call("arith.minui", ctx, _make_env(), operands=["%a", "%b"]) == 3
+
+    def test_maxui_scalar(self):
+        ctx = _ctx_with(**{"%a": 3, "%b": 7})
+        assert _call("arith.maxui", ctx, _make_env(), operands=["%a", "%b"]) == 7
+
+    def test_floordivsi_scalar(self):
+        ctx = _ctx_with(**{"%a": 7, "%b": 2})
+        assert _call("arith.floordivsi", ctx, _make_env(), operands=["%a", "%b"]) == 3
+
+    def test_andi_scalar(self):
+        ctx = _ctx_with(**{"%a": 0b1010, "%b": 0b1100})
+        assert _call("arith.andi", ctx, _make_env(), operands=["%a", "%b"]) == 0b1000
+
+    def test_ori_scalar(self):
+        ctx = _ctx_with(**{"%a": 0b1010, "%b": 0b1100})
+        assert _call("arith.ori", ctx, _make_env(), operands=["%a", "%b"]) == 0b1110
+
+    def test_xori_scalar(self):
+        ctx = _ctx_with(**{"%a": 0b1010, "%b": 0b1100})
+        assert _call("arith.xori", ctx, _make_env(), operands=["%a", "%b"]) == 0b0110
+
+    def test_shli_scalar(self):
+        ctx = _ctx_with(**{"%a": 1, "%b": 3})
+        assert _call("arith.shli", ctx, _make_env(), operands=["%a", "%b"]) == 8
+
+    def test_shrsi_scalar(self):
+        ctx = _ctx_with(**{"%a": 8, "%b": 2})
+        assert _call("arith.shrsi", ctx, _make_env(), operands=["%a", "%b"]) == 2
+
+    def test_shrui_scalar(self):
+        ctx = _ctx_with(**{"%a": 8, "%b": 2})
+        assert _call("arith.shrui", ctx, _make_env(), operands=["%a", "%b"]) == 2
+
+    def test_andi_tile(self):
+        data = np.array([0b1010, 0b1100, 0b1111], dtype=np.int32)
+        t = Tile(data, "i32", data.shape)
+        ctx = _ctx_with(**{"%a": t, "%b": 0b1010})
+        result = _call("arith.andi", ctx, _make_env(), operands=["%a", "%b"])
+        assert isinstance(result, Tile)
+        assert np.array_equal(result.data, np.array([0b1010, 0b1000, 0b1010]))
+
+# ---------------------------------------------------------------------------
+# arith (float unary + cmpf) dialect exec
+# ---------------------------------------------------------------------------
+
+class TestArithFloatUnary:
+    def test_negf_scalar(self):
+        ctx = _ctx_with(**{"%a": np.float16(3.0)})
+        result = _call("arith.negf", ctx, _make_env(), operands=["%a"])
+        assert float(result) == pytest.approx(-3.0, rel=1e-2)
+
+    def test_negf_tile(self):
+        ctx = _ctx_with(**{"%a": _tile([1, -2, 3])})
+        result = _call("arith.negf", ctx, _make_env(), operands=["%a"])
+        assert isinstance(result, Tile)
+        assert np.array_equal(result.data, np.array([-1, 2, -3], dtype=np.float16))
+
+    def test_absf_scalar(self):
+        ctx = _ctx_with(**{"%a": np.float16(-5.0)})
+        result = _call("arith.absf", ctx, _make_env(), operands=["%a"])
+        assert float(result) == pytest.approx(5.0, rel=1e-2)
+
+    def test_absf_tile(self):
+        ctx = _ctx_with(**{"%a": _tile([-1, 2, -3])})
+        result = _call("arith.absf", ctx, _make_env(), operands=["%a"])
+        assert isinstance(result, Tile)
+        assert np.array_equal(result.data, np.array([1, 2, 3], dtype=np.float16))
+
+    def test_remf_scalars(self):
+        ctx = _ctx_with(**{"%a": np.float16(5.0), "%b": np.float16(3.0)})
+        result = _call("arith.remf", ctx, _make_env(), operands=["%a", "%b"])
+        assert float(result) == pytest.approx(2.0, rel=1e-2)
+
+    def test_minf_tiles(self):
+        ctx = _ctx_with(**{"%a": _tile([1, 5, 3]), "%b": _tile([2, 4, 3])})
+        result = _call("arith.minf", ctx, _make_env(), operands=["%a", "%b"])
+        assert isinstance(result, Tile)
+        assert np.array_equal(result.data, np.array([1, 4, 3], dtype=np.float16))
+
+    def test_minimumf_tiles(self):
+        # arith.minimumf dispatches to the same handler as arith.minf
+        ctx = _ctx_with(**{"%a": _tile([1, 5, 3]), "%b": _tile([2, 4, 3])})
+        result = _call("arith.minimumf", ctx, _make_env(), operands=["%a", "%b"])
+        assert isinstance(result, Tile)
+        assert np.array_equal(result.data, np.array([1, 4, 3], dtype=np.float16))
+
+    def test_cmpf_olt_scalar(self):
+        ctx = _ctx_with(**{"%a": np.float16(1.0), "%b": np.float16(2.0)})
+        result = _call("arith.cmpf", ctx, _make_env(),
+                       operands=["%a", "%b"], attributes={"predicate": "olt"})
+        assert result is True
+
+    def test_cmpf_ogt_scalar(self):
+        ctx = _ctx_with(**{"%a": np.float16(3.0), "%b": np.float16(2.0)})
+        result = _call("arith.cmpf", ctx, _make_env(),
+                       operands=["%a", "%b"], attributes={"predicate": "ogt"})
+        assert result is True
+
+    def test_cmpf_oeq_tile(self):
+        ctx = _ctx_with(**{"%a": _tile([1, 2, 3]), "%b": _tile([1, 0, 3])})
+        result = _call("arith.cmpf", ctx, _make_env(),
+                       operands=["%a", "%b"], attributes={"predicate": "oeq"})
+        assert isinstance(result, Tile)
+        assert np.array_equal(result.data, np.array([True, False, True]))
+
+# ---------------------------------------------------------------------------
+# arith (new casts) dialect exec
+# ---------------------------------------------------------------------------
+
+class TestArithNewCasts:
+    def test_extui_scalar(self):
+        ctx = _ctx_with(**{"%a": 5})
+        assert _call("arith.extui", ctx, _make_env(), operands=["%a"]) == 5
+
+    def test_trunci_scalar(self):
+        ctx = _ctx_with(**{"%a": 300})
+        assert _call("arith.trunci", ctx, _make_env(), operands=["%a"]) == 300
+
+    def test_uitofp_scalar(self):
+        ctx = _ctx_with(**{"%a": 4})
+        result = _call("arith.uitofp", ctx, _make_env(), operands=["%a"])
+        assert float(result) == pytest.approx(4.0, rel=1e-2)
+
+    def test_fptosi_scalar(self):
+        ctx = _ctx_with(**{"%a": np.float16(3.7)})
+        result = _call("arith.fptosi", ctx, _make_env(), operands=["%a"])
+        assert int(result) == 3
+
+    def test_fptoui_scalar(self):
+        ctx = _ctx_with(**{"%a": np.float16(2.9)})
+        result = _call("arith.fptoui", ctx, _make_env(), operands=["%a"])
+        assert int(result) == 2
+
+    def test_extui_tile(self):
+        data = np.array([1, 2, 3], dtype=np.int32)
+        t = Tile(data, "i32", data.shape)
+        ctx = _ctx_with(**{"%a": t})
+        result = _call("arith.extui", ctx, _make_env(), operands=["%a"])
+        assert isinstance(result, Tile)
+        assert result.data.dtype == np.int64
+
+    def test_fptosi_tile(self):
+        ctx = _ctx_with(**{"%a": _tile([1.7, 2.3, -3.9])})
+        result = _call("arith.fptosi", ctx, _make_env(), operands=["%a"])
+        assert isinstance(result, Tile)
+        assert np.array_equal(result.data, np.array([1, 2, -3], dtype=np.int32))
+
 # ---------------------------------------------------------------------------
 # arith (casts) dialect exec
 # ---------------------------------------------------------------------------
@@ -263,11 +457,26 @@ class TestArithCastsConstants:
         ctx = _ctx_with(**{"%a": 7})
         assert _call("arith.index_cast", ctx, _make_env(), operands=["%a"]) == 7
 
+    def test_index_castui(self):
+        ctx = _ctx_with(**{"%a": 7})
+        assert _call("arith.index_castui", ctx, _make_env(), operands=["%a"]) == 7
+
+    def test_convertf_f16_to_f32(self):
+        ctx = _ctx_with(**{"%a": _tile([1.0, 2.0])})
+        result = _call("arith.convertf", ctx, _make_env(), operands=["%a"])
+        assert result.data.dtype == np.float32
+
+    def test_convertf_f32_to_f16(self):
+        t = Tile(np.array([1.0, 2.0], dtype=np.float32), "f32", (2,))
+        ctx = _ctx_with(**{"%a": t})
+        result = _call("arith.convertf", ctx, _make_env(), operands=["%a"])
+        assert result.data.dtype == np.float16
+
     def test_sitofp(self):
-        # signed int to float — returns np.float16
+        # signed int to float — returns a float scalar
         ctx = _ctx_with(**{"%a": 3})
         result = _call("arith.sitofp", ctx, _make_env(), operands=["%a"])
-        assert isinstance(result, np.float16)
+        assert isinstance(result, (float, np.floating))
         assert float(result) == pytest.approx(3.0, rel=1e-2)
 
 

--- a/tests/test_dialects_exec.py
+++ b/tests/test_dialects_exec.py
@@ -35,13 +35,13 @@ from ktir_cpu.ops.comm_ops import RingNetwork
 # Fixtures
 # ---------------------------------------------------------------------------
 
-def _op(op_type, operands=None, attributes=None, result=None, regions=None):
+def _op(op_type, operands=None, attributes=None, result=None, regions=None, result_type=None):
     return Operation(
         op_type=op_type,
         operands=operands or [],
         attributes=attributes or {},
         result=result,
-        result_type=None,
+        result_type=result_type,
         regions=regions or [],
     )
 
@@ -239,9 +239,20 @@ class TestArithInt:
         ctx = _ctx_with(**{"%a": 7, "%b": 2})
         assert _call("arith.divsi", ctx, _make_env(), operands=["%a", "%b"]) == 3
 
+    def test_divsi_truncates_toward_zero(self):
+        # -7 / 2 = -3 (truncate), not -4 (floor)
+        ctx = _ctx_with(**{"%a": -7, "%b": 2})
+        assert _call("arith.divsi", ctx, _make_env(), operands=["%a", "%b"]) == -3
+
     def test_remsi_scalar(self):
         ctx = _ctx_with(**{"%a": 7, "%b": 3})
         assert _call("arith.remsi", ctx, _make_env(), operands=["%a", "%b"]) == 1
+
+    def test_remsi_negative(self):
+        # MLIR remsi: remainder matches sign of dividend
+        # -7 % 3 = -1 (truncating), not 2 (Python %)
+        ctx = _ctx_with(**{"%a": -7, "%b": 3})
+        assert _call("arith.remsi", ctx, _make_env(), operands=["%a", "%b"]) == -1
 
     def test_ceildivsi_scalar(self):
         ctx = _ctx_with(**{"%a": 7, "%b": 2})
@@ -478,6 +489,20 @@ class TestArithCastsConstants:
         result = _call("arith.sitofp", ctx, _make_env(), operands=["%a"])
         assert isinstance(result, (float, np.floating))
         assert float(result) == pytest.approx(3.0, rel=1e-2)
+
+    def test_sitofp_respects_result_type_f16(self):
+        ctx = _ctx_with(**{"%a": 3})
+        result = _call("arith.sitofp", ctx, _make_env(), operands=["%a"],
+                       result_type="f16")
+        assert result.dtype == np.float16
+
+    def test_sitofp_respects_result_type_f32(self):
+        t = Tile(np.array([1, -2], dtype=np.int32), "i32", (2,))
+        ctx = _ctx_with(**{"%a": t})
+        result = _call("arith.sitofp", ctx, _make_env(), operands=["%a"],
+                       result_type="f32")
+        assert result.data.dtype == np.float32
+        np.testing.assert_array_equal(result.data, [1.0, -2.0])
 
 
 class TestArithBitcast:

--- a/tests/test_dialects_parse.py
+++ b/tests/test_dialects_parse.py
@@ -17,21 +17,22 @@ Parser tests for the KTIR dialect layer and module-level parser.
 
 Covers:
 - Module/function-level parser (moved from test_ktir_cpu.py)
-- arith dialect parsers: arith.constant, arith.cmpi, arith.sitofp
+- arith dialect parsers: arith.constant, arith.cmpi, arith.cmpf, arith.sitofp
 - linalg dialect parsers: linalg.reduce, linalg.fill, linalg.broadcast
 - tensor dialect parsers: tensor.empty, tensor.splat, tensor.extract, tensor.expand_shape
 - ktdp dialect parsers: ktdp.get_compute_tile_id, ktdp.construct_memory_view,
                          ktdp.construct_access_tile
 - scf dialect parsers: scf.for, scf.yield
+- math dialect parsers: math.exp, math.sqrt, math.rsqrt, math.log, math.log2,
+                         math.log1p, math.tanh, math.sin, math.cos, math.absf,
+                         math.absi, math.ceil, math.floor, math.erf, math.powf,
+                         math.fma
 
 Design rule
 -----------
-The goal of the regex parser is to parse valid MLIR.  All op text examples
-in this file must therefore be valid MLIR.  Non-MLIR syntax forces the
-corresponding test_parse_adapt.py test to be skipped, which defeats the
-purpose of sharing tests between the two parser backends.
-
-All op text examples have been verified to parse with both backends.
+All op text examples in this file must be valid MLIR so that the tests are
+fully portable to the MLIRFrontendParser backend in test_parse_adapt.py.
+All op examples have been verified to parse with both backends.
 """
 
 import numpy as np
@@ -283,7 +284,8 @@ class TestArithParsers(ParseTestMixin):
         self.assert_operand_names(op, "%i")
         self.assert_result_type(op, "f16")
 
-    def test_cmpf_olt(self):
+    def test_cmpf_basic(self):
+        # cmpf records predicate and both operands
         op = self._parse(
             "%r = arith.cmpf olt, %a, %b : f16",
             args={"%a": "f16", "%b": "f16"},
@@ -302,6 +304,24 @@ class TestArithParsers(ParseTestMixin):
         self.assert_attribute(op, "predicate", "uge")
         self.assert_num_operands(op, 2)
         self.assert_operand_names(op, "%x", "%y")
+
+    def test_cmpf_all_ordered_predicates(self):
+        # all ordered float comparison predicates are recognised
+        for pred in ("oeq", "ogt", "oge", "olt", "ole", "one", "ord"):
+            op = self._parse(
+                f"%b = arith.cmpf {pred}, %x, %y : f32",
+                args={"%x": "f32", "%y": "f32"},
+            )
+            self.assert_attribute(op, "predicate", pred)
+
+    def test_cmpf_unordered_predicates(self):
+        # all unordered float comparison predicates are recognised
+        for pred in ("ueq", "ugt", "uge", "ult", "ule", "une", "uno"):
+            op = self._parse(
+                f"%b = arith.cmpf {pred}, %x, %y : f32",
+                args={"%x": "f32", "%y": "f32"},
+            )
+            self.assert_attribute(op, "predicate", pred)
 
     def test_cmpf_missing_predicate_raises(self):
         # regex parser raises ValueError; MLIR frontend raises MLIRError

--- a/tests/test_dialects_parse.py
+++ b/tests/test_dialects_parse.py
@@ -362,17 +362,9 @@ class TestArithParsers(ParseTestMixin):
         self.assert_operand_names(op, "%x", "%y")
 
     def test_cmpf_all_ordered_predicates(self):
-        # all ordered float comparison predicates are recognised
-        for pred in ("oeq", "ogt", "oge", "olt", "ole", "one", "ord"):
-            op = self._parse(
-                f"%b = arith.cmpf {pred}, %x, %y : f32",
-                args={"%x": "f32", "%y": "f32"},
-            )
-            self.assert_attribute(op, "predicate", pred)
-
-    def test_cmpf_unordered_predicates(self):
-        # all unordered float comparison predicates are recognised
-        for pred in ("ueq", "ugt", "uge", "ult", "ule", "une", "uno"):
+        # all ordered, unordered, and always-true/false predicates are recognised
+        for pred in ("false", "oeq", "ogt", "oge", "olt", "ole", "one", "ord",
+                     "ueq", "ugt", "uge", "ult", "ule", "une", "uno", "true"):
             op = self._parse(
                 f"%b = arith.cmpf {pred}, %x, %y : f32",
                 args={"%x": "f32", "%y": "f32"},

--- a/tests/test_dialects_parse.py
+++ b/tests/test_dialects_parse.py
@@ -253,6 +253,62 @@ class TestArithParsers(ParseTestMixin):
         self.assert_attribute(op, "shape", (4,))
         self.assert_attribute(op, "dtype", "f16")
 
+    @pytest.mark.parametrize("op_name", [
+        "arith.addi", "arith.subi", "arith.muli",
+        "arith.divsi", "arith.divui",
+        "arith.remsi", "arith.remui",
+        "arith.ceildivsi", "arith.floordivsi",
+        "arith.minsi", "arith.maxsi",
+        "arith.minui", "arith.maxui",
+        "arith.andi", "arith.ori", "arith.xori",
+        "arith.shli", "arith.shrsi", "arith.shrui",
+    ])
+    def test_int_binop(self, op_name):
+        op = self._parse(
+            f"%r = {op_name} %a, %b : i32",
+            args={"%a": "i32", "%b": "i32"},
+        )
+        self.assert_op_type(op, op_name)
+        self.assert_num_operands(op, 2)
+
+    @pytest.mark.parametrize("op_name", [
+        "arith.extsi", "arith.extui", "arith.trunci",
+        "arith.fptosi", "arith.fptoui",
+        "arith.uitofp",
+    ])
+    def test_int_cast(self, op_name):
+        type_map = {
+            "arith.extsi":  ("i16", "i32"),
+            "arith.extui":  ("i16", "i32"),
+            "arith.trunci": ("i32", "i16"),
+            "arith.fptosi": ("f32", "i32"),
+            "arith.fptoui": ("f32", "i32"),
+            "arith.uitofp": ("i32", "f32"),
+        }
+        src_type, dst_type = type_map[op_name]
+        op = self._parse(
+            f"%r = {op_name} %a : {src_type} to {dst_type}",
+            args={"%a": src_type},
+        )
+        self.assert_op_type(op, op_name)
+        self.assert_num_operands(op, 1)
+
+    def test_index_cast(self):
+        op = self._parse(
+            "%r = arith.index_cast %a : i32 to index",
+            args={"%a": "i32"},
+        )
+        self.assert_op_type(op, "arith.index_cast")
+        self.assert_num_operands(op, 1)
+
+    def test_select(self):
+        op = self._parse(
+            "%r = arith.select %cond, %a, %b : i32",
+            args={"%cond": "i1", "%a": "i32", "%b": "i32"},
+        )
+        self.assert_op_type(op, "arith.select")
+        self.assert_num_operands(op, 3)
+
     def test_cmpi_basic(self):
         # cmpi records predicate and both operands
         op = self._parse(


### PR DESCRIPTION
Closes #23.

## Summary

- Add `dialects/_helpers.py` with three shared dispatch helpers (`_float_binop`, `_int_binop`, `_unary`) that eliminate the repetitive Tile-vs-scalar branching duplicated across every arith and math handler
- Rewrite `dialects/arith_ops.py` using the helpers; each float/int binop handler is now a one-liner
- Refactor `dialects/math_ops.py` to use `_unary` for all unary math ops
- Add executors for previously missing arith ops: `remf`, `negf`, `absf`, `minf`/`minimumf`, `minnumf`, `cmpf`, `divsi`, `ceildivsi`, `floordivsi`, `remsi`, `andi`, `ori`, `xori`, `shli`, `shrsi`, `shrui`, `extui`, `trunci`, `uitofp`, `fptosi`, `fptoui`
- Add `parse_arith_cmpf` regex parser
- Update `mlir_frontend/parser.py`: register all new ops; add `_adapt_arith_cmpf` predicate-integer → string adapter
- Extend `ops/arith_ops.py` with backing compute methods for all new ops
- Add tests in `test_dialects_exec.py` and `test_dialects_parse.py` covering the new executors and parsers

## Design note

The helpers live in `dialects/_helpers.py` (not `ops/` or `dtypes.py`) because they are IR dispatch patterns — they read `op.operands` and construct `Tile` objects. The `ops/` layer and `dtypes.py` remain pure compute/data with no IR knowledge.

`linalg`, `scf`, and `tensor` dialect handlers were intentionally left unreafactored: their dispatch logic is bespoke (reductions, loop state, shape construction) and does not fit the uniform binop/unary pattern.

## Test plan

- [ ] `uv run pytest tests/ -v` — 665 passed, 6 xfailed, 0 failures