### PR TITLE
[Fix] Fix dynamic shapes: `memref<?>`, SSA sizes as operands, symbolic affine dims

### DIFF
--- a/examples/triton-ktir/vector_add_dynamic_ktir.mlir
+++ b/examples/triton-ktir/vector_add_dynamic_ktir.mlir
@@ -1,0 +1,42 @@
+#map = affine_map<(d0) -> (d0)>
+#set = affine_set<(d0)[s0] : (d0 >= 0, -d0 + s0 - 1 >= 0)>
+#set1 = affine_set<(d0) : (d0 >= 0, -d0 + 1023 >= 0)>
+module {
+  func.func @add_kernel_dynamic(
+      %x_ptr: index,
+      %y_ptr: index,
+      %output_ptr: index,
+      %n_elements: i32
+  ) attributes {grid = [1]} {
+    %c0 = arith.constant 0 : index
+    %n = arith.index_cast %n_elements : i32 to index
+
+    %x_view = ktdp.construct_memory_view %x_ptr, sizes: [%n], strides: [1] {
+      coordinate_set = #set, memory_space = #ktdp.spyre_memory_space<HBM>
+    } : memref<?xf32>
+    %x_tile = ktdp.construct_access_tile %x_view[%c0] {
+      access_tile_order = #map, access_tile_set = #set1
+    } : memref<?xf32> -> !ktdp.access_tile<1024xindex>
+    %x = ktdp.load %x_tile : <1024xindex> -> tensor<1024xf32>
+
+    %y_view = ktdp.construct_memory_view %y_ptr, sizes: [%n], strides: [1] {
+      coordinate_set = #set, memory_space = #ktdp.spyre_memory_space<HBM>
+    } : memref<?xf32>
+    %y_tile = ktdp.construct_access_tile %y_view[%c0] {
+      access_tile_order = #map, access_tile_set = #set1
+    } : memref<?xf32> -> !ktdp.access_tile<1024xindex>
+    %y = ktdp.load %y_tile : <1024xindex> -> tensor<1024xf32>
+
+    %output = arith.addf %x, %y : tensor<1024xf32>
+
+    %output_view = ktdp.construct_memory_view %output_ptr, sizes: [%n], strides: [1] {
+      coordinate_set = #set, memory_space = #ktdp.spyre_memory_space<HBM>
+    } : memref<?xf32>
+    %output_tile = ktdp.construct_access_tile %output_view[%c0] {
+      access_tile_order = #map, access_tile_set = #set1
+    } : memref<?xf32> -> !ktdp.access_tile<1024xindex>
+    ktdp.store %output, %output_tile : tensor<1024xf32>, <1024xindex>
+
+    return
+  }
+}

--- a/examples/triton-ktir/vector_add_dynamic_ktir.mlir
+++ b/examples/triton-ktir/vector_add_dynamic_ktir.mlir
@@ -1,3 +1,7 @@
+// #set bounds the memory view to n_elements (symbolic s0); elements outside
+// this range are masked on load and ignored on store — matching tensor_descriptor
+// semantics. The access tile (#set1) is fixed at 1024; when n_elements < 1024
+// the out-of-bounds positions are masked rather than triggering an error.
 #map = affine_map<(d0) -> (d0)>
 #set = affine_set<(d0)[s0] : (d0 >= 0, -d0 + s0 - 1 >= 0)>
 #set1 = affine_set<(d0) : (d0 >= 0, -d0 + 1023 >= 0)>

--- a/ktir_cpu/affine.py
+++ b/ktir_cpu/affine.py
@@ -79,32 +79,34 @@ class AffineMap:
 
 @dataclass(frozen=True)
 class AffineSet:
-    """Parsed affine_set<(d0,...) : (c0 >= 0, ...)>.
+    """Parsed affine_set<(d0,...)[s0,...] : (c0 >= 0, ...)>.
 
     Attributes:
         n_dims:       number of dimension variables
+        n_syms:       number of symbol variables (s0, s1, ...)
         constraints:  tuple of AST nodes; each node is the LHS of ``expr >= 0``
         source:       original verbatim string (for debugging / round-trip)
     """
     n_dims: int
     constraints: Tuple["_Node", ...]
     source: str
+    n_syms: int = 0
 
-    def contains(self, point: Sequence[int]) -> bool:
+    def contains(self, point: Sequence[int], symbols: Sequence[int] = ()) -> bool:
         """Return True if *point* satisfies all constraints.
 
         Delegates to ``parser_ast.affine_set_contains``.
         """
         from .parser_ast import affine_set_contains
-        return affine_set_contains(self, point)
+        return affine_set_contains(self, point, symbols)
 
-    def enumerate(self, shape: Tuple[int, ...]) -> List[Tuple[int, ...]]:
+    def enumerate(self, shape: Tuple[int, ...], symbols: Sequence[int] = ()) -> List[Tuple[int, ...]]:
         """Return all integer points in ``[0, shape)`` satisfying all constraints.
 
         Delegates to ``parser_ast.enumerate_affine_set``.
         """
         from .parser_ast import enumerate_affine_set
-        return enumerate_affine_set(self, shape)
+        return enumerate_affine_set(self, shape, symbols)
 
     def is_full(self, shape: Tuple[int, ...]) -> bool:
         """Return True if this set covers every coordinate in *shape*.

--- a/ktir_cpu/dialects/ktdp_ops.py
+++ b/ktir_cpu/dialects/ktdp_ops.py
@@ -48,7 +48,11 @@ def ktdp__construct_memory_view(op, context, env):
     for attr in ("shape", "strides", "memory_space", "dtype"):
         if attr not in op.attributes:
             raise ValueError(f"construct_memory_view: missing required attribute '{attr}'")
-    shape = tuple(op.attributes["shape"])
+    # SSA size names are stored as strings by the parser; resolve them at runtime.
+    shape = tuple(
+        context.get_value(s) if isinstance(s, str) else s
+        for s in op.attributes["shape"]
+    )
     # SSA stride names are stored as strings by the parser; resolve them at runtime.
     strides = [context.get_value(s) if isinstance(s, str) else s for s in op.attributes["strides"]]
     memory_space = op.attributes["memory_space"]
@@ -147,8 +151,10 @@ def parse_construct_memory_view(op_text, parse_ctx: ParseContext):
     result_name = result_match.group(1)
     ptr_operand = result_match.group(2)
 
-    # Parse sizes — int values validated against memref dims; SSA names stored as None.
+    # Parse sizes — int values validated against memref dims; SSA names stored as strings
+    # and collected in ssa_size_operands so the executor can resolve them at runtime.
     sizes = None
+    ssa_size_operands = []
     sizes_match = re.search(r'sizes\s*:\s*\[([^\]]+)\]', op_text)
     if sizes_match:
         sizes = []
@@ -157,7 +163,9 @@ def parse_construct_memory_view(op_text, parse_ctx: ParseContext):
             try:
                 sizes.append(int(token))
             except ValueError:
-                sizes.append(None)  # SSA name
+                sizes.append(token)  # SSA name — resolved at runtime
+                if token not in ssa_size_operands:
+                    ssa_size_operands.append(token)
 
     # SSA stride operands: when a stride is a runtime SSA value (not a literal),
     # the parser stores the name as a string and appends it to ssa_stride_operands
@@ -194,16 +202,25 @@ def parse_construct_memory_view(op_text, parse_ctx: ParseContext):
         raise ValueError(
             f"construct_memory_view: memref<{memref_match.group(1)}> has no dimensions"
         )
-    memref_dims = [int(p) for p in parts[:-1]]
-    shape = tuple(memref_dims)
-    # If sizes is None, no checking is performed.
+    memref_dims = [None if p == "?" else int(p) for p in parts[:-1]]
+    # Build shape: prefer SSA size tokens for dynamic dims, fall back to memref_dims.
+    # SSA size strings are resolved at runtime by the executor via context.get_value().
     if sizes is not None:
+        resolved = []
         for i, s in enumerate(sizes):
-            if s is not None and s != memref_dims[i]:
+            mem_d = memref_dims[i] if i < len(memref_dims) else None
+            if isinstance(s, str):
+                resolved.append(s)  # SSA name — runtime value
+            elif s is not None and mem_d is not None and s != mem_d:
                 raise ValueError(
                     f"construct_memory_view: sizes[{i}]={s} does not match "
-                    f"memref dimension {memref_dims[i]}"
+                    f"memref dimension {mem_d}"
                 )
+            else:
+                resolved.append(s if s is not None else mem_d)
+        shape = tuple(resolved)
+    else:
+        shape = tuple(memref_dims)
 
     attrs = parse_attr_block(op_text, parse_ctx.aliases)
     coordinate_set_str = attrs.get('coordinate_set')
@@ -221,9 +238,9 @@ def parse_construct_memory_view(op_text, parse_ctx: ParseContext):
     return Operation(
         result=result_name,
         op_type="ktdp.construct_memory_view",
-        operands=[ptr_operand] + ssa_stride_operands,
+        operands=[ptr_operand] + ssa_size_operands + ssa_stride_operands,
         attributes=attributes,
-        result_type=f"memref<{'x'.join(str(s) for s in shape)}x{dtype}>"
+        result_type=f"memref<{'x'.join('?' if (s is None or isinstance(s, str)) else str(s) for s in shape)}x{dtype}>"
     )
 
 

--- a/ktir_cpu/dialects/ktdp_ops.py
+++ b/ktir_cpu/dialects/ktdp_ops.py
@@ -202,15 +202,20 @@ def parse_construct_memory_view(op_text, parse_ctx: ParseContext):
         raise ValueError(
             f"construct_memory_view: memref<{memref_match.group(1)}> has no dimensions"
         )
+    # '?' in the memref type means the dimension is dynamic (value only known at
+    # runtime).  We keep it as None until we can substitute the SSA size below.
     memref_dims = [None if p == "?" else int(p) for p in parts[:-1]]
     # Build shape: prefer SSA size tokens for dynamic dims, fall back to memref_dims.
-    # SSA size strings are resolved at runtime by the executor via context.get_value().
+    # An SSA name (e.g. "%n_idx") is kept as a string in the shape tuple; the
+    # executor resolves it via context.get_value() at runtime.  The result_type
+    # round-trips the string back to '?' so downstream MLIR consumers see a valid
+    # dynamic memref type.
     if sizes is not None:
         resolved = []
         for i, s in enumerate(sizes):
             mem_d = memref_dims[i] if i < len(memref_dims) else None
             if isinstance(s, str):
-                resolved.append(s)  # SSA name — runtime value
+                resolved.append(s)  # SSA name — resolved at runtime
             elif s is not None and mem_d is not None and s != mem_d:
                 raise ValueError(
                     f"construct_memory_view: sizes[{i}]={s} does not match "
@@ -240,7 +245,7 @@ def parse_construct_memory_view(op_text, parse_ctx: ParseContext):
         op_type="ktdp.construct_memory_view",
         operands=[ptr_operand] + ssa_size_operands + ssa_stride_operands,
         attributes=attributes,
-        result_type=f"memref<{'x'.join('?' if (s is None or isinstance(s, str)) else str(s) for s in shape)}x{dtype}>"
+        result_type=f"memref<{'x'.join(str(s) if isinstance(s, int) else '?' for s in shape)}x{dtype}>"
     )
 
 

--- a/ktir_cpu/dialects/ktdp_ops.py
+++ b/ktir_cpu/dialects/ktdp_ops.py
@@ -205,26 +205,37 @@ def parse_construct_memory_view(op_text, parse_ctx: ParseContext):
     # '?' in the memref type means the dimension is dynamic (value only known at
     # runtime).  We keep it as None until we can substitute the SSA size below.
     memref_dims = [None if p == "?" else int(p) for p in parts[:-1]]
-    # Build shape: prefer SSA size tokens for dynamic dims, fall back to memref_dims.
-    # An SSA name (e.g. "%n_idx") is kept as a string in the shape tuple; the
-    # executor resolves it via context.get_value() at runtime.  The result_type
-    # round-trips the string back to '?' so downstream MLIR consumers see a valid
-    # dynamic memref type.
     if sizes is not None:
+        if len(sizes) != len(memref_dims):
+            raise ValueError(
+                f"construct_memory_view: sizes count {len(sizes)} does not match "
+                f"memref dimension count {len(memref_dims)}"
+            )
         resolved = []
-        for i, s in enumerate(sizes):
-            mem_d = memref_dims[i] if i < len(memref_dims) else None
-            if isinstance(s, str):
-                resolved.append(s)  # SSA name — resolved at runtime
-            elif s is not None and mem_d is not None and s != mem_d:
-                raise ValueError(
-                    f"construct_memory_view: sizes[{i}]={s} does not match "
-                    f"memref dimension {mem_d}"
-                )
+        for i, (s, mem_d) in enumerate(zip(sizes, memref_dims)):
+            if mem_d is not None:
+                # concrete dim — s must equal it
+                if not isinstance(s, str) and s != mem_d:
+                    raise ValueError(
+                        f"construct_memory_view: sizes[{i}]={s} does not match "
+                        f"memref dimension {mem_d}"
+                    )
+                resolved.append(s)
             else:
-                resolved.append(s if s is not None else mem_d)
+                # dynamic dim ('?') — s must be an SSA name
+                if not isinstance(s, str):
+                    raise ValueError(
+                        f"construct_memory_view: sizes[{i}]={s} given for a '?' dim; "
+                        f"dynamic dim requires an SSA name, not a literal"
+                    )
+                resolved.append(s)
         shape = tuple(resolved)
     else:
+        if any(d is None for d in memref_dims):
+            raise ValueError(
+                "construct_memory_view: memref has dynamic '?' dim(s) but no sizes: "
+                "attribute was provided; dynamic dims require SSA sizes"
+            )
         shape = tuple(memref_dims)
 
     attrs = parse_attr_block(op_text, parse_ctx.aliases)

--- a/ktir_cpu/parser_ast.py
+++ b/ktir_cpu/parser_ast.py
@@ -83,10 +83,10 @@ _Node = tuple
 
 _TOKEN_RE = re.compile(
     r'\s*(?:'
-    r'(%[a-zA-Z_]\w*)'             # named reference %name (group 1)
-    r'|([a-zA-Z_]\w*)'             # bare identifier  (group 2)
-    r'|(-?\d+)'                    # integer literal, possibly negative (group 3)
-    r'|(>=|<=|->|[+\-*(),:])'      # operator / punctuation  (group 4)
+    r'(%[a-zA-Z_]\w*)'               # named reference %name (group 1)
+    r'|([a-zA-Z_]\w*)'               # bare identifier  (group 2)
+    r'|(-?\d+)'                      # integer literal, possibly negative (group 3)
+    r'|(>=|<=|->|[+\-*(),:[\]])'     # operator / punctuation incl. [ ]  (group 4)
     r')'
 )
 
@@ -125,6 +125,9 @@ class _Parser:
         # Set by callers after parsing the dim list so that _atom can resolve
         # arbitrary identifiers used as dimension variables.
         self.dim_index: dict = {}
+        # Maps symbol name (e.g. "s0", "n") to its positional index.
+        # Set by callers after parsing the optional symbol list in affine sets.
+        self.sym_index: dict = {}
 
     # --- helpers ---
 
@@ -149,6 +152,19 @@ class _Parser:
             if self.peek() == ",":
                 self.consume(",")
         self.consume(")")
+        return names
+
+    def parse_sym_list(self) -> List[str]:
+        """Parse optional ``[s0, s1, ...]`` symbol list and return names."""
+        if self.peek() != "[":
+            return []
+        self.consume("[")
+        names: List[str] = []
+        while self.peek() != "]":
+            names.append(self.consume())
+            if self.peek() == ",":
+                self.consume(",")
+        self.consume("]")
         return names
 
     def parse_expr(self) -> _Node:
@@ -225,6 +241,15 @@ class _Parser:
         if re.fullmatch(r'd\d+', tok) and not self.dim_index:
             self.consume()
             return ("dim", int(tok[1:]))
+
+        # Symbol variable — any identifier that appears in the symbol list.
+        if tok in self.sym_index:
+            self.consume()
+            return ("sym", self.sym_index[tok])
+        # Fallback for canonical sN names when sym_index is empty.
+        if re.fullmatch(r's\d+', tok) and not self.sym_index:
+            self.consume()
+            return ("sym", int(tok[1:]))
 
         # Positive integer constant (negative handled in _term)
         if re.fullmatch(r'\d+', tok):
@@ -329,9 +354,9 @@ def parse_affine_map(s: str) -> AffineMap:
 
 
 def parse_affine_set(s: str) -> AffineSet:
-    """Parse ``affine_set<(d0,...) : (c0 >= 0, ...)>`` into an :class:`AffineSet`.
+    """Parse ``affine_set<(d0,...)[s0,...] : (c0 >= 0, ...)>`` into an :class:`AffineSet`.
 
-    The ``affine_set<...>`` wrapper is optional.
+    The ``affine_set<...>`` wrapper and the ``[s0, ...]`` symbol list are optional.
 
     Raises:
         ValueError: on any parse error.
@@ -342,19 +367,22 @@ def parse_affine_set(s: str) -> AffineSet:
     dim_part = inner[:colon].strip()
     con_part = inner[colon + 1:].strip()
 
+    # Parse dim list and optional symbol list from dim_part, e.g. "(d0)[s0]"
     dim_tokens = _tokenise(dim_part)
     p1 = _Parser(dim_tokens)
     dim_names = p1.parse_dim_list()
+    sym_names = p1.parse_sym_list()
 
     con_tokens = _tokenise(con_part)
     p2 = _Parser(con_tokens)
-    # Share the same name→index map so constraint expressions can reference
-    # the same dim names as the dim list.
+    # Share name→index maps so constraint expressions can reference dims and syms.
     p2.dim_index = {name: idx for idx, name in enumerate(dim_names)}
+    p2.sym_index = {name: idx for idx, name in enumerate(sym_names)}
     constraints = p2.parse_constraint_list()
 
     return AffineSet(
         n_dims=len(dim_names),
+        n_syms=len(sym_names),
         constraints=tuple(constraints),
         source=source,
     )
@@ -364,21 +392,23 @@ def parse_affine_set(s: str) -> AffineSet:
 # Evaluation functions (called by AffineMap / AffineSet convenience methods)
 # ---------------------------------------------------------------------------
 
-def _eval_node(node: _Node, dims: List[int]) -> int:
-    """Recursively evaluate an AST node given concrete dimension values."""
+def _eval_node(node: _Node, dims: List[int], syms: Optional[List[int]] = None) -> int:
+    """Recursively evaluate an AST node given concrete dimension and symbol values."""
     tag = node[0]
     if tag == "const":
         return node[1]
     if tag == "dim":
         return dims[node[1]]
+    if tag == "sym":
+        return (syms or [])[node[1]]
     if tag == "add":
-        return _eval_node(node[1], dims) + _eval_node(node[2], dims)
+        return _eval_node(node[1], dims, syms) + _eval_node(node[2], dims, syms)
     if tag == "sub":
-        return _eval_node(node[1], dims) - _eval_node(node[2], dims)
+        return _eval_node(node[1], dims, syms) - _eval_node(node[2], dims, syms)
     if tag == "neg":
-        return -_eval_node(node[1], dims)
+        return -_eval_node(node[1], dims, syms)
     if tag == "mul":
-        return node[1] * _eval_node(node[2], dims)
+        return node[1] * _eval_node(node[2], dims, syms)
     raise ValueError(f"Unknown AST node tag: {tag!r}")  # pragma: no cover
 
 
@@ -403,18 +433,20 @@ def eval_affine_map(amap: AffineMap, dims: Sequence[int]) -> Tuple[int, ...]:
     return tuple(_eval_node(e, env) for e in amap.exprs)
 
 
-def affine_set_contains(aset: AffineSet, point: Sequence[int]) -> bool:
+def affine_set_contains(aset: AffineSet, point: Sequence[int], symbols: Sequence[int] = ()) -> bool:
     """Return True if *point* satisfies all constraints in *aset*."""
     env = list(point)
-    return all(_eval_node(c, env) >= 0 for c in aset.constraints)
+    syms = list(symbols)
+    return all(_eval_node(c, env, syms) >= 0 for c in aset.constraints)
 
 
-def enumerate_affine_set(aset: AffineSet, shape: Tuple[int, ...]) -> List[Tuple[int, ...]]:
+def enumerate_affine_set(aset: AffineSet, shape: Tuple[int, ...], symbols: Sequence[int] = ()) -> List[Tuple[int, ...]]:
     """Return all integer points in ``[0, shape)`` satisfying *aset*.
 
     Args:
-        aset:  Parsed AffineSet.
-        shape: Bounding box — one upper bound (exclusive) per dimension.
+        aset:    Parsed AffineSet.
+        shape:   Bounding box — one upper bound (exclusive) per dimension.
+        symbols: Concrete values for symbol variables s0, s1, ...
 
     Returns:
         List of coordinate tuples in row-major order.
@@ -427,7 +459,7 @@ def enumerate_affine_set(aset: AffineSet, shape: Tuple[int, ...]) -> List[Tuple[
             f"AffineSet has {aset.n_dims} dim(s), got shape with {len(shape)}: {aset.source!r}"
         )
     ranges = [range(s) for s in shape]
-    return [pt for pt in itertools.product(*ranges) if affine_set_contains(aset, pt)]
+    return [pt for pt in itertools.product(*ranges) if affine_set_contains(aset, pt, symbols)]
 
 
 # ---------------------------------------------------------------------------

--- a/ktir_cpu/parser_ast.py
+++ b/ktir_cpu/parser_ast.py
@@ -22,31 +22,34 @@ This module owns all AST-level concerns for affine maps and sets:
 
 Public API
 ----------
-parse_affine_map(s)          -> AffineMap
-parse_affine_set(s)          -> AffineSet
-eval_affine_map(amap, dims)  -> tuple[int, ...]
-affine_set_contains(aset, point) -> bool
-enumerate_affine_set(aset, shape) -> list[tuple[int, ...]]
+parse_affine_map(s)                        -> AffineMap
+parse_affine_set(s)                        -> AffineSet
+eval_affine_map(amap, dims)                -> tuple[int, ...]
+affine_set_contains(aset, point, symbols)  -> bool
+enumerate_affine_set(aset, shape, symbols) -> list[tuple[int, ...]]
 
-The first two are called by ``parser.py`` (MLIR structure parser) when it
-encounters an ``affine_map<...>`` or ``affine_set<...>`` string.
-The remaining three are called by the convenience methods on ``AffineMap``
-and ``AffineSet`` in ``affine.py``, and directly by ``memory_ops.py``.
+``parse_affine_map`` / ``parse_affine_set`` are called by ``parser.py``
+when it encounters an ``affine_map<...>`` or ``affine_set<...>`` string.
+The evaluation functions are called by the convenience methods on
+``AffineMap`` and ``AffineSet`` in ``affine.py``, and directly by
+``memory_ops.py``.
 
 Supported scope
 ---------------
-Linear affine expressions only:
-  - Dimension variables:  d0, d1, ...
+Linear affine expressions:
+  - Dimension variables: d0, d1, ... (or arbitrary names via the dim list)
+  - Symbol variables:    s0, s1, ... (or arbitrary names via the symbol list)
   - Integer constants
   - Addition (+), subtraction (-), negation (unary -)
-  - Multiplication by a constant coefficient (N * dI)
+  - Multiplication by a constant coefficient (N * dI or dI * N)
 
-No symbolic identifiers (s0, s1, ...), floordiv, ceildiv, or mod.
+Not supported: floordiv, ceildiv, mod.
 
-Assumption for affine_set enumeration
--------------------------------------
-Constraints are interpreted in *local* (0-based) coordinates within the
-access tile.  The caller passes the tile shape as a bounding box.
+Affine set enumeration
+----------------------
+Constraints are interpreted in local (0-based) coordinates within the
+access tile.  The caller passes the tile shape as a bounding box and,
+for sets with symbol variables, the concrete symbol values.
 """
 
 from __future__ import annotations
@@ -242,11 +245,17 @@ class _Parser:
             self.consume()
             return ("dim", int(tok[1:]))
 
-        # Symbol variable — any identifier that appears in the symbol list.
+        # Symbol variable — any identifier that appears in the symbol list,
+        # e.g. affine_set<(d0)[s0, n] : (d0 >= 0, -d0 + n - 1 >= 0)>.
+        # Symbols are runtime-known constants (unlike dims, which index the
+        # iteration space).  sym_index is populated from the parsed [s0, ...]
+        # list in parse_affine_set; callers pass concrete values via the
+        # ``symbols`` argument to affine_set_contains / enumerate_affine_set.
+        # Fallback: if sym_index is empty (standalone parse_expr call), accept
+        # canonical sN names by parsing the numeric suffix directly (s0→0, ...).
         if tok in self.sym_index:
             self.consume()
             return ("sym", self.sym_index[tok])
-        # Fallback for canonical sN names when sym_index is empty.
         if re.fullmatch(r's\d+', tok) and not self.sym_index:
             self.consume()
             return ("sym", int(tok[1:]))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,4 +47,5 @@ python_files = ["test_*.py"]
 python_functions = ["test_*"]
 markers = [
     "spec_gap: RFC conformance gap — feature not yet implemented in the interpreter",
+    "regex_only: test validates regex-parser-specific behaviour; skipped under the MLIR frontend adapter",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -155,6 +155,15 @@ EXAMPLE_PARAMS: dict[str, list[dict]] = {
             },
         },
     ],
+    "add_kernel_dynamic": [
+        {
+            "path": "triton-ktir/vector_add_dynamic_ktir.mlir",
+            # n_elements drives the symbolic coordinate set bound to %n;
+            # must be <= 1024 (access tile set covers d0 in [0, 1023]).
+            # List of values: the test parametrizes over each.
+            "execute_kwargs": {"n_elements": [256, 512, 1024]},
+        },
+    ],
     "reduce_explicit_region": [
         {
             "path": "ktir/reduce_generic.mlir",
@@ -248,6 +257,11 @@ def get_test_params(
     skipped unless a ``filter`` string explicitly selects them.  This prevents
     failure examples from appearing in normal parametrize lists while still
     allowing dedicated failure tests to select them by path substring.
+
+    If any value in ``execute_kwargs`` is a list, the entry is expanded into
+    one triple per list element, with the list replaced by the scalar value.
+    This lets conftest express multiple runtime values (e.g. varying
+    ``n_elements``) without requiring a separate parametrize in each test.
     """
     names = func_names or tuple(EXAMPLE_PARAMS.keys())
     result = []
@@ -258,11 +272,22 @@ def get_test_params(
             if filter is not None:
                 if filter not in rel_path and filter not in fn:
                     continue
-                # Filter explicitly matched — include even failure examples.
             elif is_failure:
-                # No filter: skip failure examples in normal parametrize lists.
                 continue
-            result.append((str(EXAMPLES_DIR / rel_path), fn, entry))
+            abs_path = str(EXAMPLES_DIR / rel_path)
+            # Expand any list-valued execute_kwargs into separate entries.
+            list_keys = [k for k, v in entry["execute_kwargs"].items() if isinstance(v, list)]
+            if not list_keys:
+                result.append((abs_path, fn, entry))
+                continue
+            # Only one list key supported per entry.
+            assert len(list_keys) == 1, (
+                f"At most one list-valued execute_kwarg per entry; got {list_keys}"
+            )
+            key = list_keys[0]
+            for val in entry["execute_kwargs"][key]:
+                expanded = {**entry, "execute_kwargs": {**entry["execute_kwargs"], key: val}}
+                result.append((abs_path, fn, expanded))
     return result
 
 
@@ -338,10 +363,11 @@ def _parse_mlir_meta(text: str, func_name: str) -> ExampleMeta:
 
         tokens = [t.strip() for t in sizes_str.split(",")]
         if any(not t.lstrip("-").isdigit() for t in tokens):
-            # SSA names in sizes: — fall back to the concrete memref<NxMxdtype>
+            # SSA names in sizes: — fall back to the concrete memref<NxMxdtype>.
+            # "?" dimensions (dynamic) are represented as None in the shape tuple.
             memref_parts = memref_str.split("x")
             dtype = memref_parts[-1]
-            shape = tuple(int(p) for p in memref_parts[:-1])
+            shape = tuple(None if p == "?" else int(p) for p in memref_parts[:-1])
         else:
             shape = tuple(int(t) for t in tokens)
             dtype = memref_str.rsplit("x", 1)[-1]

--- a/tests/mlir_frontend/conftest.py
+++ b/tests/mlir_frontend/conftest.py
@@ -6,3 +6,9 @@ try:
     import mlir_ktdp  # noqa: F401
 except ImportError:
     pytest.skip("mlir_ktdp not installed", allow_module_level=True)
+
+
+@pytest.fixture(autouse=True)
+def _skip_regex_only(request):
+    if request.node.get_closest_marker("regex_only"):
+        pytest.skip("regex-parser only")

--- a/tests/mlir_frontend/test_parse_adapt.py
+++ b/tests/mlir_frontend/test_parse_adapt.py
@@ -92,11 +92,13 @@ class TestTensorAdapt(MLIRFrontendParseTestMixin, _TestTensorParsers):
 class TestKtdpAdapt(MLIRFrontendParseTestMixin, _TestKtdpParsers):
     """Ktdp tests via MLIRFrontendParser."""
 
-
     # test_construct_access_tile: inherited
-
     # test_construct_access_tile_non_index_elem_type_rejected: inherited
     # test_construct_access_tile_malformed_type_rejected: inherited
+
+    # test_affine_set_with_symbolic_dim: inherited
+    # test_construct_memory_view_dynamic_memref_type: inherited
+    # test_construct_memory_view_ssa_size_as_operand: inherited
 
 
 # ---------------------------------------------------------------------------

--- a/tests/mlir_frontend/test_parse_adapt.py
+++ b/tests/mlir_frontend/test_parse_adapt.py
@@ -100,6 +100,8 @@ class TestKtdpAdapt(MLIRFrontendParseTestMixin, _TestKtdpParsers):
     # test_construct_memory_view_dynamic_memref_type: inherited
     # test_construct_memory_view_ssa_size_as_operand: inherited
 
+    # test_construct_memory_view_multi_dim_mixed_static_dynamic: inherited
+
 
 # ---------------------------------------------------------------------------
 # Scf

--- a/tests/test_affine.py
+++ b/tests/test_affine.py
@@ -75,3 +75,20 @@ class TestAffineSetObject:
         s = parse_affine_set("affine_set<(d0) : (d0 >= 0)>")
         with pytest.raises((AttributeError, TypeError)):
             s.n_dims = 99  # type: ignore[misc]
+
+    def test_n_syms_default_zero(self):
+        s = parse_affine_set("affine_set<(d0) : (d0 >= 0)>")
+        assert s.n_syms == 0
+
+    def test_n_syms_parsed(self):
+        s = parse_affine_set("affine_set<(d0)[s0] : (d0 >= 0, -d0 + s0 - 1 >= 0)>")
+        assert s.n_syms == 1
+
+    def test_contains_with_symbol(self):
+        s = parse_affine_set("affine_set<(d0)[s0] : (d0 >= 0, -d0 + s0 - 1 >= 0)>")
+        assert s.contains([3], symbols=[8])
+        assert not s.contains([8], symbols=[8])
+
+    def test_enumerate_with_symbol(self):
+        s = parse_affine_set("affine_set<(d0)[s0] : (d0 >= 0, -d0 + s0 - 1 >= 0)>")
+        assert s.enumerate((10,), symbols=[4]) == [(0,), (1,), (2,), (3,)]

--- a/tests/test_ast.py
+++ b/tests/test_ast.py
@@ -231,6 +231,35 @@ class TestParseAffineSet:
         assert s.constraints[0] == ("sub", ("dim", 0), ("dim", 1))
         assert s.constraints[1] == ("sub", ("const", 63), ("dim", 0))
 
+    def test_symbolic_dim_parsed(self):
+        # (d0)[s0] : (d0 >= 0, -d0 + s0 - 1 >= 0) — s0 is a runtime symbol
+        s = parse_affine_set("affine_set<(d0)[s0] : (d0 >= 0, -d0 + s0 - 1 >= 0)>")
+        assert s.n_dims == 1
+        assert s.n_syms == 1
+        assert len(s.constraints) == 2
+        # Second constraint: -d0 + s0 - 1 >= 0, normalised to sub(lhs, 0)
+        # The s0 token should appear as ("sym", 0) in the AST
+        def _find_sym(node):
+            if isinstance(node, tuple):
+                if node[0] == "sym":
+                    return node
+                for child in node[1:]:
+                    found = _find_sym(child)
+                    if found:
+                        return found
+            return None
+        assert _find_sym(s.constraints[1]) == ("sym", 0)
+
+    def test_symbolic_dim_multiple_syms(self):
+        # Two symbols: (d0)[s0, s1]
+        s = parse_affine_set("affine_set<(d0)[s0, s1] : (d0 >= 0, -d0 + s0 - 1 >= 0, s1 >= 0)>")
+        assert s.n_syms == 2
+
+    def test_no_symbol_list_n_syms_zero(self):
+        # A set with no [sN] list has n_syms == 0
+        s = parse_affine_set("affine_set<(d0) : (d0 >= 0, -d0 + 3 >= 0)>")
+        assert s.n_syms == 0
+
 
 # ===========================================================================
 # eval_affine_map
@@ -305,6 +334,14 @@ class TestAffineSetContains:
         assert not affine_set_contains(s, [2, 5])  # 2 < 5
         assert not affine_set_contains(s, [64, 0]) # 64 > 63
 
+    def test_symbolic_contains_with_symbol(self):
+        # (d0)[s0] : (d0 >= 0, -d0 + s0 - 1 >= 0) → 0 <= d0 <= s0-1
+        s = parse_affine_set("affine_set<(d0)[s0] : (d0 >= 0, -d0 + s0 - 1 >= 0)>")
+        assert affine_set_contains(s, [0], symbols=[8])
+        assert affine_set_contains(s, [7], symbols=[8])
+        assert not affine_set_contains(s, [8], symbols=[8])
+        assert not affine_set_contains(s, [-1], symbols=[8])
+
 
 # ===========================================================================
 # enumerate_affine_set
@@ -345,6 +382,18 @@ class TestEnumerateAffineSet:
         s = parse_affine_set("affine_set<(d0, d1) : (d0 >= 0, d1 >= 0)>")
         with pytest.raises(ValueError, match="2 dim"):
             enumerate_affine_set(s, (4,))
+
+    def test_symbolic_enumerate_with_symbol(self):
+        # (d0)[s0] : (d0 >= 0, -d0 + s0 - 1 >= 0) enumerates [0, s0)
+        s = parse_affine_set("affine_set<(d0)[s0] : (d0 >= 0, -d0 + s0 - 1 >= 0)>")
+        pts = enumerate_affine_set(s, (16,), symbols=[5])
+        assert pts == [(0,), (1,), (2,), (3,), (4,)]
+
+    def test_symbolic_enumerate_symbol_larger_than_shape(self):
+        # When s0 > shape bound, shape acts as the cap
+        s = parse_affine_set("affine_set<(d0)[s0] : (d0 >= 0, -d0 + s0 - 1 >= 0)>")
+        pts = enumerate_affine_set(s, (4,), symbols=[100])
+        assert len(pts) == 4  # capped by shape
 
 
 # ===========================================================================

--- a/tests/test_dialects_parse.py
+++ b/tests/test_dialects_parse.py
@@ -514,12 +514,11 @@ class TestKtdpParsers(ParseTestMixin):
                 args={"%view": "memref<1024xf16>", "%c0": "index"},
             )
 
-    # -- Dynamic-size tests (currently failing) --------------------------------
-    # These document the three gaps that need to be fixed:
-    #   (1) affine_set with symbolic dims [s0] crashes the parser
-    #   (2) memref<?xf32> (dynamic dimension '?') crashes memref type parsing
-    #   (3) SSA sizes like sizes: [%n_idx] are stored as None and never
-    #       registered as operands, so context.get_value() cannot resolve them
+    # -- Dynamic-size tests ----------------------------------------------------
+    # These cover the three gaps fixed in issue #30:
+    #   (1) affine_set with symbolic dims [s0]
+    #   (2) memref<?xf32> (dynamic dimension '?')
+    #   (3) SSA sizes like sizes: [%n_idx] registered as operands
     #
     # See: https://github.com/torch-spyre/ktir-cpu/issues/30
 

--- a/tests/test_dialects_parse.py
+++ b/tests/test_dialects_parse.py
@@ -514,6 +514,75 @@ class TestKtdpParsers(ParseTestMixin):
                 args={"%view": "memref<1024xf16>", "%c0": "index"},
             )
 
+    # -- Dynamic-size tests (currently failing) --------------------------------
+    # These document the three gaps that need to be fixed:
+    #   (1) affine_set with symbolic dims [s0] crashes the parser
+    #   (2) memref<?xf32> (dynamic dimension '?') crashes memref type parsing
+    #   (3) SSA sizes like sizes: [%n_idx] are stored as None and never
+    #       registered as operands, so context.get_value() cannot resolve them
+    #
+    # See: https://github.com/torch-spyre/ktir-cpu/issues/30
+
+    def test_affine_set_with_symbolic_dim(self):
+        # affine_set<(d0)[s0] : (d0 >= 0, -d0 + s0 - 1 >= 0)> uses a symbolic
+        # dimension s0 whose value is only known at runtime (the tensor size).
+        # The current parser raises ValueError on the unknown token 's0'.
+        op = self._parse(
+            "%view = ktdp.construct_memory_view %ptr, sizes: [%n_idx], strides: [1]"
+            " { coordinate_set = affine_set<(d0)[s0] : (d0 >= 0, -d0 + s0 - 1 >= 0)>,"
+            " memory_space = #ktdp.spyre_memory_space<HBM> } : memref<?xf32>",
+            args={"%ptr": "index", "%n_idx": "index"},
+        )
+        self.assert_op_type(op, "ktdp.construct_memory_view")
+        self.assert_attribute(op, "dtype", "f32")
+        self.assert_attribute(op, "memory_space", "HBM")
+        # shape should be dynamic (None or -1 convention TBD)
+        # operands must include both %ptr and %n_idx
+        self.assert_num_operands(op, 2)
+
+    def test_construct_memory_view_dynamic_memref_type(self):
+        # memref<?xf32> uses '?' for a dimension whose size is an SSA value.
+        # coordinate_set with symbolic dim is required by the MLIR verifier
+        # when the memref has a dynamic dimension.
+        op = self._parse(
+            "%view = ktdp.construct_memory_view %ptr, sizes: [%n_idx], strides: [1]"
+            " { coordinate_set = affine_set<(d0)[s0] : (d0 >= 0, -d0 + s0 - 1 >= 0)>,"
+            " memory_space = #ktdp.spyre_memory_space<HBM> } : memref<?xf32>",
+            args={"%ptr": "index", "%n_idx": "index"},
+        )
+        self.assert_op_type(op, "ktdp.construct_memory_view")
+        self.assert_attribute(op, "dtype", "f32")
+
+    def test_construct_memory_view_ssa_size_as_operand(self):
+        # When sizes: [%n_idx] appears, %n_idx must be added to the op's
+        # operand list (like SSA strides already are) so the executor can
+        # call context.get_value("%n_idx") to resolve the runtime size.
+        # coordinate_set with symbolic dim is required by the MLIR verifier
+        # when the memref has a dynamic dimension.
+        op = self._parse(
+            "%view = ktdp.construct_memory_view %ptr, sizes: [%n_idx], strides: [1]"
+            " { coordinate_set = affine_set<(d0)[s0] : (d0 >= 0, -d0 + s0 - 1 >= 0)>,"
+            " memory_space = #ktdp.spyre_memory_space<HBM> } : memref<?xf32>",
+            args={"%ptr": "index", "%n_idx": "index"},
+        )
+        # %ptr + %n_idx = 2 operands
+        self.assert_num_operands(op, 2)
+        self.assert_operand_names(op, "%ptr", "%n_idx")
+
+    def test_construct_access_tile_dynamic_memref(self):
+        # construct_access_tile already handles memref<?xf32> correctly:
+        # it reads shape only from the !ktdp.access_tile<...> result type,
+        # never from the memref type, so '?' passes through without issue.
+        op = self._parse(
+            "%x_tile = ktdp.construct_access_tile %x_mem[%off_idx]"
+            " { access_tile_order = affine_map<(d0) -> (d0)>,"
+            "   access_tile_set = affine_set<(d0) : (d0 >= 0, -d0 + 1023 >= 0)> }"
+            " : memref<?xf32> -> !ktdp.access_tile<1024xindex>",
+            args={"%x_mem": "memref<?xf32>", "%off_idx": "index"},
+        )
+        self.assert_op_type(op, "ktdp.construct_access_tile")
+        self.assert_attribute(op, "shape", (1024,))
+
 
 # ---------------------------------------------------------------------------
 # scf dialect parsers

--- a/tests/test_dialects_parse.py
+++ b/tests/test_dialects_parse.py
@@ -566,6 +566,79 @@ class TestKtdpParsers(ParseTestMixin):
         self.assert_num_operands(op, 2)
         self.assert_operand_names(op, "%ptr", "%n_idx")
 
+    def test_construct_memory_view_multi_dim_mixed_static_dynamic(self):
+        # Multi-dim memref with one static and one dynamic dimension.
+        # sizes: [1024, %n] — first dim matches the concrete memref dim,
+        # second dim is an SSA name for the '?' dim.
+        op = self._parse(
+            "%view = ktdp.construct_memory_view %ptr, sizes: [1024, %n], strides: [%n, 1]"
+            " { coordinate_set = affine_set<(d0, d1)[s0] : (d0 >= 0, -d0 + 1023 >= 0,"
+            " d1 >= 0, -d1 + s0 - 1 >= 0)>,"
+            " memory_space = #ktdp.spyre_memory_space<HBM> } : memref<1024x?xf16>",
+            args={"%ptr": "index", "%n": "index"},
+        )
+        self.assert_op_type(op, "ktdp.construct_memory_view")
+        self.assert_attribute(op, "dtype", "f16")
+        # Only assert the concrete dim — the dynamic dim is represented as the
+        # SSA name string "%n" by the regex parser, and as the ShapedType
+        # sentinel by the MLIR frontend.
+        shape = op.attributes["shape"]
+        assert shape[0] == 1024
+        assert len(shape) == 2
+
+    @pytest.mark.regex_only
+    def test_construct_memory_view_sizes_count_mismatch_rejected(self):
+        # sizes: has 2 entries but memref<1024xf16> has only 1 dimension.
+        with pytest.raises(ValueError, match=r"sizes count.*does not match|mismatch"):
+            self._parse(
+                "%view = ktdp.construct_memory_view %ptr, sizes: [1024, 32], strides: [1]"
+                " { memory_space = #ktdp.spyre_memory_space<HBM> } : memref<1024xf16>",
+                args={"%ptr": "index"},
+            )
+
+    @pytest.mark.regex_only
+    def test_construct_memory_view_static_dim_mismatch_rejected(self):
+        # sizes: [512] disagrees with the concrete memref dim 1024.
+        with pytest.raises(ValueError, match=r"sizes\[0\]=512 does not match memref dimension 1024"):
+            self._parse(
+                "%view = ktdp.construct_memory_view %ptr, sizes: [512], strides: [1]"
+                " { memory_space = #ktdp.spyre_memory_space<HBM> } : memref<1024xf16>",
+                args={"%ptr": "index"},
+            )
+
+    @pytest.mark.regex_only
+    @pytest.mark.parametrize("sizes_str,memref_type,strides_str,args", [
+        # 1-D: single dynamic dim given a concrete literal
+        ("[512]",      "memref<?xf16>",       "[1]",    {"%ptr": "index"}),
+        # 2-D: first dim dynamic, second static — literal given for the '?' dim
+        ("[512, 32]",  "memref<?x32xf16>",    "[32, 1]", {"%ptr": "index"}),
+        # 2-D: second dim dynamic, first static — literal given for the '?' dim
+        ("[1024, 32]", "memref<1024x?xf16>",  "[32, 1]", {"%ptr": "index"}),
+        # 2-D: both dims dynamic — literals given for both '?' dims
+        ("[512, 32]",  "memref<?x?xf16>",     "[32, 1]", {"%ptr": "index"}),
+    ])
+    def test_construct_memory_view_dynamic_dim_with_concrete_size_rejected(
+        self, sizes_str, memref_type, strides_str, args
+    ):
+        # A '?' dim must be given an SSA name in sizes:, not a concrete literal.
+        with pytest.raises(ValueError, match=r"dynamic dim.*requires.*SSA|'\\?' dim.*must be.*SSA"):
+            self._parse(
+                f"%view = ktdp.construct_memory_view %ptr, sizes: {sizes_str},"
+                f" strides: {strides_str}"
+                f" {{ memory_space = #ktdp.spyre_memory_space<HBM> }} : {memref_type}",
+                args=args,
+            )
+
+    @pytest.mark.regex_only
+    def test_construct_memory_view_dynamic_dim_no_sizes_rejected(self):
+        # No sizes: attribute at all, but memref has a '?' dim — unresolvable at parse time.
+        with pytest.raises(ValueError, match=r"dynamic dim|'\\?' dim|no sizes"):
+            self._parse(
+                "%view = ktdp.construct_memory_view %ptr, strides: [1]"
+                " { memory_space = #ktdp.spyre_memory_space<HBM> } : memref<?xf16>",
+                args={"%ptr": "index"},
+            )
+
     def test_construct_access_tile_dynamic_memref(self):
         # construct_access_tile already handles memref<?xf32> correctly:
         # it reads shape only from the !ktdp.access_tile<...> result type,

--- a/tests/test_dialects_parse.py
+++ b/tests/test_dialects_parse.py
@@ -525,7 +525,6 @@ class TestKtdpParsers(ParseTestMixin):
     def test_affine_set_with_symbolic_dim(self):
         # affine_set<(d0)[s0] : (d0 >= 0, -d0 + s0 - 1 >= 0)> uses a symbolic
         # dimension s0 whose value is only known at runtime (the tensor size).
-        # The current parser raises ValueError on the unknown token 's0'.
         op = self._parse(
             "%view = ktdp.construct_memory_view %ptr, sizes: [%n_idx], strides: [1]"
             " { coordinate_set = affine_set<(d0)[s0] : (d0 >= 0, -d0 + s0 - 1 >= 0)>,"
@@ -535,8 +534,7 @@ class TestKtdpParsers(ParseTestMixin):
         self.assert_op_type(op, "ktdp.construct_memory_view")
         self.assert_attribute(op, "dtype", "f32")
         self.assert_attribute(op, "memory_space", "HBM")
-        # shape should be dynamic (None or -1 convention TBD)
-        # operands must include both %ptr and %n_idx
+        # dynamic dim stored as the SSA name string "%n_idx" in the shape tuple
         self.assert_num_operands(op, 2)
 
     def test_construct_memory_view_dynamic_memref_type(self):

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -191,6 +191,34 @@ class TestVectorAddExecution(InterpreterTestMixin):
         np.testing.assert_allclose(result, expected, rtol=1e-2, atol=1e-2)
 
 
+class TestVectorAddDynamicExecution(InterpreterTestMixin):
+    """End-to-end execution of vector_add_dynamic_ktir.mlir.
+
+    Verifies that a symbolic coordinate set (memref<?xf32>) correctly masks
+    out-of-range elements through ktdp.load / ktdp.store for varying n_elements.
+    """
+
+    @pytest.mark.parametrize("path,func_name,entry", get_test_params("add_kernel_dynamic"))
+    def test_vector_add_dynamic(self, path, func_name, entry):
+        interp = self._make_interp()
+        interp.load(path)
+
+        x_ptr, y_ptr, output_ptr, n_elements = interp.arg_names(func_name)
+        n = entry["execute_kwargs"]["n_elements"]
+        rng = np.random.default_rng(42)
+        x = rng.standard_normal(n).astype(np.float32)
+        y = rng.standard_normal(n).astype(np.float32)
+        output = np.zeros(n, dtype=np.float32)
+
+        outputs = interp.execute_function(func_name, **{
+            x_ptr: x, y_ptr: y, output_ptr: output,
+            n_elements: np.int32(n),
+        })
+
+        result = outputs[output_ptr]
+        np.testing.assert_allclose(result, x + y, rtol=1e-5, atol=1e-5)
+
+
 class TestSoftmaxExecution(InterpreterTestMixin):
     """End-to-end execution of softmax MLIR."""
 


### PR DESCRIPTION
Redoing #30 because the original PR had some problems. @lchu6 if you can approve this I will go ahead to merge. Its basically the same thing as #30