### PR TITLE
Implement ktdp.construct_distributed_memory_view (fixes #1)

### DIFF
--- a/docs/gap_analysis.md
+++ b/docs/gap_analysis.md
@@ -11,7 +11,7 @@
 
 | # | Spec Operation | Status | Notes |
 |---|---------------|--------|-------|
-| 1 | `ktdp.construct_distributed_memory_view` | ❌ | No handler, no parser. Key primitive for composing multiple per-partition memory views into a single distributed logical view. Critical for modeling distributed scratchpads. |
+| 1 | `ktdp.construct_distributed_memory_view` | ✅ | Handler and parser implemented in `ktir_cpu/dialects/ktdp_ops.py`; produces `DistributedMemRef` (composition of N per-partition `MemRef`s). Per-partition routing at access time via `MemoryOps.distributed_tile_access` → `DistributedTileRef`. Tests in `tests/test_distributed_view.py`. |
 | 2 | `ktdp.construct_indirect_access_tile` | ✅ | Handler and parser implemented in `ktir_cpu/dialects/ktdp_ops.py`; tests passing in `tests/test_indirect_access.py`. |
 
 ## B. `ktdp` Types & Attributes
@@ -131,7 +131,6 @@ The spec explicitly mentions `memref.subview` for view-based transformations. **
 ### High Priority
 Blocks running spec-compliant KTIR programs:
 
-- **#1**: ❌ `construct_distributed_memory_view`
 - **#25**: ❌ `linalg.add` — used in the spec's primary example and won't execute
 - **#5**: 🟡 `coordinate_set` on memory views preserved but not enforced
 
@@ -173,8 +172,6 @@ Significant progress since the original writeup:
 
 Remaining notable gaps:
 
-- `ktdp.construct_distributed_memory_view` (#1) is still the largest missing
-  ktdp op; it blocks distributed scratchpad modeling.
 - `linalg.add` (#25) is still missing — the RFC's canonical matrix-add example
   cannot execute without it.
 - `coordinate_set` on memory views (#5) is preserved in the IR but not used
@@ -191,7 +188,7 @@ The initial phases of this roadmap are complete. The conformance target was esta
 Goal: cover the RFC-defined `ktdp` surface.
 
 - ✅ Implement `ktdp.construct_indirect_access_tile`.
-- ❌ Implement `ktdp.construct_distributed_memory_view`.
+- ✅ Implement `ktdp.construct_distributed_memory_view`.
 - Add validation rules for:
   matching dimensionalities,
   allowed direct versus indirect dimensions,
@@ -294,7 +291,7 @@ If we want the fastest path to meaningful conformance progress:
 1. ✅ Build the first-class access-tile IR and affine evaluator.
 2. ✅ Rework `ktdp.load` / `ktdp.store` around that representation.
 3. ✅ Add `construct_indirect_access_tile`.
-4. ❌ Add `construct_distributed_memory_view`.
+4. ✅ Add `construct_distributed_memory_view`.
 5. ❌ Add `linalg.add`, `tensor.extract_slice`, and `memref.subview`.
 6. ❌ Fill in the missing RFC-listed SCF ops.
 7. ❌ Expand broader Arith/Math/Linalg coverage as compiler demand appears.
@@ -305,6 +302,6 @@ A strong first milestone would be:
 
 - ✅ affine attributes are preserved and exercised in tests
 - ✅ `ktdp.load` / `ktdp.store` operate over real coordinate collections
-- 🟡 all RFC-defined `ktdp` ops parse and execute (`construct_distributed_memory_view` still missing)
+- ✅ all RFC-defined `ktdp` ops parse and execute
 - ❌ the RFC matrix-add example can run with only mechanical syntax adaptation
 - ❌ the repo has explicit tests for unsupported versus supported RFC surface

--- a/examples/rfc/distributed-view-copy.mlir
+++ b/examples/rfc/distributed-view-copy.mlir
@@ -2,8 +2,19 @@
 // This is an example program to illustrate the use of ktdp.construct_distributed_memory_view.
 // The program copies a distributed tensor A (partitioned across HBM and two LX scratchpads)
 // into a contiguous output tensor B on HBM.
-// NOTE: Copied from KTIR-V1.ppt slide 9 - construct distributed memory view
-// NOTE: Minor correction #ktpd.spyre_memory_space<LX0> -> LX
+// NOTE: Copied from KTIR-V1.ppt slide 9 - construct distributed memory view.
+// NOTE: Minor correction #ktpd.spyre_memory_space<LX0> -> LX.
+// NOTE: The two LX partitions are tagged with distinct `core = N` indices
+//       per the KTDP ODS `#ktdp.spyre_memory_space<LX, core = N>` form
+//       (KernelTileIR/src/Dialects/KTDP/KTDPOps.td:68-104).  In real hardware
+//       each compute core has its own private LX SRAM, so A_LX0's and
+//       A_LX1's byte-address spaces are independent and both bases could
+//       naturally be 0 (a common layout in real kernels).
+// NOTE: Simulator caveat — ktir-cpu does not yet honor the `core = N`
+//       index: every `<LX, core = *>` memref resolves to the currently
+//       executing core's single scratchpad.  This test is marked xfail
+//       until per-core LX routing is implemented.  Once it lands, all
+//       three partition bases can collapse to 0.
 
 // A is a 192x64 logical tensor partitioned across three memory spaces:
 //   A_HBM  = rows   0..95,  stored on HBM,  row-major    (96x64)
@@ -19,7 +30,7 @@
 #var_space_order = affine_map<(d0, d1) -> (d0, d1)>
 
 module {
-  func.func @distributed_view_copy() {
+  func.func @distributed_view_copy() attributes { grid = [2, 1, 1] } {
 
         %c0 = arith.constant 0 : index
 
@@ -51,12 +62,12 @@ module {
         // Note: column-major layout expressed via strides [1, 64]
         %A_LX0_view = ktdp.construct_memory_view %A_LX0_addr, sizes: [32, 64], strides: [1, 64] {
             coordinate_set = #A_LX0_coord_set,
-            memory_space = #ktdp.spyre_memory_space<LX>
+            memory_space = #ktdp.spyre_memory_space<LX, core = 0>
         } : memref<32x64xf16>
 
         %A_LX1_view = ktdp.construct_memory_view %A_LX1_addr, sizes: [64, 64], strides: [64, 1] {
             coordinate_set = #A_LX1_coord_set,
-            memory_space = #ktdp.spyre_memory_space<LX>
+            memory_space = #ktdp.spyre_memory_space<LX, core = 1>
         } : memref<64x64xf16>
 
         // (1) Compose the three partition views into a single logical distributed view of shape 192x64

--- a/ktir_cpu/affine.py
+++ b/ktir_cpu/affine.py
@@ -22,13 +22,54 @@ delegate there.
 Types
 -----
 AffineMap   — represents affine_map<(d0,...) -> (e0,...)>
-AffineSet   — represents affine_set<(d0,...) : (c0 >= 0, ...)>
+AffineSet   — represents affine_set<(d0,...)[s0,...] : (c0 >= 0, ...)>
+BoxSet      — axis-aligned specialisation of AffineSet; O(ndim) ops.
+
+Relationship between AffineSet and BoxSet
+-----------------------------------------
+``BoxSet`` is the axis-aligned specialisation of ``AffineSet``.  Every
+``BoxSet`` could equivalently be expressed as an ``AffineSet`` with
+per-axis inequalities, but the explicit ``(lo, hi)`` form makes
+``contains`` / ``enumerate`` / ``intersect`` / ``translate`` /
+``lower_bounds`` / ``is_empty`` / ``is_full`` all O(ndim) with no
+constraint-AST walk.
+
+They are peer dataclasses under a ``Union``, NOT a class hierarchy:
+structural fast paths must be visible at each call site via
+``isinstance`` dispatch.  Mixed-type operations (e.g.
+``BoxSet.intersect(AffineSet)``) raise ``TypeError`` — there is no
+auto-promotion.
+
+Parse-time lowering: ``parse_affine_set`` (in ``parser_ast.py``) lowers
+axis-aligned, fully-pinned, unit-coefficient, non-symbolic sets to
+``BoxSet`` via :meth:`BoxSet.try_from_affine_set`.  Other sets stay as
+``AffineSet``.  ``parse_affine_set_raw`` skips the lowering for tests
+that need to inspect the AST directly.
+
+TODO: BoxSet does not yet compose with AffineSet's ``n_syms`` /
+``symbols`` parameters (added in PR #42 for dynamic-shape symbolic
+bounds).  ``try_from_affine_set`` currently rejects symbolic sets
+(``n_syms > 0``) so they stay on the AffineSet branch.  When symbolic
+boxes are needed, ``BoxSet.lo``/``hi`` will need to accept symbolic
+expressions and ``contains``/``enumerate`` will need to take a
+``symbols`` argument.
+
+TODO: ``parse_affine_set_raw`` (in ``parser_ast.py``) exists only because
+``parse_affine_set`` now lowers axis-aligned inputs to ``BoxSet`` by
+default, and ``test_ast.py`` needs raw ``AffineSet`` access to inspect
+``.constraints`` / ``.source`` / ``.n_syms``.  A cleaner shape is to
+refactor ``BoxSet.try_from_affine_set`` to parse directly from the
+source string (skipping the AST round-trip and ``_constraint_to_linear``
+entirely), at which point ``parse_affine_set_raw`` collapses into the
+underlying AST parser and can be retired from the public API.  Defer
+until after C4 to keep this commit faithful to backup.
 """
 
 from __future__ import annotations
 
+import itertools
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, List, Sequence, Tuple
+from typing import TYPE_CHECKING, List, Optional, Sequence, Tuple
 
 if TYPE_CHECKING:
     # Avoid circular import at runtime; parser_ast imports nothing from here.
@@ -129,3 +170,199 @@ class AffineSet:
         import itertools as _it
         corners = _it.product(*((0, n - 1) for n in shape))
         return all(self.contains(pt) for pt in corners)
+
+
+@dataclass(frozen=True)
+class BoxSet:
+    """Axis-aligned integer hyperrectangle: ``{p : lo[d] <= p[d] < hi[d]}``.
+
+    The axis-aligned specialisation of :class:`AffineSet`: every ``BoxSet``
+    could equivalently be written as an ``AffineSet`` with per-axis
+    inequalities, but carrying the ``(lo, hi)`` structure explicitly makes
+    every operation (``contains``, ``enumerate``, ``is_empty``, ``is_full``,
+    ``lower_bounds``, ``translate``, ``intersect``) O(ndim) with no
+    constraint-AST walk.  Used for partition extents (``B_i``), access tile
+    sets (``A``), and their intersections (``C_i``) in
+    ``distributed_tile_access``; the parser lowers axis-aligned affine sets
+    to this form at parse time (see ``try_from_affine_set``).
+
+    ``BoxSet`` and ``AffineSet`` are peer dataclasses under a ``Union``
+    rather than parent/child classes — structural fast paths must be
+    visible at each call site via ``isinstance`` dispatch, not hidden
+    behind polymorphism.  Mixed-type operations — e.g.
+    ``BoxSet.intersect(aset: AffineSet)`` — raise ``TypeError``.
+    """
+    lo: Tuple[int, ...]   # inclusive
+    hi: Tuple[int, ...]   # exclusive
+
+    def __post_init__(self) -> None:
+        if len(self.lo) != len(self.hi):
+            raise ValueError(
+                f"BoxSet: lo/hi length mismatch: lo={self.lo} hi={self.hi}"
+            )
+
+    @property
+    def n_dims(self) -> int:
+        return len(self.lo)
+
+    def contains(self, point: Sequence[int]) -> bool:
+        """True iff ``lo[d] <= point[d] < hi[d]`` for every dim."""
+        if len(point) != self.n_dims:
+            return False
+        return all(self.lo[d] <= point[d] < self.hi[d] for d in range(self.n_dims))
+
+    def enumerate(self, shape: Optional[Tuple[int, ...]] = None) -> List[Tuple[int, ...]]:
+        """Return all integer points in the box in row-major order.
+
+        ``shape`` is accepted for signature parity with
+        :meth:`AffineSet.enumerate` (which needs an external bounding box
+        for its brute-force iteration).  A ``BoxSet`` is self-bounded,
+        so ``shape`` only serves as a sanity check: passed values must
+        upper-bound ``hi`` componentwise.
+        """
+        if shape is not None:
+            if len(shape) != self.n_dims:
+                raise ValueError(
+                    f"BoxSet.enumerate: shape ndim {len(shape)} does not "
+                    f"match box ndim {self.n_dims}"
+                )
+            for d in range(self.n_dims):
+                if self.hi[d] > shape[d]:
+                    raise ValueError(
+                        f"BoxSet.enumerate: hi[{d}]={self.hi[d]} exceeds "
+                        f"shape[{d}]={shape[d]} — box is not contained in "
+                        f"the nominal bounding box."
+                    )
+        return list(itertools.product(*(range(self.lo[d], self.hi[d]) for d in range(self.n_dims))))
+
+    def is_empty(self) -> bool:
+        """True iff any axis has ``hi[d] <= lo[d]`` (i.e. empty extent)."""
+        return any(self.hi[d] <= self.lo[d] for d in range(self.n_dims))
+
+    def is_full(self, shape: Tuple[int, ...]) -> bool:
+        """True iff this box equals ``[0, shape)``."""
+        if len(shape) != self.n_dims:
+            return False
+        return self.lo == (0,) * self.n_dims and tuple(self.hi) == tuple(shape)
+
+    def lower_bounds(self) -> Tuple[int, ...]:
+        """Return ``lo`` — the per-axis minimum coordinate, O(1)."""
+        return self.lo
+
+    def translate(self, offset: Sequence[int]) -> "BoxSet":
+        """Return a new box shifted by *offset* along each axis."""
+        if len(offset) != self.n_dims:
+            raise ValueError(
+                f"BoxSet.translate: offset dim mismatch: "
+                f"offset={tuple(offset)} n_dims={self.n_dims}"
+            )
+        return BoxSet(
+            lo=tuple(self.lo[d] + offset[d] for d in range(self.n_dims)),
+            hi=tuple(self.hi[d] + offset[d] for d in range(self.n_dims)),
+        )
+
+    def intersect(self, other: "BoxSet") -> "BoxSet":
+        """Axis-wise intersection; result may be empty (``is_empty()``)."""
+        if not isinstance(other, BoxSet):
+            raise TypeError(
+                f"BoxSet.intersect: mixed-type intersection not supported "
+                f"(other is {type(other).__name__}).  Box and AffineSet are "
+                f"structural peers, not interchangeable."
+            )
+        if other.n_dims != self.n_dims:
+            raise ValueError(
+                f"BoxSet.intersect: n_dims mismatch {self.n_dims} vs {other.n_dims}"
+            )
+        return BoxSet(
+            lo=tuple(max(self.lo[d], other.lo[d]) for d in range(self.n_dims)),
+            hi=tuple(min(self.hi[d], other.hi[d]) for d in range(self.n_dims)),
+        )
+
+    @classmethod
+    def try_from_affine_set(cls, aset: "AffineSet") -> Optional["BoxSet"]:
+        """Lower an axis-aligned :class:`AffineSet` to a ``BoxSet``.
+
+        Returns ``None`` when the set is not representable as an integer
+        box.  Lowering succeeds iff every constraint has the form
+        ``c * d_i + k >= 0`` with ``c ∈ {+1, -1}`` (single dim, unit coeff)
+        and every axis is pinned on **both** sides (at least one ``+d_i``
+        and one ``-d_i`` constraint).
+
+        TODO: symbolic sets (``aset.n_syms > 0``, added by PR #42 for
+        dynamic shapes) are rejected here — they stay on the AffineSet
+        branch.  Lifting this would require BoxSet to carry symbolic
+        bounds and a ``symbols`` argument on contains/enumerate to
+        compose with AffineSet's signature.  ``getattr`` keeps this
+        correct on older AffineSet objects without ``n_syms``.
+        """
+        if getattr(aset, "n_syms", 0) != 0:
+            return None
+        n = aset.n_dims
+        los: List[Optional[int]] = [None] * n
+        his: List[Optional[int]] = [None] * n
+        for c in aset.constraints:
+            lin = _constraint_to_linear(c, n)
+            if lin is None:
+                return None
+            coeffs, const = lin
+            nz = [i for i, k in enumerate(coeffs) if k != 0]
+            if len(nz) != 1:
+                return None
+            i = nz[0]
+            k = coeffs[i]
+            if k == 1:
+                # d_i + const >= 0  →  d_i >= -const
+                candidate = -const
+                los[i] = candidate if los[i] is None else max(los[i], candidate)
+            elif k == -1:
+                # -d_i + const >= 0  →  d_i <= const  →  hi = const + 1
+                candidate = const + 1
+                his[i] = candidate if his[i] is None else min(his[i], candidate)
+            else:
+                return None
+        if any(v is None for v in los) or any(v is None for v in his):
+            return None
+        return cls(lo=tuple(los), hi=tuple(his))  # type: ignore[arg-type]
+
+
+def _constraint_to_linear(node: "_Node", n_dims: int) -> Optional[Tuple[List[int], int]]:
+    """Flatten a parsed constraint AST into ``(coeffs, const)``.
+
+    Returns ``None`` if the expression isn't a pure linear combination of
+    dimension variables and integer constants (e.g. contains ``sym`` or
+    ``ref`` atoms).  The constraint represents
+    ``sum(coeffs[i] * d_i) + const >= 0``.
+    """
+    coeffs = [0] * n_dims
+    const_box = [0]
+
+    def walk(n: "_Node", sign: int) -> bool:
+        tag = n[0]
+        if tag == "const":
+            const_box[0] += sign * n[1]
+            return True
+        if tag == "dim":
+            coeffs[n[1]] += sign
+            return True
+        if tag == "add":
+            return walk(n[1], sign) and walk(n[2], sign)
+        if tag == "sub":
+            return walk(n[1], sign) and walk(n[2], -sign)
+        if tag == "neg":
+            return walk(n[1], -sign)
+        if tag == "mul":
+            coef = n[1]
+            inner = n[2]
+            if inner[0] == "dim":
+                coeffs[inner[1]] += sign * coef
+                return True
+            if inner[0] == "const":
+                const_box[0] += sign * coef * inner[1]
+                return True
+            return False
+        # 'sym', 'ref', or anything else — not a linear combination of dims.
+        return False
+
+    if not walk(node, 1):
+        return None
+    return coeffs, const_box[0]

--- a/ktir_cpu/dialects/ktdp_ops.py
+++ b/ktir_cpu/dialects/ktdp_ops.py
@@ -27,6 +27,8 @@ from ..ir_types import (
     Tile,
 )
 from ..latency import LatencyCategory as LC
+from ..ops.arith_ops import ArithOps
+from ..ops.comm_ops import CommOps
 from ..ops.grid_ops import GridOps
 from ..ops.memory_ops import MemoryOps
 from ..parser_ast import parse_affine_map, parse_affine_set
@@ -66,7 +68,8 @@ def ktdp__construct_memory_view(op, context, env):
     memory_space = op.attributes["memory_space"]
     dtype = op.attributes["dtype"]
     coordinate_set = op.attributes.get("coordinate_set")
-    return MemoryOps.tile_view(context, ptr, shape, strides, memory_space, dtype, coordinate_set)
+    lx_core_id = op.attributes.get("lx_core_id") if memory_space == "LX" else None
+    return MemoryOps.tile_view(context, ptr, shape, strides, memory_space, dtype, coordinate_set, lx_core_id)
 
 
 @register("ktdp.construct_distributed_memory_view")
@@ -245,9 +248,19 @@ def parse_construct_memory_view(op_text, parse_ctx: ParseContext):
         strides = parsed
 
     memory_space = "HBM"
-    mem_match = re.search(r'#ktdp\.spyre_memory_space<(\w+)>', op_text)
+    lx_core_id = None
+    # Accept both `<HBM>`/`<LX>` and the RFC's per-core LX form
+    # `<LX, core = N>`.  On real hardware each compute core has its own
+    # private LX SRAM, so a partition tagged `core = N` lives in core N's
+    # scratchpad — captured into lx_core_id and used at load/store time.
+    mem_match = re.search(
+        r'#ktdp\.spyre_memory_space<\s*(\w+)(?:\s*,\s*core\s*=\s*(\d+))?\s*>',
+        op_text,
+    )
     if mem_match:
         memory_space = mem_match.group(1)
+        if mem_match.group(2) is not None:
+            lx_core_id = int(mem_match.group(2))
 
     # dtype and shape are parsed from the memref result type.
     # Validate sizes against memref dimensions when both are concrete.
@@ -306,6 +319,8 @@ def parse_construct_memory_view(op_text, parse_ctx: ParseContext):
         "memory_space": memory_space,
         "dtype": dtype,
     }
+    if lx_core_id is not None:
+        attributes["lx_core_id"] = lx_core_id
     if coordinate_set is not None:
         attributes["coordinate_set"] = coordinate_set
 
@@ -736,3 +751,23 @@ def parse_construct_indirect_access_tile(op_text, parse_ctx: ParseContext):
     )
 
 
+
+
+# ---------------------------------------------------------------------------
+# Communication ops (moved from scf_ops.py)
+# ---------------------------------------------------------------------------
+
+@register("ktdp.transfer", latency_category=LC.COMM)
+def ktdp__transfer(op, context, env):
+    tile = context.get_value(op.operands[0])
+    dst_cores = context.get_value(op.operands[1])
+    CommOps.transfer(context, tile, dst_cores, env.ring_backend)
+    return None
+
+
+@register("ktdp.reduce", latency_category=LC.COMM)
+def ktdp__reduce(op, context, env):
+    tile = context.get_value(op.operands[0])
+    core_group = context.get_value(op.operands[1])
+    reduce_fn = lambda t1, t2: ArithOps.addf(t1, t2)
+    return CommOps.reduce(context, tile, core_group, reduce_fn, env.ring_backend)

--- a/ktir_cpu/dialects/ktdp_ops.py
+++ b/ktir_cpu/dialects/ktdp_ops.py
@@ -17,7 +17,15 @@
 import re
 
 from .ktdp_helpers import parse_subscript_expr
-from ..ir_types import AccessTile, IndirectAccessTile, Operation, Tile
+from ..ir_types import (
+    AccessTile,
+    DistributedMemRef,
+    DistributedTileRef,
+    IndirectAccessTile,
+    MemRef,
+    Operation,
+    Tile,
+)
 from ..latency import LatencyCategory as LC
 from ..ops.grid_ops import GridOps
 from ..ops.memory_ops import MemoryOps
@@ -61,6 +69,33 @@ def ktdp__construct_memory_view(op, context, env):
     return MemoryOps.tile_view(context, ptr, shape, strides, memory_space, dtype, coordinate_set)
 
 
+@register("ktdp.construct_distributed_memory_view")
+def ktdp__construct_distributed_memory_view(op, context, env):
+    """Compose N per-partition memory views into one distributed view.
+
+    Each operand must resolve to a :class:`MemRef` carrying its own
+    ``coordinate_set`` (= B_i in global coords).  The op does not allocate
+    or move data — partition resolution at access time is performed by
+    ``MemoryOps.distributed_tile_access``.
+    """
+    partitions = [context.get_value(name) for name in op.operands]
+    for i, p in enumerate(partitions):
+        if not isinstance(p, MemRef):
+            raise ValueError(
+                f"construct_distributed_memory_view: operand {i} "
+                f"is {type(p).__name__}, expected MemRef"
+            )
+    if "shape" not in op.attributes or "dtype" not in op.attributes:
+        raise ValueError(
+            "construct_distributed_memory_view: missing required attributes 'shape'/'dtype'"
+        )
+    return DistributedMemRef(
+        partitions=partitions,
+        shape=tuple(op.attributes["shape"]),
+        dtype=op.attributes["dtype"],
+    )
+
+
 @register("ktdp.construct_access_tile")
 def ktdp__construct_access_tile(op, context, env):
     parent_ref = context.get_value(op.operands[0])
@@ -72,12 +107,27 @@ def ktdp__construct_access_tile(op, context, env):
     # Pass it to tile_access so the offset is computed via affine evaluation rather than
     # the old rectangular sum(idx * stride) shortcut.
     base_map = op.attributes["base_map"]
+    coordinate_set = op.attributes.get("coordinate_set")
+    if isinstance(parent_ref, DistributedMemRef):
+        # Distributed parent: resolve partition routing now and produce a
+        # DistributedTileRef carrying surviving partitions.  Load/store
+        # consume it directly.
+        dist_tile_ref = MemoryOps.distributed_tile_access(
+            parent_ref, access_shape, base_map, indices, access_tile_set=coordinate_set
+        )
+        return AccessTile(
+            parent_ref=dist_tile_ref,
+            shape=access_shape,
+            base_map=base_map,
+            coordinate_set=coordinate_set,
+            coordinate_order=op.attributes.get("coordinate_order"),
+        )
     tile_ref = MemoryOps.tile_access(context, parent_ref, indices, access_shape, base_map)
     return AccessTile(
         parent_ref=tile_ref,
         shape=access_shape,
         base_map=base_map,
-        coordinate_set=op.attributes.get("coordinate_set"),
+        coordinate_set=coordinate_set,
         coordinate_order=op.attributes.get("coordinate_order"),
     )
 
@@ -88,6 +138,11 @@ def ktdp__load(op, context, env):
     if isinstance(access_tile, IndirectAccessTile):
         result_shape = op.attributes.get("_result_shape", access_tile.shape)
         return MemoryOps.indirect_load(context, access_tile, result_shape=result_shape)
+    if isinstance(access_tile.parent_ref, DistributedTileRef):
+        result_shape = op.attributes.get("_result_shape", access_tile.shape)
+        return MemoryOps.distributed_load(
+            context, access_tile.parent_ref, result_shape=result_shape
+        )
     css = access_tile.coordinate_set    # AffineSet | None
     cso = access_tile.coordinate_order  # AffineMap | None
     if css is not None:
@@ -106,6 +161,9 @@ def ktdp__store(op, context, env):
     access_tile = context.get_value(op.operands[1])
     if isinstance(access_tile, IndirectAccessTile):
         raise NotImplementedError("ktdp.store with IndirectAccessTile is not yet supported")
+    if isinstance(access_tile.parent_ref, DistributedTileRef):
+        MemoryOps.distributed_store(context, value, access_tile.parent_ref)
+        return None
     tile_ref = access_tile.parent_ref
     css = access_tile.coordinate_set
     cso = access_tile.coordinate_order
@@ -257,6 +315,80 @@ def parse_construct_memory_view(op_text, parse_ctx: ParseContext):
         operands=[ptr_operand] + ssa_size_operands + ssa_stride_operands,
         attributes=attributes,
         result_type=f"memref<{'x'.join(str(s) if isinstance(s, int) else '?' for s in shape)}x{dtype}>"
+    )
+
+
+@register_parser("ktdp.construct_distributed_memory_view")
+def parse_construct_distributed_memory_view(op_text, parse_ctx: ParseContext):
+    """Parse ``%R = ktdp.construct_distributed_memory_view (%a, %b, ... : types) : memref<...>``.
+
+    Variadic memref operands, no required attributes — each input carries
+    its own ``coordinate_set`` (on the input's ``construct_memory_view``).
+    Result type encodes the global logical shape and dtype.
+    """
+    result_match = re.match(
+        r'(%\w+)\s*=\s*ktdp\.construct_distributed_memory_view', op_text
+    )
+    if not result_match:
+        return None
+
+    result_name = result_match.group(1)
+
+    # Extract operand list from the first parenthesized block.  The block's
+    # content is "<%ops> : <types>"; we only need the %ops portion.
+    paren_start = op_text.find('(', result_match.end())
+    if paren_start == -1:
+        raise ValueError(
+            "construct_distributed_memory_view: missing operand parenthesis"
+        )
+    inner = _extract_bracket_content(op_text[paren_start:], '()')
+    if inner is None:
+        raise ValueError(
+            "construct_distributed_memory_view: unbalanced operand parenthesis"
+        )
+    # Split on the first top-level ':' to separate operands from types.
+    colon_idx = None
+    depth = 0
+    for i, ch in enumerate(inner):
+        if ch in '([<':
+            depth += 1
+        elif ch in ')]>':
+            depth -= 1
+        elif ch == ':' and depth == 0:
+            colon_idx = i
+            break
+    ops_section = inner if colon_idx is None else inner[:colon_idx]
+    operands = [
+        t.strip() for t in split_top_level(ops_section) if t.strip().startswith('%')
+    ]
+    if not operands:
+        raise ValueError(
+            "construct_distributed_memory_view: no memref operands found"
+        )
+
+    # Parse the result memref type: same pattern as construct_memory_view.
+    memref_match = re.search(
+        r'(?:}\s*)?:\s*memref<([^>]+)>\s*$', op_text.rstrip()
+    )
+    if not memref_match:
+        raise ValueError(
+            "construct_distributed_memory_view: could not parse result memref<> type"
+        )
+    parts = memref_match.group(1).split('x')
+    if len(parts) <= 1:
+        raise ValueError(
+            f"construct_distributed_memory_view: memref<{memref_match.group(1)}> "
+            "has no dimensions"
+        )
+    dtype = parts[-1]
+    shape = tuple(int(p) for p in parts[:-1])
+
+    return Operation(
+        result=result_name,
+        op_type="ktdp.construct_distributed_memory_view",
+        operands=operands,
+        attributes={"shape": shape, "dtype": dtype},
+        result_type=f"memref<{'x'.join(str(s) for s in shape)}x{dtype}>"
     )
 
 

--- a/ktir_cpu/dialects/registry.py
+++ b/ktir_cpu/dialects/registry.py
@@ -25,7 +25,7 @@ from typing import Any, Callable, Dict, List, Optional
 
 from ..grid import CoreContext, GridExecutor
 from ..ir_types import Operation
-from ..ops.comm_ops import RingNetwork
+from ..ops.comm_ops import RingBackend
 
 # ---------------------------------------------------------------------------
 # Execution handler registry
@@ -136,5 +136,5 @@ class ExecutionEnv:
     """Lightweight bag of core-external resources passed to handlers."""
 
     grid_executor: GridExecutor
-    ring: RingNetwork
+    ring_backend: RingBackend
     execute_region: Callable[[CoreContext, List[Operation]], Any]

--- a/ktir_cpu/dialects/scf_ops.py
+++ b/ktir_cpu/dialects/scf_ops.py
@@ -18,8 +18,6 @@ import re
 
 from ..ir_types import Operation
 from ..latency import LatencyCategory as LC
-from ..ops.comm_ops import CommOps
-from ..ops.arith_ops import ArithOps
 from ..ops.control_ops import ControlOps
 from .registry import register, register_parser
 
@@ -81,21 +79,7 @@ def _return_alias(op, context, env):
     return func__return(op, context, env)
 
 
-# Communication operations (bundled here since they're few)
-@register("ktdp.transfer", latency_category=LC.COMM)
-def ktdp__transfer(op, context, env):
-    tile = context.get_value(op.operands[0])
-    dst_cores = context.get_value(op.operands[1])
-    CommOps.transfer(context, tile, dst_cores, env.ring)
-    return None
-
-
-@register("ktdp.reduce", latency_category=LC.COMM)
-def ktdp__reduce(op, context, env):
-    tile = context.get_value(op.operands[0])
-    core_group = context.get_value(op.operands[1])
-    reduce_fn = lambda t1, t2: ArithOps.addf(t1, t2)
-    return CommOps.reduce(context, tile, core_group, reduce_fn, env.ring)
+# ktdp.transfer / ktdp.reduce moved to ktdp_ops.py (alongside other ktdp.* ops).
 
 
 # ---------------------------------------------------------------------------

--- a/ktir_cpu/grid.py
+++ b/ktir_cpu/grid.py
@@ -18,9 +18,12 @@ Grid and core execution management for KTIR CPU backend.
 Simulates multi-core grid execution with per-core execution contexts.
 """
 
-from typing import Dict, List, Optional, Set, Tuple, Any
+from typing import TYPE_CHECKING, Dict, List, Optional, Set, Tuple, Any
 from .ir_types import Tile
 from .memory import LXScratchpad, SpyreMemoryHierarchy, HBMSimulator
+
+if TYPE_CHECKING:
+    from .ops.comm_ops import RingBackend
 
 
 class CoreContext:
@@ -69,14 +72,36 @@ class CoreContext:
         # Re-bind %m_acc = %m_new in parent scope, re-track LX.
     """
 
-    def __init__(self, core_id: int, grid_pos: Tuple[int, int, int], lx: LXScratchpad, hbm: HBMSimulator):
+    def __init__(self, core_id: int, grid_pos: Tuple[int, int, int], lx: LXScratchpad, hbm: HBMSimulator, ring_backend: Optional["RingBackend"] = None):
         self.core_id = core_id
         self.grid_pos = grid_pos  # (x, y, z) position in grid
-        self.lx = lx  # Core-local LX scratchpad
-        self.hbm = hbm  # Shared HBM
+        self.lx = lx              # Core-local LX scratchpad
+        self.hbm = hbm            # Shared HBM
+        # Backend for remote LX access.  None is allowed for tests that
+        # construct CoreContext directly and never access a remote core's LX.
+        # get_lx() raises explicitly if a remote core is requested without a backend.
+        self.ring_backend = ring_backend
         self._scope_stack: List[Dict[str, Any]] = [{}]  # bottom = function body
         self._lx_bytes: Dict[str, int] = {}  # SSA name -> LX bytes (single source of truth)
         self._lx_next_ptr_stack: List[int] = []  # watermarks for lx.next_ptr rewind on pop_scope
+
+    def get_lx(self, core_id: Optional[int] = None) -> LXScratchpad:
+        """Return the LXScratchpad for *core_id*.
+
+        When *core_id* is None or equals this core's own id, returns the
+        local scratchpad directly.  For a remote core, delegates to
+        ring_backend.get_lx() — raises if no backend is configured
+        (single-core mode).
+        """
+        if core_id is None or core_id == self.core_id:
+            return self.lx
+        if self.ring_backend is None:
+            raise RuntimeError(
+                f"CoreContext(core_id={self.core_id}) has no ring_backend — "
+                f"cannot access remote LX for core {core_id}. "
+                f"Pass ring_backend when constructing CoreContext for multi-core execution."
+            )
+        return self.ring_backend.get_lx(core_id)
 
     def get_grid_id(self, dim: int) -> int:
         """Get grid ID for dimension.
@@ -215,17 +240,18 @@ class GridExecutor:
     Handles sequential simulation of cores with communication support.
     """
 
-    def __init__(self, grid_shape: Tuple[int, int, int], memory: SpyreMemoryHierarchy):
+    def __init__(self, grid_shape: Tuple[int, int, int], memory: SpyreMemoryHierarchy, ring_backend: Optional["RingBackend"] = None):
         self.grid_shape = grid_shape
         self.memory = memory
         self.num_cores = grid_shape[0] * grid_shape[1] * grid_shape[2]
 
-        # Create core contexts
+        # Create core contexts — ring_backend is injected so each core can
+        # access remote LX scratchpads via context.get_lx(core_id).
         self.cores = []
         for core_id in range(self.num_cores):
             grid_pos = self._linear_to_grid(core_id)
             lx = memory.get_lx(core_id)
-            self.cores.append(CoreContext(core_id, grid_pos, lx, memory.hbm))
+            self.cores.append(CoreContext(core_id, grid_pos, lx, memory.hbm, ring_backend))
 
     def _linear_to_grid(self, core_id: int) -> Tuple[int, int, int]:
         """Convert linear core ID to (x, y, z) grid position.
@@ -296,14 +322,18 @@ class GridExecutor:
 
         return core_ids
 
-    def execute_with_communication(self, execute_fn, ring_network, max_rounds=10, *args, **kwargs):
+    def execute_with_communication(self, execute_fn, max_rounds=10, *args, **kwargs):
         """Execute function on all cores with communication support.
 
-        Uses multi-pass execution to handle inter-core communication.
+        Uses single-pass execution under DirectLXBackend (no ring messages
+        actually flow).  When RingTransferBackend lands, this method will
+        need access to the ring backend (via ExecutionEnv or a direct
+        parameter) to drive message delivery between rounds — calling
+        ring_backend.deliver_all() and checking for pending messages
+        before deciding whether to continue or raise on non-convergence.
 
         Args:
-            execute_fn: Function to execute
-            ring_network: RingNetwork instance for communication
+            execute_fn: Function(core: CoreContext) to execute per core
             max_rounds: Maximum communication rounds
             *args, **kwargs: Additional arguments
 
@@ -311,21 +341,8 @@ class GridExecutor:
             List of results from each core
         """
         for round_num in range(max_rounds):
-            # Execute all cores
             results = []
             for core in self.cores:
-                result = execute_fn(core, ring_network, *args, **kwargs)
+                result = execute_fn(core, *args, **kwargs)
                 results.append(result)
-
-            # Deliver messages
-            ring_network.deliver_all()
-
-            # Check if communication is done
-            if not ring_network.has_pending_messages():
-                return results
-
-        # Communication didn't converge
-        raise RuntimeError(
-            f"Communication didn't converge after {max_rounds} rounds. "
-            f"Still have {ring_network.pending_message_count()} pending messages."
-        )
+            return results

--- a/ktir_cpu/interpreter.py
+++ b/ktir_cpu/interpreter.py
@@ -26,7 +26,7 @@ from .ir_types import Operation, IRModule, Tile
 from .parser import KTIRParser, KTIRParserBase
 from .memory import SpyreMemoryHierarchy
 from .grid import GridExecutor, CoreContext
-from .ops.comm_ops import RingNetwork
+from .ops.comm_ops import DirectLXBackend, RingBackend, RingNetwork
 from .latency import HardwareConfig, LatencyTracker, LatencyReport
 from .dialects import dispatch, ExecutionEnv
 
@@ -65,6 +65,7 @@ class KTIRInterpreter:
         self.memory: Optional[SpyreMemoryHierarchy] = None
         self.grid_executor: Optional[GridExecutor] = None
         self.ring_network: Optional[RingNetwork] = None
+        self.ring_backend: Optional[RingBackend] = None
         self._env: Optional[ExecutionEnv] = None
         self._parser: Optional[KTIRParserBase] = parser
         self._latency_tracker: Optional[LatencyTracker] = (
@@ -94,11 +95,15 @@ class KTIRInterpreter:
         """
         num_cores = grid_shape[0] * grid_shape[1] * grid_shape[2]
         self.memory = SpyreMemoryHierarchy(num_cores)
-        self.grid_executor = GridExecutor(grid_shape, self.memory)
+        # DirectLXBackend gives each core direct access to remote LX
+        # scratchpads via context.get_lx(N).  RingNetwork is held alongside
+        # for ktdp.transfer / ktdp.reduce until RingTransferBackend lands.
         self.ring_network = RingNetwork(num_cores)
+        self.ring_backend = DirectLXBackend(self.memory, ring=self.ring_network)
+        self.grid_executor = GridExecutor(grid_shape, self.memory, ring_backend=self.ring_backend)
         self._env = ExecutionEnv(
             grid_executor=self.grid_executor,
-            ring=self.ring_network,
+            ring_backend=self.ring_backend,
             execute_region=self.execute_region,
         )
         if self._latency_tracker is not None:
@@ -152,19 +157,18 @@ class KTIRInterpreter:
                 input_ptrs[arg_name] = tensor
 
         # Execute on all cores
-        def execute_on_core(core: CoreContext, ring: RingNetwork):
+        def execute_on_core(core: CoreContext):
             # Initialize context with function arguments
             for arg_name, arg_val in input_ptrs.items():
                 core.set_value("%" + arg_name, arg_val)
 
             # Execute function body
             for op in func.operations:
-                self._execute_operation(op, core, ring)
+                self._execute_operation(op, core)
 
         # Execute with communication support
         self.grid_executor.execute_with_communication(
             execute_on_core,
-            self.ring_network,
             max_rounds=10
         )
 
@@ -179,13 +183,12 @@ class KTIRInterpreter:
 
         return outputs
 
-    def _execute_operation(self, op: Operation, context: CoreContext, ring: RingNetwork) -> Any:
+    def _execute_operation(self, op: Operation, context: CoreContext) -> Any:
         """Execute a single operation.
 
         Args:
             op: Operation to execute
             context: Core execution context
-            ring: Ring network
 
         Returns:
             Operation result
@@ -278,5 +281,5 @@ class KTIRInterpreter:
         """
         result = None
         for op in operations:
-            result = self._execute_operation(op, context, self.ring_network)
+            result = self._execute_operation(op, context)
         return result

--- a/ktir_cpu/ir_types.py
+++ b/ktir_cpu/ir_types.py
@@ -56,12 +56,21 @@ class MemRef:
     memory_space: str          # "HBM" or "LX"
     dtype: str = "f16"
     coordinate_set: Optional[AffineSet] = None
+    # Set when memory_space="LX" and a core index was specified via
+    # #ktdp.spyre_memory_space<LX, core = N>.  None means "the executing
+    # core's own LX scratchpad" (default routing).
+    lx_core_id: Optional[int] = None
 
     def __post_init__(self):
         valid = ("HBM", "LX")
         if self.memory_space not in valid:
             raise ValueError(
                 f"Invalid memory_space {self.memory_space!r}. Must be one of {valid}."
+            )
+        if self.lx_core_id is not None and self.memory_space != "LX":
+            raise ValueError(
+                f"lx_core_id may only be set when memory_space is 'LX', "
+                f"got memory_space={self.memory_space!r}"
             )
 
     @property

--- a/ktir_cpu/ir_types.py
+++ b/ktir_cpu/ir_types.py
@@ -18,7 +18,11 @@ Core IR data types.
 Types are ordered by the data-flow pipeline:
 
 - MemRef: Hardware-aware memory view (construct_memory_view result; stick-indexed for HBM)
+- DistributedMemRef: Distributed analogue of MemRef — list of per-partition MemRefs
+  (construct_distributed_memory_view result)
 - TileRef: Byte-addressed sub-tile view (construct_access_tile result; produced from MemRef)
+- DistributedTileRef: Distributed analogue of TileRef — list of per-partition TileRef
+  survivors after access-set intersection (distributed_tile_access result)
 - Tile: Data value backed by a NumPy array (load result; tensor in MLIR)
 - AccessTile / IndirectAccessTile: Coordinate descriptors for load/store
 - Operation: Single IR operation
@@ -93,6 +97,55 @@ class MemRef:
 
 
 @dataclass
+class DistributedMemRef:
+    """Distributed memory view: composition of N per-partition MemRefs.
+
+    Produced by ``ktdp.construct_distributed_memory_view``.  Each partition
+    is a plain :class:`MemRef` carrying its own ``coordinate_set`` (= B_i
+    in global coords), ``memory_space``, ``base_ptr``, and ``strides``;
+    this wrapper records the global logical shape and can dispatch a
+    global coordinate to the first partition whose set contains it.
+
+    The op does not allocate or move data — this is bookkeeping only.
+    Access-time partition resolution (intersect with the access tile and
+    return the survivors) is performed by
+    ``MemoryOps.distributed_tile_access`` and yields a
+    :class:`DistributedTileRef`.
+    """
+    partitions: List[MemRef]
+    shape: Tuple[int, ...]   # global logical shape (coordinate_sets use these coords)
+    dtype: str
+
+    def __post_init__(self):
+        if not self.partitions:
+            raise ValueError("DistributedMemRef requires at least one partition")
+        for i, p in enumerate(self.partitions):
+            if p.coordinate_set is None:
+                raise ValueError(
+                    f"DistributedMemRef partition {i} must have a coordinate_set"
+                )
+            if p.dtype != self.dtype:
+                raise ValueError(
+                    f"DistributedMemRef partition {i} dtype {p.dtype!r} "
+                    f"does not match view dtype {self.dtype!r}"
+                )
+
+    def find_partition(self, coord: Tuple[int, ...]) -> Tuple[int, MemRef]:
+        """Return ``(index, partition)`` whose coordinate_set contains *coord*.
+
+        Returns the first match; per RFC 0682 §3.3, overlapping coordinate
+        sets produce unspecified behavior, and "first match" is a legal
+        (and conveniently deterministic) resolution.
+        """
+        for i, p in enumerate(self.partitions):
+            if p.coordinate_set.contains(coord):
+                return i, p
+        raise IndexError(
+            f"No partition of DistributedMemRef contains global coord {coord}"
+        )
+
+
+@dataclass
 class TileRef:
     """Byte-addressed tile view for load/store operations.
 
@@ -111,6 +164,39 @@ class TileRef:
         """Calculate size in bytes."""
         from .dtypes import bytes_per_elem
         return int(np.prod(self.shape) * bytes_per_elem(self.dtype))
+
+
+@dataclass
+class DistributedTileRef:
+    """Distributed analogue of TileRef: per-partition survivors of an access.
+
+    Produced by ``MemoryOps.distributed_tile_access``.  Each survivor is a
+    plain :class:`TileRef` whose ``memref`` points to the partition's
+    :class:`MemRef` (so memory-space dispatch and per-core LX routing
+    work without any DistributedMemRef-aware code at the load/store call
+    site).
+
+    The wrapper records the global logical shape (inherited from the
+    DistributedMemRef the access was issued against) and ``global_base``
+    — the origin of the access tile in global coords (= ``base_map.eval(indices)``).
+    distributed_load and distributed_store consume this object directly.
+    """
+    partitions: List['TileRef']
+    shape: Tuple[int, ...]                           # global logical shape
+    dtype: str
+    global_base: Optional[Tuple[int, ...]] = None    # x = base_map.eval(indices); set by
+                                                     # distributed_tile_access, None on
+                                                     # construct_distributed_memory_view
+
+    def __post_init__(self):
+        if not self.partitions:
+            raise ValueError("DistributedTileRef requires at least one partition")
+        for i, p in enumerate(self.partitions):
+            if p.dtype != self.dtype:
+                raise ValueError(
+                    f"DistributedTileRef partition {i} dtype {p.dtype!r} "
+                    f"does not match view dtype {self.dtype!r}"
+                )
 
 
 @dataclass
@@ -166,8 +252,13 @@ class AccessTile:
     Holds the affine attributes that describe which coordinates of the
     parent memref to access.  Load and store operations use these to
     find the actual memory location.
+
+    ``parent_ref`` is a :class:`TileRef` for the single-allocation case
+    or a :class:`DistributedTileRef` when the access was constructed
+    against a distributed memory view (in which case partition routing
+    has already been resolved by ``MemoryOps.distributed_tile_access``).
     """
-    parent_ref: TileRef
+    parent_ref: Union[TileRef, 'DistributedTileRef']
     shape: Tuple[int, ...]
     base_map: AffineMap                                  # always present; synthesized as identity if absent in MLIR
     coordinate_set: Optional[AffineSet] = None     # parsed access_tile_set; None if omitted

--- a/ktir_cpu/ir_types.py
+++ b/ktir_cpu/ir_types.py
@@ -33,7 +33,13 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Tuple, Union
 import numpy as np
 
-from .affine import AffineMap, AffineSet
+from .affine import AffineMap, AffineSet, BoxSet
+
+# Type alias for TileRef.coordinate_set: parsed affine sets lower to BoxSet
+# at parse time when axis-aligned; non-box sets stay as AffineSet; the
+# distributed slow path stores a pre-enumerated list of points; None means
+# the field hasn't been set (ordinary single-allocation TileRefs).
+CoordinateSet = Union[BoxSet, AffineSet, List[Tuple[int, ...]]]
 
 
 @dataclass
@@ -159,9 +165,13 @@ class TileRef:
     strides: List[int]         # element counts
     memref: 'MemRef'           # parent MemRef — always set; owns memory_space and hw address conversion
     dtype: str = "f16"
-    # Per-survivor metadata set by distributed_tile_access; None on
-    # ordinary single-allocation TileRefs.
-    coordinate_set: Optional[List[Tuple[int, ...]]] = None  # C_i in global coords (slow path)
+    # Per-survivor metadata set by distributed_tile_access (None on
+    # ordinary single-allocation TileRefs).  ``coordinate_set`` is one of:
+    #   - BoxSet: axis-aligned C_i, produced by the BoxSet fast path in
+    #     distributed_tile_access (B_i and A both BoxSet).  O(ndim) ops.
+    #   - List[Tuple[int,...]]: pre-enumerated C_i points from the slow
+    #     path (B_i or A is AffineSet — non-box).
+    coordinate_set: Optional[CoordinateSet] = None
     partition_origin: Optional[Tuple[int, ...]] = None      # p_i = min(B_i) in global coords
 
     def size_bytes(self) -> int:

--- a/ktir_cpu/ir_types.py
+++ b/ktir_cpu/ir_types.py
@@ -55,6 +55,12 @@ class MemRef:
     strides: List[int]         # element counts
     memory_space: str          # "HBM" or "LX"
     dtype: str = "f16"
+    # ``coordinate_set`` is the set of global coords this MemRef owns.
+    # Per-axis ``strides`` only describes a strided rectangle, so a
+    # non-rectangular set is stored BB-padded inside ``shape`` (slots
+    # outside the set are unused but addressable).  Hence the partition
+    # origin in global coords is ``min(coordinate_set)`` (= BB lower
+    # corner) — relied on by ``distributed_tile_access`` for ``p_i``.
     coordinate_set: Optional[AffineSet] = None
     # Set when memory_space="LX" and a core index was specified via
     # #ktdp.spyre_memory_space<LX, core = N>.  None means "the executing

--- a/ktir_cpu/ir_types.py
+++ b/ktir_cpu/ir_types.py
@@ -159,6 +159,10 @@ class TileRef:
     strides: List[int]         # element counts
     memref: 'MemRef'           # parent MemRef — always set; owns memory_space and hw address conversion
     dtype: str = "f16"
+    # Per-survivor metadata set by distributed_tile_access; None on
+    # ordinary single-allocation TileRefs.
+    coordinate_set: Optional[List[Tuple[int, ...]]] = None  # C_i in global coords (slow path)
+    partition_origin: Optional[Tuple[int, ...]] = None      # p_i = min(B_i) in global coords
 
     def size_bytes(self) -> int:
         """Calculate size in bytes."""

--- a/ktir_cpu/ops/comm_ops.py
+++ b/ktir_cpu/ops/comm_ops.py
@@ -23,6 +23,83 @@ from typing import Dict, List, Tuple, Callable, Optional
 import numpy as np
 from ..ir_types import Tile
 from ..grid import CoreContext
+from ..memory import LXScratchpad, SpyreMemoryHierarchy
+
+
+class RingBackend:
+    """Abstract backend for inter-core LX access and ring communication.
+
+    The backend is the single seam between memory operations that need
+    remote LX data and the communication model used to obtain it.
+
+    Two implementations are planned:
+
+    DirectLXBackend (this file, first pass):
+        Returns the target scratchpad directly from SpyreMemoryHierarchy.
+        No ring messages, no latency modelling.  Valid when LX partitions
+        are pre-seeded by the host before kernel execution (e.g. the RFC
+        distributed-view-copy test).
+
+    RingTransferBackend (future):
+        When a core requests remote LX data, it issues a send on
+        RingNetwork and suspends execution at that point (coroutine model).
+        The scheduler resumes the core once the sender has delivered the
+        message.  This models actual ring hop cost and enables correct
+        cyclic communication.
+    """
+
+    def get_lx(self, core_id: int) -> LXScratchpad:
+        """Return the LXScratchpad for *core_id*."""
+        raise NotImplementedError
+
+    def send(self, src_core: int, dst_core: int, tile: Tile) -> None:
+        """Send *tile* from *src_core* to *dst_core* via the ring."""
+        raise NotImplementedError
+
+    def recv(self, src_core: int, dst_core: int) -> Optional[Tile]:
+        """Receive a tile sent from *src_core* to *dst_core*."""
+        raise NotImplementedError
+
+
+class DirectLXBackend(RingBackend):
+    """First-pass backend: direct scratchpad access, no ring modelling.
+
+    get_lx(N) returns memory.lx_scratchpads[N] directly — valid for the
+    distributed-view use case where LX partitions are pre-seeded by the
+    host and no cross-core data movement occurs at runtime.
+
+    send/recv delegate to the provided RingNetwork so that ktdp.transfer
+    and ktdp.reduce continue to work as before.
+    """
+
+    def __init__(self, memory: SpyreMemoryHierarchy, ring: Optional["RingNetwork"] = None):
+        self._memory = memory
+        self._ring = ring
+
+    def get_lx(self, core_id: int) -> LXScratchpad:
+        """Return the LXScratchpad for *core_id* via direct lookup."""
+        num = self._memory.num_cores
+        if core_id < 0 or core_id >= num:
+            raise ValueError(
+                f"get_lx: core_id={core_id} is out of range [0, {num}) for this grid"
+            )
+        return self._memory.get_lx(core_id)
+
+    def send(self, src_core: int, dst_core: int, tile: Tile) -> None:
+        if self._ring is None:
+            raise NotImplementedError(
+                "DirectLXBackend was constructed without a RingNetwork — "
+                "ktdp.transfer/reduce require one"
+            )
+        self._ring.send(src_core, dst_core, tile)
+
+    def recv(self, src_core: int, dst_core: int) -> Optional[Tile]:
+        if self._ring is None:
+            raise NotImplementedError(
+                "DirectLXBackend was constructed without a RingNetwork — "
+                "ktdp.transfer/reduce require one"
+            )
+        return self._ring.recv_from(src_core, dst_core)
 
 
 class RingNetwork:
@@ -102,18 +179,11 @@ class CommOps:
         context: CoreContext,
         tile: Tile,
         dst_cores: List[int],
-        ring: RingNetwork
+        ring_backend: RingBackend,
     ):
-        """Transfer a tile to destination cores via the ring network.
-
-        Args:
-            context: Core execution context
-            tile: Tile to transfer
-            dst_cores: List of destination core IDs
-            ring: Ring network
-        """
+        """Transfer a tile to destination cores via the ring backend."""
         for dst_core in dst_cores:
-            ring.send(context.core_id, dst_core, tile)
+            ring_backend.send(context.core_id, dst_core, tile)
 
     @staticmethod
     def reduce(
@@ -121,7 +191,7 @@ class CommOps:
         tile: Tile,
         core_group: List[int],
         reduce_fn: Callable[[Tile, Tile], Tile],
-        ring: RingNetwork
+        ring_backend: RingBackend,
     ) -> Tuple[Tile, bool]:
         """Reduce a tile across a core group using the ring network.
 
@@ -160,14 +230,14 @@ class CommOps:
             # Send to next core in ring
             next_idx = (my_idx + 1) % n_cores
             next_core = core_group[next_idx]
-            ring.send(context.core_id, next_core, result)
+            ring_backend.send(context.core_id, next_core, result)
 
             # Receive from previous core in ring
             prev_idx = (my_idx - 1) % n_cores
             prev_core = core_group[prev_idx]
 
             # In sequential simulation, message is immediately available
-            received = ring.recv_from(prev_core, context.core_id)
+            received = ring_backend.recv(prev_core, context.core_id)
 
             # Apply reduction
             if received is not None:

--- a/ktir_cpu/ops/memory_ops.py
+++ b/ktir_cpu/ops/memory_ops.py
@@ -416,6 +416,12 @@ class MemoryOps:
         Each survivor inherits ``memref = P_i``, ``base_ptr =
         P_i.byte_address``, and ``strides = P_i.strides``.  Load/store
         translate per-coord via ``C_i - p_i``.
+
+        ``p_i = min(B_i)`` (per-axis) is the partition's origin in
+        global coords.  This is correct because per-axis ``strides`` on
+        ``MemRef`` can only describe a strided rectangle, so any
+        non-rectangular ``B_i`` is stored BB-padded inside the
+        partition's ``shape`` (see ``MemRef.coordinate_set``).
         """
         global_base = tuple(base_map.eval(indices))
         x = global_base

--- a/ktir_cpu/ops/memory_ops.py
+++ b/ktir_cpu/ops/memory_ops.py
@@ -19,12 +19,12 @@ Tile view construction, sub-tile access, and HBM/LX load/store
 primitives used by dialect handlers in ``ktir_cpu.dialects``.
 """
 
-from typing import List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 import numpy as np
-from ..affine import AffineMap
+from ..affine import AffineMap, AffineSet
 from ..dialects.ktdp_helpers import eval_subscript_expr
-from ..dtypes import bytes_per_elem as _bytes_per_elem
-from ..ir_types import MemRef, Tile, TileRef
+from ..dtypes import bytes_per_elem as _bytes_per_elem, to_np_dtype as _to_np_dtype
+from ..ir_types import DistributedMemRef, DistributedTileRef, MemRef, Tile, TileRef
 from ..grid import CoreContext
 from ..memory import HBMSimulator
 
@@ -369,3 +369,182 @@ class MemoryOps:
 
         out_shape = result_shape if result_shape is not None else iat.shape
         return MemoryOps.load(context, iat.parent_ref.to_tile_ref(), coords=coords, result_shape=out_shape)
+
+    # ------------------------------------------------------------------
+    # Distributed memory views (RFC 0682 §3.3)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def distributed_tile_access(
+        dist_ref: DistributedMemRef,
+        access_shape: Tuple[int, ...],
+        base_map: AffineMap,
+        indices: List[int],
+        access_tile_set: Optional[AffineSet] = None,
+    ) -> DistributedTileRef:
+        """Construct a DistributedTileRef from a DistributedMemRef + access tile.
+
+        v1 (C1): pass-through partition resolution.  Each partition becomes
+        a survivor TileRef pointing to that partition's full allocation;
+        per-coord routing happens at load/store time via
+        :meth:`DistributedMemRef.find_partition`.  C2 will narrow each
+        survivor to its own ``C_i = (x + A) ∩ B_i``.
+        """
+        global_base = tuple(base_map.eval(indices))
+        survivors: List[TileRef] = []
+        for part in dist_ref.partitions:
+            survivors.append(TileRef(
+                base_ptr=part.byte_address,
+                shape=part.shape,
+                strides=list(part.strides),
+                memref=part,
+                dtype=part.dtype,
+            ))
+        return DistributedTileRef(
+            partitions=survivors,
+            shape=dist_ref.shape,
+            dtype=dist_ref.dtype,
+            global_base=global_base,
+        )
+
+    @staticmethod
+    def _enumerate_dist_coords(
+        dist_tile_ref: DistributedTileRef, result_shape: Tuple[int, ...]
+    ) -> List[Tuple[int, ...]]:
+        """Enumerate the global coords covered by a DistributedTileRef access.
+
+        v1 (C1): the access region is the full result_shape, anchored at
+        ``global_base``.  C2 will replace this with per-survivor C_i
+        enumeration.
+        """
+        x = dist_tile_ref.global_base
+        if x is None:
+            x = (0,) * len(result_shape)
+        ndim = len(result_shape)
+        return [
+            tuple(x[d] + idx[d] for d in range(ndim))
+            for idx in np.ndindex(*result_shape)
+        ]
+
+    @staticmethod
+    def _route_coords_to_partitions(
+        dist_tile_ref: DistributedTileRef,
+        coords: List[Tuple[int, ...]],
+    ) -> Dict[int, Tuple[List[int], List[Tuple[int, ...]]]]:
+        """Group global *coords* by owning partition and translate to local.
+
+        Returns ``{partition_idx: (orig_positions, local_coords)}``.
+        ``orig_positions[k]`` is the index into *coords* that produced
+        ``local_coords[k]`` — used to scatter per-partition results back
+        into the flat output buffer.
+
+        Per-partition origin (= ``min(B_i)``) is computed lazily and once.
+        """
+        ndim = len(dist_tile_ref.shape)
+        origins: Dict[int, Tuple[int, ...]] = {}
+        groups: Dict[int, Tuple[List[int], List[Tuple[int, ...]]]] = {}
+        # Build a virtual DistributedMemRef-like view from the survivor
+        # MemRefs so we can reuse find_partition semantics without the
+        # dataclass validation.  In C1 the survivors' memref fields are
+        # exactly the partitions of the original DistributedMemRef.
+        partition_memrefs = [s.memref for s in dist_tile_ref.partitions]
+        for pos, coord in enumerate(coords):
+            part_idx = None
+            for i, p_memref in enumerate(partition_memrefs):
+                if p_memref.coordinate_set.contains(coord):
+                    part_idx = i
+                    break
+            if part_idx is None:
+                raise IndexError(
+                    f"distributed access: no partition contains global coord {coord}"
+                )
+            if part_idx not in origins:
+                p_set = partition_memrefs[part_idx].coordinate_set
+                pts = p_set.enumerate(dist_tile_ref.shape)
+                if not pts:
+                    raise ValueError(
+                        f"distributed access: partition {part_idx} coordinate_set "
+                        f"is empty over shape {dist_tile_ref.shape}"
+                    )
+                origins[part_idx] = tuple(min(p[d] for p in pts) for d in range(ndim))
+            origin = origins[part_idx]
+            local = tuple(int(coord[d] - origin[d]) for d in range(ndim))
+            pos_list, local_list = groups.setdefault(part_idx, ([], []))
+            pos_list.append(pos)
+            local_list.append(local)
+        return groups
+
+    @staticmethod
+    def distributed_load(
+        context: CoreContext,
+        dist_tile_ref: DistributedTileRef,
+        result_shape: Optional[Tuple[int, ...]] = None,
+    ) -> Tile:
+        """Gather elements across partitions and return a single LX-resident Tile.
+
+        For each global coord in the access region, route to the owning
+        partition, translate to that partition's local coord, issue one
+        batched read per partition group, and scatter the values back into
+        a flat output buffer indexed by the coord's original position.
+        Writes the result into LX so the caller sees the same contract as
+        :meth:`load`.
+        """
+        out_shape = (
+            tuple(result_shape) if result_shape is not None else tuple(dist_tile_ref.shape)
+        )
+        coords = MemoryOps._enumerate_dist_coords(dist_tile_ref, out_shape)
+        n_total = len(coords)
+        out_flat = np.zeros(n_total, dtype=_to_np_dtype(dist_tile_ref.dtype))
+        groups = MemoryOps._route_coords_to_partitions(dist_tile_ref, coords)
+
+        total_unique_sticks = 0
+        for part_idx, (orig_positions, local_coords) in groups.items():
+            survivor = dist_tile_ref.partitions[part_idx]
+            mgr = _MemAccessor(context, survivor.memref.memory_space, survivor.base_ptr)
+            offsets, unique_sticks = MemoryOps._flat_memory_offsets(
+                survivor.base_ptr, survivor.shape, survivor.strides, survivor.dtype,
+                local_coords, stick_bytes=mgr.stick_bytes,
+            )
+            span = max(offsets) + 1 if offsets else 1
+            flat = mgr.read(span, survivor.dtype)
+            out_flat[orig_positions] = flat[offsets]
+            if unique_sticks is not None:
+                total_unique_sticks += unique_sticks
+
+        data = out_flat.reshape(out_shape)
+        MemoryOps._write_to_lx(context, data)
+        return Tile(
+            data,
+            dist_tile_ref.dtype,
+            out_shape,
+            total_unique_sticks if total_unique_sticks else None,
+        )
+
+    @staticmethod
+    def distributed_store(
+        context: CoreContext,
+        tile: Tile,
+        dist_tile_ref: DistributedTileRef,
+    ) -> None:
+        """Scatter a tile across partitions, symmetric to :meth:`distributed_load`.
+
+        For each global coord covered by the access region, route to the
+        owning partition and translate to that partition's local coord;
+        per partition, do one read-modify-write covering the partition's
+        scatter targets.
+        """
+        coords = MemoryOps._enumerate_dist_coords(dist_tile_ref, tile.shape)
+        groups = MemoryOps._route_coords_to_partitions(dist_tile_ref, coords)
+        flat_values = tile.data.flatten()
+
+        for part_idx, (orig_positions, local_coords) in groups.items():
+            survivor = dist_tile_ref.partitions[part_idx]
+            mgr = _MemAccessor(context, survivor.memref.memory_space, survivor.base_ptr)
+            offsets, _ = MemoryOps._flat_memory_offsets(
+                survivor.base_ptr, survivor.shape, survivor.strides, survivor.dtype,
+                local_coords,
+            )
+            span = max(offsets) + 1 if offsets else 1
+            flat = mgr.read(span, survivor.dtype)
+            flat[offsets] = flat_values[orig_positions]
+            mgr.write(flat)

--- a/ktir_cpu/ops/memory_ops.py
+++ b/ktir_cpu/ops/memory_ops.py
@@ -19,12 +19,14 @@ Tile view construction, sub-tile access, and HBM/LX load/store
 primitives used by dialect handlers in ``ktir_cpu.dialects``.
 """
 
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple, Union
 import numpy as np
-from ..affine import AffineMap, AffineSet
+from ..affine import AffineMap, AffineSet, BoxSet
 from ..dialects.ktdp_helpers import eval_subscript_expr
 from ..dtypes import bytes_per_elem as _bytes_per_elem, to_np_dtype as _to_np_dtype
-from ..ir_types import DistributedMemRef, DistributedTileRef, MemRef, Tile, TileRef
+from ..ir_types import (
+    CoordinateSet, DistributedMemRef, DistributedTileRef, MemRef, Tile, TileRef,
+)
 from ..grid import CoreContext
 from ..memory import HBMSimulator
 
@@ -395,48 +397,73 @@ class MemoryOps:
         access_shape: Tuple[int, ...],
         base_map: AffineMap,
         indices: List[int],
-        access_tile_set: Optional[AffineSet] = None,
+        access_tile_set: Optional[Union[BoxSet, AffineSet]] = None,
     ) -> DistributedTileRef:
         """Resolve partition routing once, return a DistributedTileRef.
 
-        For each partition i:
-          1. Enumerate B_i over the global view shape; skip if empty.
-          2. Compute p_i = min(B_i) (per-dim minimum).
-          3. Filter to C_i = points of B_i that lie within x + A.
-             - access_tile_set None ⇒ A is the full box [0, access_shape).
-             - access_tile_set AffineSet ⇒ membership tested point-by-point.
-          4. Drop the partition if C_i is empty.
-          5. Otherwise emit a survivor TileRef with
-             ``coordinate_set = C_i`` (List[Tuple[int,...]]),
-             ``partition_origin = p_i``, ``memref = P_i``,
-             ``base_ptr = P_i.byte_address`` (full partition base; load/
-             store will translate per-coord via C_i - p_i).
+        Fast path (BoxSet): when both ``B_i`` and the access set ``A``
+        (or the implicit full-box A) are :class:`BoxSet`, compute
+        ``C_i = B_i ∩ (x + A)`` in O(ndim) via ``translate`` +
+        ``intersect`` and store ``C_i`` as a ``BoxSet``.  Skip empty
+        intersections.
+
+        Slow path (AffineSet on either side): enumerate B_i over the
+        global shape, filter by membership in ``x + A``, store C_i as
+        a ``List[Tuple[int, ...]]``.
+
+        Each survivor inherits ``memref = P_i``, ``base_ptr =
+        P_i.byte_address``, and ``strides = P_i.strides``.  Load/store
+        translate per-coord via ``C_i - p_i``.
         """
         global_base = tuple(base_map.eval(indices))
         x = global_base
         ndim = len(dist_ref.shape)
 
+        # Pre-compute (x + A) as a BoxSet when possible.  None ⇒ A is
+        # the implicit full box [0, access_shape).
+        xA_box: Optional[BoxSet] = None
+        if access_tile_set is None:
+            xA_box = BoxSet(
+                lo=tuple(x),
+                hi=tuple(x[d] + access_shape[d] for d in range(ndim)),
+            )
+        elif isinstance(access_tile_set, BoxSet):
+            xA_box = access_tile_set.translate(x)
+
         def _in_xA(p: Tuple[int, ...]) -> bool:
+            """Slow-path membership test: point ∈ x + A."""
             if access_tile_set is None:
                 return all(0 <= p[d] - x[d] < access_shape[d] for d in range(ndim))
             return access_tile_set.contains(tuple(p[d] - x[d] for d in range(ndim)))
 
         survivors: List[TileRef] = []
         for part in dist_ref.partitions:
-            B_i_pts = part.coordinate_set.enumerate(dist_ref.shape)
-            if not B_i_pts:
-                continue
-            p_i = tuple(min(pt[d] for pt in B_i_pts) for d in range(ndim))
-            C_i_pts = [pt for pt in B_i_pts if _in_xA(pt)]
-            if not C_i_pts:
-                continue
+            B_i = part.coordinate_set
+            if isinstance(B_i, BoxSet) and xA_box is not None:
+                # Fast path: O(ndim) intersect
+                C_i = B_i.intersect(xA_box)
+                if C_i.is_empty():
+                    continue
+                p_i = B_i.lower_bounds()
+                coordinate_set_out: CoordinateSet = C_i
+            else:
+                # Slow path: brute-force enumerate + filter
+                B_i_pts = B_i.enumerate(dist_ref.shape)
+                if not B_i_pts:
+                    continue
+                p_i = tuple(min(pt[d] for pt in B_i_pts) for d in range(ndim))
+                C_i_pts = [pt for pt in B_i_pts if _in_xA(pt)]
+                if not C_i_pts:
+                    continue
+                coordinate_set_out = C_i_pts
+
             survivors.append(TileRef(
                 base_ptr=part.byte_address,
                 shape=part.shape,
                 strides=list(part.strides),
                 memref=part,
                 dtype=part.dtype,
-                coordinate_set=C_i_pts,
+                coordinate_set=coordinate_set_out,
                 partition_origin=p_i,
             ))
 
@@ -453,6 +480,32 @@ class MemoryOps:
         )
 
     @staticmethod
+    def _subtile_ref(survivor: TileRef, box: BoxSet) -> TileRef:
+        """Build a TileRef covering exactly *box* (in global coords) within *survivor*.
+
+        Inherits the survivor's strides verbatim; only ``shape`` shrinks
+        to the box extent and ``base_ptr`` shifts to the box's local
+        origin (``box.lo - p_i``, in element units, scaled by bpe).  The
+        resulting sub-TileRef plugs into :meth:`load` / :meth:`store`,
+        whose strided iteration lands each element at the byte offset
+        the parent layout dictates — row-major and column-packed
+        partitions both work uniformly without caller-side transposes.
+        """
+        ndim = len(survivor.shape)
+        p_i = survivor.partition_origin or (0,) * ndim
+        local_lo = tuple(box.lo[d] - p_i[d] for d in range(ndim))
+        sub_shape = tuple(box.hi[d] - box.lo[d] for d in range(ndim))
+        bpe = _bytes_per_elem(survivor.dtype)
+        byte_offset = sum(local_lo[d] * survivor.strides[d] for d in range(ndim)) * bpe
+        return TileRef(
+            base_ptr=survivor.base_ptr + byte_offset,
+            shape=sub_shape,
+            strides=list(survivor.strides),
+            memref=survivor.memref,
+            dtype=survivor.dtype,
+        )
+
+    @staticmethod
     def distributed_load(
         context: CoreContext,
         dist_tile_ref: DistributedTileRef,
@@ -460,9 +513,14 @@ class MemoryOps:
     ) -> Tile:
         """Gather elements across surviving partitions into a single LX-resident Tile.
 
-        Per survivor: translate C_i to partition-local coords (C_i - p_i),
-        issue one batched read, scatter into the access-local positions
-        (C_i - x) of the output buffer.
+        Fast path (BoxSet C_i): build a sub-TileRef of the partition
+        covering exactly C_i, delegate the read to :meth:`load`, and
+        slot the returned tile into a rectangular slice of the output
+        buffer.  One NumPy slice assignment per partition.
+
+        Slow path (List[Tuple] C_i): per-coord scatter — translate C_i
+        to partition-local coords, issue one batched read, write each
+        element into the access-local position of the output buffer.
         """
         x = dist_tile_ref.global_base or (0,) * len(dist_tile_ref.shape)
         ndim = len(dist_tile_ref.shape)
@@ -473,7 +531,22 @@ class MemoryOps:
 
         total_unique_sticks = 0
         for survivor in dist_tile_ref.partitions:
-            C_i = survivor.coordinate_set or []
+            cs = survivor.coordinate_set
+            if isinstance(cs, BoxSet):
+                # Fast path: rectangular sub-tile.
+                sub = MemoryOps._subtile_ref(survivor, cs)
+                tile = MemoryOps.load(context, sub)
+                # access-local rectangle = C_i - x
+                slc = tuple(
+                    slice(cs.lo[d] - x[d], cs.hi[d] - x[d]) for d in range(ndim)
+                )
+                out[slc] = tile.data
+                if tile.unique_sticks is not None:
+                    total_unique_sticks += tile.unique_sticks
+                continue
+
+            # Slow path: List[Tuple[int, ...]] enumeration.
+            C_i = cs or []
             p_i = survivor.partition_origin or (0,) * ndim
             local_coords = [
                 tuple(c[d] - p_i[d] for d in range(ndim)) for c in C_i
@@ -509,15 +582,30 @@ class MemoryOps:
     ) -> None:
         """Scatter a tile to surviving partitions, symmetric to :meth:`distributed_load`.
 
-        Per survivor: select tile elements at access-local positions
-        (C_i - x), write them to partition-local positions (C_i - p_i)
-        via one read-modify-write.
+        Fast path (BoxSet C_i): slice the source tile rectangularly at
+        ``C_i - x``, wrap in a Tile, write through a sub-TileRef built
+        on C_i.  np.ascontiguousarray covers the case where the slice
+        is a non-contiguous view.
+
+        Slow path (List[Tuple] C_i): per-coord gather/write via one
+        read-modify-write.
         """
         x = dist_tile_ref.global_base or (0,) * len(dist_tile_ref.shape)
         ndim = len(dist_tile_ref.shape)
 
         for survivor in dist_tile_ref.partitions:
-            C_i = survivor.coordinate_set or []
+            cs = survivor.coordinate_set
+            if isinstance(cs, BoxSet):
+                sub = MemoryOps._subtile_ref(survivor, cs)
+                slc = tuple(
+                    slice(cs.lo[d] - x[d], cs.hi[d] - x[d]) for d in range(ndim)
+                )
+                src = np.ascontiguousarray(tile.data[slc])
+                sub_tile = Tile(src, survivor.dtype, src.shape)
+                MemoryOps.store(context, sub_tile, sub)
+                continue
+
+            C_i = cs or []
             p_i = survivor.partition_origin or (0,) * ndim
             local_coords = [
                 tuple(c[d] - p_i[d] for d in range(ndim)) for c in C_i

--- a/ktir_cpu/ops/memory_ops.py
+++ b/ktir_cpu/ops/memory_ops.py
@@ -50,7 +50,13 @@ class _MemAccessor:
     require no changes.
     """
 
-    def __init__(self, context: CoreContext, memory_space: str, byte_addr: int):
+    def __init__(
+        self,
+        context: CoreContext,
+        memory_space: str,
+        byte_addr: int,
+        lx_core_id: Optional[int] = None,
+    ):
         if memory_space == "HBM":
             self.stick_bytes: Optional[int] = HBMSimulator.STICK_BYTES
             self._sim = context.hbm
@@ -59,7 +65,10 @@ class _MemAccessor:
             self._kwargs = {"intra_byte": intra}
         else:
             self.stick_bytes = None
-            self._sim = context.lx
+            # Per-core routing: when lx_core_id is None or matches the
+            # executing core, context.lx is used directly; otherwise we
+            # route to a remote LX scratchpad via the ring backend.
+            self._sim = context.get_lx(lx_core_id)
             self._args = (byte_addr,)
             self._kwargs = {}
 
@@ -81,22 +90,14 @@ class MemoryOps:
         memory_space: str,
         dtype: str = "f16",
         coordinate_set: Optional[str] = None,
+        lx_core_id: Optional[int] = None,
     ) -> MemRef:
         """Create a hardware-aware memory view (MemRef).
 
         Builds a MemRef describing a contiguous region in HBM or LX.
-
-        Args:
-            context: Core execution context
-            ptr: Base pointer (stick index for HBM, byte address for LX)
-            shape: Tile shape
-            strides: Memory strides (element counts)
-            memory_space: "HBM" or "LX"
-            dtype: Data type
-            coordinate_set: Verbatim affine_set string, no evaluation
-
-        Returns:
-            MemRef describing the memory layout
+        ``lx_core_id``, when set, identifies which core's LX scratchpad
+        the data lives in (parsed from #ktdp.spyre_memory_space<LX, core=N>);
+        load/store use it to route via context.get_lx().
         """
         return MemRef(
             base_ptr=ptr,
@@ -105,6 +106,7 @@ class MemoryOps:
             memory_space=memory_space,
             dtype=dtype,
             coordinate_set=coordinate_set,
+            lx_core_id=lx_core_id,
         )
 
     @staticmethod
@@ -252,7 +254,7 @@ class MemoryOps:
         Returns:
             Tile value (tensor) loaded into LX
         """
-        mgr = _MemAccessor(context, tile_ref.memref.memory_space, tile_ref.base_ptr)
+        mgr = _MemAccessor(context, tile_ref.memref.memory_space, tile_ref.base_ptr, tile_ref.memref.lx_core_id)
         stick_bytes = mgr.stick_bytes
 
         # Fast path: contiguous tile, no coord filtering — single dict-key read.
@@ -311,7 +313,7 @@ class MemoryOps:
             tile_ref: Tile reference (memref) describing destination
             coords: Optional list of local coordinate tuples to scatter into.
         """
-        mgr = _MemAccessor(context, tile_ref.memref.memory_space, tile_ref.base_ptr)
+        mgr = _MemAccessor(context, tile_ref.memref.memory_space, tile_ref.base_ptr, tile_ref.memref.lx_core_id)
 
         # Fast path: contiguous tile, no coord filtering — single dict-key write.
         if coords is None and MemoryOps._is_contiguous(tile_ref.shape, tile_ref.strides):
@@ -361,7 +363,7 @@ class MemoryOps:
                     )
                     offset = sum(c * s for c, s in zip(idx_coords, idx_view.strides))
                     addr = idx_view.byte_address + offset * _bytes_per_elem(idx_view.dtype)
-                    raw = _MemAccessor(context, idx_view.memory_space, addr).read(1, idx_view.dtype)
+                    raw = _MemAccessor(context, idx_view.memory_space, addr, idx_view.lx_core_id).read(1, idx_view.dtype)
                     coord.append(int(raw[0]))
                 elif sub["kind"] == "direct":
                     coord.append(pt[sub["var_index"]])
@@ -554,7 +556,7 @@ class MemoryOps:
             access_coords = [
                 tuple(c[d] - x[d] for d in range(ndim)) for c in C_i
             ]
-            mgr = _MemAccessor(context, survivor.memref.memory_space, survivor.base_ptr)
+            mgr = _MemAccessor(context, survivor.memref.memory_space, survivor.base_ptr, survivor.memref.lx_core_id)
             offsets, unique_sticks = MemoryOps._flat_memory_offsets(
                 survivor.base_ptr, survivor.shape, survivor.strides, survivor.dtype,
                 local_coords, stick_bytes=mgr.stick_bytes,
@@ -613,7 +615,7 @@ class MemoryOps:
             access_coords = [
                 tuple(c[d] - x[d] for d in range(ndim)) for c in C_i
             ]
-            mgr = _MemAccessor(context, survivor.memref.memory_space, survivor.base_ptr)
+            mgr = _MemAccessor(context, survivor.memref.memory_space, survivor.base_ptr, survivor.memref.lx_core_id)
             offsets, _ = MemoryOps._flat_memory_offsets(
                 survivor.base_ptr, survivor.shape, survivor.strides, survivor.dtype,
                 local_coords,

--- a/ktir_cpu/ops/memory_ops.py
+++ b/ktir_cpu/ops/memory_ops.py
@@ -30,30 +30,36 @@ from ..memory import HBMSimulator
 
 
 class _MemAccessor:
-    """Resolves a (context, memref, byte_addr) triple into simulator read/write calls.
+    """Resolves a (context, memory_space, byte_addr) triple into simulator
+    read/write calls.
 
     This is the single place in the codebase that manages the intra-stick byte
-    offset abstraction: HBMSimulator requires a (stick, intra_byte) address pair
-    while LXScratchpad uses a plain byte address.  ``MemRef.split_addr`` produces
-    the pair; this class captures it and forwards any extra address kwargs to the
-    underlying simulator so callers never handle them directly.
+    offset abstraction: HBMSimulator requires a (stick, intra_byte) address
+    pair while LXScratchpad uses a plain byte address.  The accessor consumes
+    only ``memory_space`` (for simulator dispatch) and an absolute
+    ``byte_addr``; the byte_addr must live in physical memory matching the
+    given memory_space.  Callers do not need to manufacture a MemRef.
 
-    ``stick_bytes`` is exposed for callers that need to count distinct HBM sticks
-    touched by an access (latency accounting); it is None for LX.
+    ``stick_bytes`` is exposed for callers that need to count distinct HBM
+    sticks touched by an access (latency accounting); it is None for LX.
 
-    To extend to a new memory space, add a branch in ``__init__`` that populates
-    ``_args`` and ``_kwargs`` appropriately — ``read`` and ``write`` require no
-    changes.
+    To extend to a new memory space, add a branch in ``__init__`` that
+    populates ``_args`` and ``_kwargs`` appropriately — ``read`` and ``write``
+    require no changes.
     """
 
-    def __init__(self, context: CoreContext, memref: MemRef, byte_addr: int):
-        _main, _intra = memref.split_addr(byte_addr)
-        self.stick_bytes: Optional[int] = HBMSimulator.STICK_BYTES if memref.memory_space == "HBM" else None
-        self._sim = context.hbm if memref.memory_space == "HBM" else context.lx
-        self._args = (_main,)
-        self._kwargs = {}
-        if memref.memory_space == "HBM":
-            self._kwargs["intra_byte"] = _intra
+    def __init__(self, context: CoreContext, memory_space: str, byte_addr: int):
+        if memory_space == "HBM":
+            self.stick_bytes: Optional[int] = HBMSimulator.STICK_BYTES
+            self._sim = context.hbm
+            stick, intra = divmod(byte_addr, HBMSimulator.STICK_BYTES)
+            self._args = (stick,)
+            self._kwargs = {"intra_byte": intra}
+        else:
+            self.stick_bytes = None
+            self._sim = context.lx
+            self._args = (byte_addr,)
+            self._kwargs = {}
 
     def read(self, n: int, dtype: str) -> np.ndarray:
         return self._sim.read(*self._args, n, dtype, **self._kwargs)
@@ -244,7 +250,7 @@ class MemoryOps:
         Returns:
             Tile value (tensor) loaded into LX
         """
-        mgr = _MemAccessor(context, tile_ref.memref, tile_ref.base_ptr)
+        mgr = _MemAccessor(context, tile_ref.memref.memory_space, tile_ref.base_ptr)
         stick_bytes = mgr.stick_bytes
 
         # Fast path: contiguous tile, no coord filtering — single dict-key read.
@@ -303,7 +309,7 @@ class MemoryOps:
             tile_ref: Tile reference (memref) describing destination
             coords: Optional list of local coordinate tuples to scatter into.
         """
-        mgr = _MemAccessor(context, tile_ref.memref, tile_ref.base_ptr)
+        mgr = _MemAccessor(context, tile_ref.memref.memory_space, tile_ref.base_ptr)
 
         # Fast path: contiguous tile, no coord filtering — single dict-key write.
         if coords is None and MemoryOps._is_contiguous(tile_ref.shape, tile_ref.strides):
@@ -353,7 +359,7 @@ class MemoryOps:
                     )
                     offset = sum(c * s for c, s in zip(idx_coords, idx_view.strides))
                     addr = idx_view.byte_address + offset * _bytes_per_elem(idx_view.dtype)
-                    raw = _MemAccessor(context, idx_view, addr).read(1, idx_view.dtype)
+                    raw = _MemAccessor(context, idx_view.memory_space, addr).read(1, idx_view.dtype)
                     coord.append(int(raw[0]))
                 elif sub["kind"] == "direct":
                     coord.append(pt[sub["var_index"]])

--- a/ktir_cpu/ops/memory_ops.py
+++ b/ktir_cpu/ops/memory_ops.py
@@ -372,6 +372,21 @@ class MemoryOps:
 
     # ------------------------------------------------------------------
     # Distributed memory views (RFC 0682 §3.3)
+    #
+    # Naming used throughout:
+    #   x   = global_base = base_map.eval(indices) — global origin of
+    #         the access tile
+    #   A   = access_tile_set, in local coords 0..access_shape-1; None
+    #         means the full box [0, access_shape)
+    #   x+A = global footprint of the access tile
+    #   B_i = partition i's coordinate_set, in global coords
+    #   C_i = (x + A) ∩ B_i — global coords covered by both the access
+    #         tile and partition i; per-survivor coordinate_set
+    #   p_i = min(B_i) — partition i's origin in global coords
+    #
+    # distributed_load consumes C_i and p_i directly:
+    #   load coords (partition-local) = C_i - p_i
+    #   output coords (access-local)  = C_i - x
     # ------------------------------------------------------------------
 
     @staticmethod
@@ -382,24 +397,54 @@ class MemoryOps:
         indices: List[int],
         access_tile_set: Optional[AffineSet] = None,
     ) -> DistributedTileRef:
-        """Construct a DistributedTileRef from a DistributedMemRef + access tile.
+        """Resolve partition routing once, return a DistributedTileRef.
 
-        v1 (C1): pass-through partition resolution.  Each partition becomes
-        a survivor TileRef pointing to that partition's full allocation;
-        per-coord routing happens at load/store time via
-        :meth:`DistributedMemRef.find_partition`.  C2 will narrow each
-        survivor to its own ``C_i = (x + A) ∩ B_i``.
+        For each partition i:
+          1. Enumerate B_i over the global view shape; skip if empty.
+          2. Compute p_i = min(B_i) (per-dim minimum).
+          3. Filter to C_i = points of B_i that lie within x + A.
+             - access_tile_set None ⇒ A is the full box [0, access_shape).
+             - access_tile_set AffineSet ⇒ membership tested point-by-point.
+          4. Drop the partition if C_i is empty.
+          5. Otherwise emit a survivor TileRef with
+             ``coordinate_set = C_i`` (List[Tuple[int,...]]),
+             ``partition_origin = p_i``, ``memref = P_i``,
+             ``base_ptr = P_i.byte_address`` (full partition base; load/
+             store will translate per-coord via C_i - p_i).
         """
         global_base = tuple(base_map.eval(indices))
+        x = global_base
+        ndim = len(dist_ref.shape)
+
+        def _in_xA(p: Tuple[int, ...]) -> bool:
+            if access_tile_set is None:
+                return all(0 <= p[d] - x[d] < access_shape[d] for d in range(ndim))
+            return access_tile_set.contains(tuple(p[d] - x[d] for d in range(ndim)))
+
         survivors: List[TileRef] = []
         for part in dist_ref.partitions:
+            B_i_pts = part.coordinate_set.enumerate(dist_ref.shape)
+            if not B_i_pts:
+                continue
+            p_i = tuple(min(pt[d] for pt in B_i_pts) for d in range(ndim))
+            C_i_pts = [pt for pt in B_i_pts if _in_xA(pt)]
+            if not C_i_pts:
+                continue
             survivors.append(TileRef(
                 base_ptr=part.byte_address,
                 shape=part.shape,
                 strides=list(part.strides),
                 memref=part,
                 dtype=part.dtype,
+                coordinate_set=C_i_pts,
+                partition_origin=p_i,
             ))
+
+        if not survivors:
+            raise ValueError(
+                f"distributed_tile_access: no partition covers access region "
+                f"global_base={global_base} shape={access_shape}"
+            )
         return DistributedTileRef(
             partitions=survivors,
             shape=dist_ref.shape,
@@ -408,98 +453,34 @@ class MemoryOps:
         )
 
     @staticmethod
-    def _enumerate_dist_coords(
-        dist_tile_ref: DistributedTileRef, result_shape: Tuple[int, ...]
-    ) -> List[Tuple[int, ...]]:
-        """Enumerate the global coords covered by a DistributedTileRef access.
-
-        v1 (C1): the access region is the full result_shape, anchored at
-        ``global_base``.  C2 will replace this with per-survivor C_i
-        enumeration.
-        """
-        x = dist_tile_ref.global_base
-        if x is None:
-            x = (0,) * len(result_shape)
-        ndim = len(result_shape)
-        return [
-            tuple(x[d] + idx[d] for d in range(ndim))
-            for idx in np.ndindex(*result_shape)
-        ]
-
-    @staticmethod
-    def _route_coords_to_partitions(
-        dist_tile_ref: DistributedTileRef,
-        coords: List[Tuple[int, ...]],
-    ) -> Dict[int, Tuple[List[int], List[Tuple[int, ...]]]]:
-        """Group global *coords* by owning partition and translate to local.
-
-        Returns ``{partition_idx: (orig_positions, local_coords)}``.
-        ``orig_positions[k]`` is the index into *coords* that produced
-        ``local_coords[k]`` — used to scatter per-partition results back
-        into the flat output buffer.
-
-        Per-partition origin (= ``min(B_i)``) is computed lazily and once.
-        """
-        ndim = len(dist_tile_ref.shape)
-        origins: Dict[int, Tuple[int, ...]] = {}
-        groups: Dict[int, Tuple[List[int], List[Tuple[int, ...]]]] = {}
-        # Build a virtual DistributedMemRef-like view from the survivor
-        # MemRefs so we can reuse find_partition semantics without the
-        # dataclass validation.  In C1 the survivors' memref fields are
-        # exactly the partitions of the original DistributedMemRef.
-        partition_memrefs = [s.memref for s in dist_tile_ref.partitions]
-        for pos, coord in enumerate(coords):
-            part_idx = None
-            for i, p_memref in enumerate(partition_memrefs):
-                if p_memref.coordinate_set.contains(coord):
-                    part_idx = i
-                    break
-            if part_idx is None:
-                raise IndexError(
-                    f"distributed access: no partition contains global coord {coord}"
-                )
-            if part_idx not in origins:
-                p_set = partition_memrefs[part_idx].coordinate_set
-                pts = p_set.enumerate(dist_tile_ref.shape)
-                if not pts:
-                    raise ValueError(
-                        f"distributed access: partition {part_idx} coordinate_set "
-                        f"is empty over shape {dist_tile_ref.shape}"
-                    )
-                origins[part_idx] = tuple(min(p[d] for p in pts) for d in range(ndim))
-            origin = origins[part_idx]
-            local = tuple(int(coord[d] - origin[d]) for d in range(ndim))
-            pos_list, local_list = groups.setdefault(part_idx, ([], []))
-            pos_list.append(pos)
-            local_list.append(local)
-        return groups
-
-    @staticmethod
     def distributed_load(
         context: CoreContext,
         dist_tile_ref: DistributedTileRef,
         result_shape: Optional[Tuple[int, ...]] = None,
     ) -> Tile:
-        """Gather elements across partitions and return a single LX-resident Tile.
+        """Gather elements across surviving partitions into a single LX-resident Tile.
 
-        For each global coord in the access region, route to the owning
-        partition, translate to that partition's local coord, issue one
-        batched read per partition group, and scatter the values back into
-        a flat output buffer indexed by the coord's original position.
-        Writes the result into LX so the caller sees the same contract as
-        :meth:`load`.
+        Per survivor: translate C_i to partition-local coords (C_i - p_i),
+        issue one batched read, scatter into the access-local positions
+        (C_i - x) of the output buffer.
         """
+        x = dist_tile_ref.global_base or (0,) * len(dist_tile_ref.shape)
+        ndim = len(dist_tile_ref.shape)
         out_shape = (
             tuple(result_shape) if result_shape is not None else tuple(dist_tile_ref.shape)
         )
-        coords = MemoryOps._enumerate_dist_coords(dist_tile_ref, out_shape)
-        n_total = len(coords)
-        out_flat = np.zeros(n_total, dtype=_to_np_dtype(dist_tile_ref.dtype))
-        groups = MemoryOps._route_coords_to_partitions(dist_tile_ref, coords)
+        out = np.zeros(out_shape, dtype=_to_np_dtype(dist_tile_ref.dtype))
 
         total_unique_sticks = 0
-        for part_idx, (orig_positions, local_coords) in groups.items():
-            survivor = dist_tile_ref.partitions[part_idx]
+        for survivor in dist_tile_ref.partitions:
+            C_i = survivor.coordinate_set or []
+            p_i = survivor.partition_origin or (0,) * ndim
+            local_coords = [
+                tuple(c[d] - p_i[d] for d in range(ndim)) for c in C_i
+            ]
+            access_coords = [
+                tuple(c[d] - x[d] for d in range(ndim)) for c in C_i
+            ]
             mgr = _MemAccessor(context, survivor.memref.memory_space, survivor.base_ptr)
             offsets, unique_sticks = MemoryOps._flat_memory_offsets(
                 survivor.base_ptr, survivor.shape, survivor.strides, survivor.dtype,
@@ -507,14 +488,14 @@ class MemoryOps:
             )
             span = max(offsets) + 1 if offsets else 1
             flat = mgr.read(span, survivor.dtype)
-            out_flat[orig_positions] = flat[offsets]
+            for ac, off in zip(access_coords, offsets):
+                out[ac] = flat[off]
             if unique_sticks is not None:
                 total_unique_sticks += unique_sticks
 
-        data = out_flat.reshape(out_shape)
-        MemoryOps._write_to_lx(context, data)
+        MemoryOps._write_to_lx(context, out)
         return Tile(
-            data,
+            out,
             dist_tile_ref.dtype,
             out_shape,
             total_unique_sticks if total_unique_sticks else None,
@@ -526,19 +507,24 @@ class MemoryOps:
         tile: Tile,
         dist_tile_ref: DistributedTileRef,
     ) -> None:
-        """Scatter a tile across partitions, symmetric to :meth:`distributed_load`.
+        """Scatter a tile to surviving partitions, symmetric to :meth:`distributed_load`.
 
-        For each global coord covered by the access region, route to the
-        owning partition and translate to that partition's local coord;
-        per partition, do one read-modify-write covering the partition's
-        scatter targets.
+        Per survivor: select tile elements at access-local positions
+        (C_i - x), write them to partition-local positions (C_i - p_i)
+        via one read-modify-write.
         """
-        coords = MemoryOps._enumerate_dist_coords(dist_tile_ref, tile.shape)
-        groups = MemoryOps._route_coords_to_partitions(dist_tile_ref, coords)
-        flat_values = tile.data.flatten()
+        x = dist_tile_ref.global_base or (0,) * len(dist_tile_ref.shape)
+        ndim = len(dist_tile_ref.shape)
 
-        for part_idx, (orig_positions, local_coords) in groups.items():
-            survivor = dist_tile_ref.partitions[part_idx]
+        for survivor in dist_tile_ref.partitions:
+            C_i = survivor.coordinate_set or []
+            p_i = survivor.partition_origin or (0,) * ndim
+            local_coords = [
+                tuple(c[d] - p_i[d] for d in range(ndim)) for c in C_i
+            ]
+            access_coords = [
+                tuple(c[d] - x[d] for d in range(ndim)) for c in C_i
+            ]
             mgr = _MemAccessor(context, survivor.memref.memory_space, survivor.base_ptr)
             offsets, _ = MemoryOps._flat_memory_offsets(
                 survivor.base_ptr, survivor.shape, survivor.strides, survivor.dtype,
@@ -546,5 +532,6 @@ class MemoryOps:
             )
             span = max(offsets) + 1 if offsets else 1
             flat = mgr.read(span, survivor.dtype)
-            flat[offsets] = flat_values[orig_positions]
+            for ac, off in zip(access_coords, offsets):
+                flat[off] = tile.data[ac]
             mgr.write(flat)

--- a/ktir_cpu/parser_ast.py
+++ b/ktir_cpu/parser_ast.py
@@ -58,7 +58,7 @@ import itertools
 import re
 from typing import List, Optional, Sequence, Tuple
 
-from .affine import AffineMap, AffineSet
+from .affine import AffineMap, AffineSet, BoxSet
 
 
 # ---------------------------------------------------------------------------
@@ -362,8 +362,13 @@ def parse_affine_map(s: str) -> AffineMap:
     )
 
 
-def parse_affine_set(s: str) -> AffineSet:
-    """Parse ``affine_set<(d0,...)[s0,...] : (c0 >= 0, ...)>`` into an :class:`AffineSet`.
+def parse_affine_set_raw(s: str) -> AffineSet:
+    """Parse ``affine_set<...>`` into an :class:`AffineSet` without lowering.
+
+    Unlike :func:`parse_affine_set`, this always returns an ``AffineSet`` —
+    no parse-time lowering to :class:`BoxSet`.  Used by tests that
+    validate the constraint AST structure, and as a building block for
+    :func:`parse_affine_set`.
 
     The ``affine_set<...>`` wrapper and the ``[s0, ...]`` symbol list are optional.
 
@@ -395,6 +400,26 @@ def parse_affine_set(s: str) -> AffineSet:
         constraints=tuple(constraints),
         source=source,
     )
+
+
+def parse_affine_set(s: str):
+    """Parse ``affine_set<(d0,...)[s0,...] : (c0 >= 0, ...)>``.
+
+    Returns a :class:`BoxSet` when the set is axis-aligned and both lo/hi
+    are pinned on every axis; otherwise returns the :class:`AffineSet`
+    fallback.  The ``affine_set<...>`` wrapper is optional.  For tests
+    that need the raw ``AffineSet`` regardless of lowerability, call
+    :func:`parse_affine_set_raw`.
+
+    Symbolic sets (``n_syms > 0``) currently stay on the ``AffineSet``
+    branch — see ``BoxSet.try_from_affine_set``'s TODO.
+
+    Raises:
+        ValueError: on any parse error.
+    """
+    aset = parse_affine_set_raw(s)
+    box = BoxSet.try_from_affine_set(aset)
+    return box if box is not None else aset
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_affine.py
+++ b/tests/test_affine.py
@@ -12,15 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for affine.py — AffineMap and AffineSet value objects.
+"""Tests for affine.py — AffineMap, AffineSet, and BoxSet value objects.
 
-These tests verify that the convenience methods (eval, contains, enumerate)
-on AffineMap and AffineSet correctly delegate to parser_ast.py.  They are
-intentionally thin — the heavy evaluation logic is tested in test_ast.py.
+These tests verify that the convenience methods on AffineMap and AffineSet
+correctly delegate to parser_ast.py.  They are intentionally thin — the heavy
+evaluation logic is tested in test_ast.py.
+
+Note on parse-time lowering: axis-aligned sets (e.g. box constraints) are
+lowered to BoxSet at parse time.  Tests that specifically exercise the
+AffineSet branch use non-axis-aligned sets like ``d1 - d0 >= 0``.
 """
 
 import pytest
 
+from ktir_cpu.affine import AffineSet, BoxSet
 from ktir_cpu.parser_ast import parse_affine_map, parse_affine_set
 
 
@@ -51,44 +56,241 @@ class TestAffineMapObject:
 
 
 class TestAffineSetObject:
+    """AffineSet behaviour on sets that are *not* lowerable to BoxSet."""
 
     def test_contains_delegates(self):
-        s = parse_affine_set("affine_set<(d0) : (d0 >= 0, -d0 + 3 >= 0)>")
-        assert s.contains([2])
-        assert not s.contains([5])
+        # Non-axis-aligned: d1 >= d0 and the box bounds.  Parse-time lowering
+        # rejects this and keeps it as AffineSet.
+        s = parse_affine_set("affine_set<(d0, d1) : (d1 - d0 >= 0, d0 >= 0, -d0 + 3 >= 0, d1 >= 0, -d1 + 3 >= 0)>")
+        assert isinstance(s, AffineSet)
+        assert s.contains([1, 2])
+        assert not s.contains([2, 1])
 
     def test_enumerate_delegates(self):
-        s = parse_affine_set("affine_set<(d0) : (d0 >= 0, -d0 + 3 >= 0)>")
-        assert s.enumerate((4,)) == [(0,), (1,), (2,), (3,)]
+        # Upper-triangular 2x2: points satisfying d1 >= d0 in [0,2)^2.
+        s = parse_affine_set("affine_set<(d0, d1) : (d1 - d0 >= 0)>")
+        assert isinstance(s, AffineSet)
+        assert s.enumerate((2, 2)) == [(0, 0), (0, 1), (1, 1)]
 
     def test_enumerate_wrong_shape_raises(self):
-        s = parse_affine_set("affine_set<(d0, d1) : (d0 >= 0, d1 >= 0)>")
+        s = parse_affine_set("affine_set<(d0, d1) : (d1 - d0 >= 0)>")
         with pytest.raises(ValueError):
             s.enumerate((4,))
 
     def test_source_field(self):
-        src = "affine_set<(d0) : (d0 >= 0, -d0 + 7 >= 0)>"
+        src = "affine_set<(d0, d1) : (d1 - d0 >= 0)>"
         s = parse_affine_set(src)
+        assert isinstance(s, AffineSet)
         assert s.source == src
 
     def test_frozen(self):
-        s = parse_affine_set("affine_set<(d0) : (d0 >= 0)>")
+        s = parse_affine_set("affine_set<(d0, d1) : (d1 - d0 >= 0)>")
         with pytest.raises((AttributeError, TypeError)):
             s.n_dims = 99  # type: ignore[misc]
 
-    def test_n_syms_default_zero(self):
-        s = parse_affine_set("affine_set<(d0) : (d0 >= 0)>")
-        assert s.n_syms == 0
+    def test_is_full_false(self):
+        """Upper-triangular set (d1 >= d0) is not full — corner (3,0) is excluded."""
+        s = parse_affine_set("affine_set<(d0, d1) : (d1 - d0 >= 0)>")
+        assert isinstance(s, AffineSet)
+        assert not s.is_full((4, 4))
 
-    def test_n_syms_parsed(self):
-        s = parse_affine_set("affine_set<(d0)[s0] : (d0 >= 0, -d0 + s0 - 1 >= 0)>")
-        assert s.n_syms == 1
+    def test_is_full_wrong_ndim(self):
+        """Shape ndim != set n_dims always returns False."""
+        # Use a non-lowerable set to stay on the AffineSet branch.
+        s = parse_affine_set("affine_set<(d0, d1) : (d1 - d0 >= 0)>")
+        assert isinstance(s, AffineSet)
+        assert not s.is_full((2,))
 
-    def test_contains_with_symbol(self):
-        s = parse_affine_set("affine_set<(d0)[s0] : (d0 >= 0, -d0 + s0 - 1 >= 0)>")
-        assert s.contains([3], symbols=[8])
-        assert not s.contains([8], symbols=[8])
 
-    def test_enumerate_with_symbol(self):
-        s = parse_affine_set("affine_set<(d0)[s0] : (d0 >= 0, -d0 + s0 - 1 >= 0)>")
-        assert s.enumerate((10,), symbols=[4]) == [(0,), (1,), (2,), (3,)]
+class TestBoxSetBasics:
+    """Direct construction and core operations on BoxSet."""
+
+    def test_contains(self):
+        b = BoxSet(lo=(0, 0), hi=(2, 3))
+        assert b.contains((0, 0))
+        assert b.contains((1, 2))
+        assert not b.contains((2, 0))  # hi is exclusive
+        assert not b.contains((0, 3))
+        assert not b.contains((-1, 0))
+
+    def test_contains_wrong_ndim(self):
+        b = BoxSet(lo=(0,), hi=(3,))
+        assert not b.contains((0, 0))
+
+    def test_enumerate_no_shape(self):
+        b = BoxSet(lo=(1, 2), hi=(3, 4))
+        assert b.enumerate() == [(1, 2), (1, 3), (2, 2), (2, 3)]
+
+    def test_enumerate_shape_matches_hi(self):
+        """Passing shape == hi is allowed (signature parity with AffineSet)."""
+        b = BoxSet(lo=(0, 0), hi=(2, 2))
+        assert b.enumerate((2, 2)) == [(0, 0), (0, 1), (1, 0), (1, 1)]
+
+    def test_enumerate_shape_upper_bounds_hi(self):
+        """Shape may be a strict upper bound — box stays self-bounded."""
+        b = BoxSet(lo=(0, 0), hi=(2, 2))
+        # 4×4 nominal bounding box; box is a 2×2 sub-region.  The call site
+        # treats shape as the enclosing tile; the box only enumerates itself.
+        assert b.enumerate((4, 4)) == [(0, 0), (0, 1), (1, 0), (1, 1)]
+
+    def test_enumerate_shape_below_hi_raises(self):
+        """If the box extends past shape, the call site has an invariant bug."""
+        b = BoxSet(lo=(0, 0), hi=(3, 3))
+        with pytest.raises(ValueError):
+            b.enumerate((2, 4))
+
+    def test_enumerate_shape_ndim_mismatch_raises(self):
+        b = BoxSet(lo=(0, 0), hi=(2, 2))
+        with pytest.raises(ValueError):
+            b.enumerate((2,))
+
+    def test_is_empty(self):
+        assert not BoxSet(lo=(0, 0), hi=(2, 2)).is_empty()
+        assert BoxSet(lo=(2, 0), hi=(2, 2)).is_empty()   # zero-width axis
+        assert BoxSet(lo=(3, 0), hi=(2, 2)).is_empty()   # hi < lo
+
+    def test_is_full(self):
+        assert BoxSet(lo=(0, 0), hi=(2, 3)).is_full((2, 3))
+        assert not BoxSet(lo=(0, 0), hi=(2, 3)).is_full((2, 4))
+        assert not BoxSet(lo=(1, 0), hi=(2, 3)).is_full((2, 3))
+
+    def test_is_full_wrong_ndim(self):
+        assert not BoxSet(lo=(0,), hi=(3,)).is_full((3, 3))
+
+    def test_lower_bounds(self):
+        assert BoxSet(lo=(2, 5), hi=(4, 7)).lower_bounds() == (2, 5)
+
+    def test_translate(self):
+        b = BoxSet(lo=(0, 0), hi=(2, 2))
+        t = b.translate((10, 20))
+        assert t == BoxSet(lo=(10, 20), hi=(12, 22))
+
+    def test_translate_wrong_ndim(self):
+        with pytest.raises(ValueError):
+            BoxSet(lo=(0, 0), hi=(2, 2)).translate((1,))
+
+    def test_intersect_disjoint_is_empty(self):
+        a = BoxSet(lo=(0, 0), hi=(2, 2))
+        b = BoxSet(lo=(2, 0), hi=(4, 2))
+        c = a.intersect(b)
+        assert c.is_empty()
+
+    def test_intersect_overlap(self):
+        a = BoxSet(lo=(0, 0), hi=(3, 3))
+        b = BoxSet(lo=(1, 1), hi=(5, 5))
+        c = a.intersect(b)
+        assert c == BoxSet(lo=(1, 1), hi=(3, 3))
+
+    def test_intersect_ndim_mismatch(self):
+        with pytest.raises(ValueError):
+            BoxSet(lo=(0,), hi=(2,)).intersect(BoxSet(lo=(0, 0), hi=(2, 2)))
+
+    def test_intersect_mixed_type_raises(self):
+        """BoxSet.intersect(AffineSet) is rejected — no auto-promotion."""
+        box = BoxSet(lo=(0, 0), hi=(2, 2))
+        aset = parse_affine_set("affine_set<(d0, d1) : (d1 - d0 >= 0)>")
+        assert isinstance(aset, AffineSet)
+        with pytest.raises(TypeError):
+            box.intersect(aset)  # type: ignore[arg-type]
+
+    def test_frozen(self):
+        b = BoxSet(lo=(0, 0), hi=(2, 2))
+        with pytest.raises((AttributeError, TypeError)):
+            b.lo = (1, 1)  # type: ignore[misc]
+
+    def test_construction_ndim_mismatch(self):
+        with pytest.raises(ValueError):
+            BoxSet(lo=(0, 0), hi=(2,))
+
+
+class TestTryFromAffineSet:
+    """Parse-time lowering from AffineSet to BoxSet."""
+
+    def _parse_aset(self, src: str) -> AffineSet:
+        """Build an AffineSet bypassing parse_affine_set's own lowering hook."""
+        # We call the parser but it may return BoxSet; for reject tests we
+        # want to drive try_from_affine_set directly with an AffineSet AST.
+        # Constructing via parser internals is fine because these tests sit
+        # next to the parser.
+        from ktir_cpu.parser_ast import (
+            _Parser, _strip_outer, _tokenise,
+        )
+        source = src.strip()
+        inner = _strip_outer(source, "affine_set")
+        colon = inner.index(":")
+        dim_part = inner[:colon].strip()
+        con_part = inner[colon + 1:].strip()
+        p1 = _Parser(_tokenise(dim_part))
+        dim_names = p1.parse_dim_list()
+        p2 = _Parser(_tokenise(con_part))
+        p2.dim_index = {name: idx for idx, name in enumerate(dim_names)}
+        constraints = p2.parse_constraint_list()
+        return AffineSet(n_dims=len(dim_names), constraints=tuple(constraints), source=source)
+
+    def test_accept_1d_range(self):
+        aset = self._parse_aset("affine_set<(d0) : (d0 >= 0, -d0 + 3 >= 0)>")
+        box = BoxSet.try_from_affine_set(aset)
+        assert box == BoxSet(lo=(0,), hi=(4,))
+
+    def test_accept_2d_box(self):
+        aset = self._parse_aset(
+            "affine_set<(d0, d1) : (d0 >= 0, -d0 + 1 >= 0, d1 >= 0, -d1 + 3 >= 0)>"
+        )
+        box = BoxSet.try_from_affine_set(aset)
+        assert box == BoxSet(lo=(0, 0), hi=(2, 4))
+
+    def test_accept_nonzero_origin(self):
+        # d0 >= 2, d0 <= 5  →  lo=2, hi=6
+        aset = self._parse_aset("affine_set<(d0) : (d0 - 2 >= 0, -d0 + 5 >= 0)>")
+        box = BoxSet.try_from_affine_set(aset)
+        assert box == BoxSet(lo=(2,), hi=(6,))
+
+    def test_accept_tightest_bounds(self):
+        # Two lo constraints (d0 >= 0, d0 >= 2) and two hi (d0 <= 5, d0 <= 3):
+        # lo = max(0, 2) = 2, hi = min(6, 4) = 4.
+        aset = self._parse_aset(
+            "affine_set<(d0) : (d0 >= 0, d0 - 2 >= 0, -d0 + 5 >= 0, -d0 + 3 >= 0)>"
+        )
+        box = BoxSet.try_from_affine_set(aset)
+        assert box == BoxSet(lo=(2,), hi=(4,))
+
+    def test_reject_not_axis_aligned(self):
+        """Upper-triangular d1 >= d0: two dims in one constraint."""
+        aset = self._parse_aset("affine_set<(d0, d1) : (d1 - d0 >= 0)>")
+        assert BoxSet.try_from_affine_set(aset) is None
+
+    def test_reject_missing_upper_bound(self):
+        """d0 >= 0 alone pins lo but not hi — reject."""
+        aset = self._parse_aset("affine_set<(d0) : (d0 >= 0)>")
+        assert BoxSet.try_from_affine_set(aset) is None
+
+    def test_reject_missing_lower_bound(self):
+        aset = self._parse_aset("affine_set<(d0) : (-d0 + 3 >= 0)>")
+        assert BoxSet.try_from_affine_set(aset) is None
+
+    def test_reject_nonunit_coefficient(self):
+        """2 * d0 >= 0 — unit coefficients only."""
+        aset = self._parse_aset("affine_set<(d0) : (2 * d0 >= 0, -d0 + 3 >= 0)>")
+        assert BoxSet.try_from_affine_set(aset) is None
+
+    def test_reject_one_axis_unpinned(self):
+        """2D set where d1 has no upper bound."""
+        aset = self._parse_aset(
+            "affine_set<(d0, d1) : (d0 >= 0, -d0 + 3 >= 0, d1 >= 0)>"
+        )
+        assert BoxSet.try_from_affine_set(aset) is None
+
+
+class TestParseAffineSetLowering:
+    """End-to-end: parse_affine_set returns BoxSet for axis-aligned sets."""
+
+    def test_axis_aligned_becomes_box(self):
+        s = parse_affine_set(
+            "affine_set<(d0, d1) : (d0 >= 0, -d0 + 3 >= 0, d1 >= 0, -d1 + 3 >= 0)>"
+        )
+        assert isinstance(s, BoxSet)
+        assert s == BoxSet(lo=(0, 0), hi=(4, 4))
+
+    def test_non_box_stays_affine_set(self):
+        s = parse_affine_set("affine_set<(d0, d1) : (d1 - d0 >= 0)>")
+        assert isinstance(s, AffineSet)

--- a/tests/test_ast.py
+++ b/tests/test_ast.py
@@ -25,7 +25,7 @@ from ktir_cpu.parser_ast import (
     parse_expr,
     eval_expr,
     parse_affine_map,
-    parse_affine_set,
+    parse_affine_set_raw as parse_affine_set,
     eval_affine_map,
     affine_set_contains,
     enumerate_affine_set,

--- a/tests/test_dialects_exec.py
+++ b/tests/test_dialects_exec.py
@@ -29,7 +29,6 @@ from ktir_cpu.ir_types import Operation, Tile
 from ktir_cpu.grid import CoreContext, GridExecutor
 from ktir_cpu.memory import HBMSimulator, LXScratchpad, SpyreMemoryHierarchy
 from ktir_cpu.dialects.registry import dispatch, ExecutionEnv
-from ktir_cpu.ops.comm_ops import RingNetwork
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -58,7 +57,6 @@ def _make_ctx(grid_pos=(0, 0, 0), core_id=0):
 def _make_env(grid_shape=(1, 1, 1)):
     memory = SpyreMemoryHierarchy(num_cores=1)
     grid = GridExecutor(grid_shape=grid_shape, memory=memory)
-    ring = RingNetwork(num_cores=1)
 
     def execute_region(context, ops):
         result = None
@@ -66,7 +64,7 @@ def _make_env(grid_shape=(1, 1, 1)):
             result = op(context)
         return result
 
-    return ExecutionEnv(grid_executor=grid, ring=ring, execute_region=execute_region)
+    return ExecutionEnv(grid_executor=grid, ring_backend=None, execute_region=execute_region)
 
 
 def _call(op_type, context, env, **op_kwargs):

--- a/tests/test_distributed_view.py
+++ b/tests/test_distributed_view.py
@@ -1,0 +1,158 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for ktdp.construct_distributed_memory_view.
+
+Covers the RFC §C.3 reference example (distributed-view-copy.mlir) with
+data-correctness verification, plus a focused small-case test exercising
+mixed-memory-space routing and differing per-partition strides.
+"""
+
+import numpy as np
+import pytest
+
+from ktir_cpu import KTIRInterpreter
+from conftest import get_test_params
+
+
+def _write_strided(mem, base_ptr: int, block: np.ndarray, strides):
+    """Write ``block`` into *mem* so that element (r, c, ...) lands at
+    byte offset ``base_ptr + sum(coord_d * strides[d]) * 2`` (f16).
+
+    Uses a single dense buffer of length ``max_offset + 1`` so holes
+    caused by non-contiguous strides are preserved as zeros.
+    """
+    assert block.dtype == np.float16
+    ndim = block.ndim
+    assert len(strides) == ndim
+    coords = np.stack(np.meshgrid(*[np.arange(s) for s in block.shape], indexing='ij'), axis=-1)
+    coords = coords.reshape(-1, ndim)
+    offsets = coords @ np.array(strides, dtype=np.int64)
+    span = int(offsets.max()) + 1 if offsets.size else 1
+    buf = np.zeros(span, dtype=np.float16)
+    buf[offsets] = block.flatten()
+    mem.write(base_ptr, buf)
+
+
+# ---------------------------------------------------------------------------
+# RFC example: distributed-view-copy.mlir
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("path,func_name,entry", get_test_params("distributed_view_copy"))
+def test_distributed_view_copy_rfc(path, func_name, entry):
+    """construct_distributed_memory_view — RFC §C.3 example file.
+
+    A is a 192×64 logical tensor distributed across three regions:
+      A_HBM (96×64, HBM,         row-major strides [64, 1])  rows   0..95
+      A_LX0 (32×64, LX,          col-packed strides [1, 64]) rows  96..127
+      A_LX1 (64×64, LX,          row-major strides [64, 1])  rows 128..191
+    The kernel copies A into contiguous HBM output B, also 192×64.
+
+    The example file uses a single LX (no ``core = N`` annotation), so
+    A_LX0 and A_LX1 share the same scratchpad — A_LX1_addr=16384 collides
+    with A_LX0's strided footprint (max offset 31+63·64 = 4063 → reaches
+    byte 20416 from base 12288).  Skip until per-core LX routing lands.
+    """
+    pytest.skip(
+        "RFC distributed-view-copy.mlir aliases A_LX0 and A_LX1 in a single "
+        "LX scratchpad; needs per-core LX routing (forthcoming) to honor "
+        "#ktdp.spyre_memory_space<LX, core = N>"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Focused small unit test: 2 partitions, mixed memory spaces, differing strides
+# ---------------------------------------------------------------------------
+
+_SMALL_MLIR = """
+#A0_set = affine_set<(d0, d1) : (d0 >= 0,   -d0 + 1 >= 0, d1 >= 0, -d1 + 3 >= 0)>
+#A1_set = affine_set<(d0, d1) : (d0 - 2 >= 0, -d0 + 3 >= 0, d1 >= 0, -d1 + 3 >= 0)>
+#B_set  = affine_set<(d0, d1) : (d0 >= 0,   -d0 + 3 >= 0, d1 >= 0, -d1 + 3 >= 0)>
+#identity = affine_map<(d0, d1) -> (d0, d1)>
+
+module {
+  func.func @small_distributed_copy() {
+    %c0 = arith.constant 0 : index
+    %A0_addr = arith.constant 0     : index
+    %A1_addr = arith.constant 4096  : index
+    %B_addr  = arith.constant 8192  : index
+
+    // A0: rows 0..1, HBM, row-major (strides [4, 1])
+    %A0 = ktdp.construct_memory_view %A0_addr, sizes: [2, 4], strides: [4, 1] {
+        coordinate_set = #A0_set,
+        memory_space = #ktdp.spyre_memory_space<HBM>
+    } : memref<2x4xf16>
+
+    // A1: rows 2..3, LX, column-packed (strides [1, 4])
+    %A1 = ktdp.construct_memory_view %A1_addr, sizes: [2, 4], strides: [1, 4] {
+        coordinate_set = #A1_set,
+        memory_space = #ktdp.spyre_memory_space<LX>
+    } : memref<2x4xf16>
+
+    %A_global = ktdp.construct_distributed_memory_view
+        (%A0, %A1 : memref<2x4xf16>, memref<2x4xf16>) : memref<4x4xf16>
+
+    // Output B on HBM, row-major
+    %B = ktdp.construct_memory_view %B_addr, sizes: [4, 4], strides: [4, 1] {
+        coordinate_set = #B_set,
+        memory_space = #ktdp.spyre_memory_space<HBM>
+    } : memref<4x4xf16>
+
+    %A_at = ktdp.construct_access_tile %A_global[%c0, %c0] {
+        access_tile_set = #B_set,
+        access_tile_order = #identity
+    } : memref<4x4xf16> -> !ktdp.access_tile<4x4xindex>
+
+    %B_at = ktdp.construct_access_tile %B[%c0, %c0] {
+        access_tile_set = #B_set,
+        access_tile_order = #identity
+    } : memref<4x4xf16> -> !ktdp.access_tile<4x4xindex>
+
+    %data = ktdp.load %A_at : !ktdp.access_tile<4x4xindex> -> tensor<4x4xf16>
+    ktdp.store %data, %B_at : tensor<4x4xf16>, !ktdp.access_tile<4x4xindex>
+    return
+  }
+}
+"""
+
+
+def test_small_distributed_copy_mixed_spaces_and_strides():
+    """2-partition distributed view: HBM row-major + LX column-packed.
+
+    Verifies end-to-end that (1) each global coord routes to the correct
+    partition, (2) HBM and LX partitions coexist in one view, and
+    (3) differing stride patterns per partition are honored.
+    """
+    interp = KTIRInterpreter()
+    interp.load(_SMALL_MLIR)
+    _orig = interp._prepare_execution
+
+    def _prepare_and_seed(grid_shape):
+        _orig(grid_shape)
+        hbm = interp.memory.hbm
+        lx0 = interp.memory.get_lx(0)
+        full = np.arange(16, dtype=np.float16).reshape(4, 4)
+        # A0: rows 0..1 of full, row-major in HBM.
+        hbm.write(0, full[0:2, :].flatten())
+        # A1: rows 2..3 of full, strided [1, 4] in LX.
+        _write_strided(lx0, 4096, full[2:4, :].copy(), strides=[1, 4])
+        # B output zeroed.
+        hbm.write(8192, np.zeros(16, dtype=np.float16))
+
+    interp._prepare_execution = _prepare_and_seed
+    interp.execute_function("small_distributed_copy")
+
+    b = interp.memory.hbm.read(8192, 16, "f16").reshape(4, 4)
+    expected = np.arange(16, dtype=np.float16).reshape(4, 4)
+    np.testing.assert_array_equal(b, expected)

--- a/tests/test_distributed_view.py
+++ b/tests/test_distributed_view.py
@@ -67,24 +67,6 @@ def _get_mem(interp, space: str):
 # MLIR builder
 # ---------------------------------------------------------------------------
 
-def _affine_set_rows(r0: int, r1: int, c0: int, c1: int) -> str:
-    """Return affine_set string covering rows r0..r1, cols c0..c1 (inclusive)."""
-    return (
-        f"affine_set<(d0, d1) : "
-        f"(d0 - {r0} >= 0, -{r0} + {r1} - d0 + {r0} >= 0, "
-        f"d1 - {c0} >= 0, -{c0} + {c1} - d1 + {c0} >= 0)>"
-    ).replace("(d0 - 0 >= 0", "(d0 >= 0").replace("(d1 - 0 >= 0", "(d1 >= 0")
-
-
-def _set_rows(r0: int, r1: int, ncols: int) -> str:
-    """affine_set covering rows [r0, r1] and all cols [0, ncols-1]."""
-    row_lo = f"d0 - {r0} >= 0" if r0 > 0 else "d0 >= 0"
-    row_hi = f"-d0 + {r1} >= 0"
-    col_lo = "d1 >= 0"
-    col_hi = f"-d1 + {ncols - 1} >= 0"
-    return f"affine_set<(d0, d1) : ({row_lo}, {row_hi}, {col_lo}, {col_hi})>"
-
-
 def _set_box(r0: int, r1: int, c0: int, c1: int) -> str:
     """affine_set covering [r0,r1] x [c0,c1] (all inclusive)."""
     parts = []
@@ -568,3 +550,373 @@ def test_distributed_copy(spec: DistCopySpec):
     """
     expected, actual = _seed_and_run(spec)
     np.testing.assert_array_equal(actual, expected)
+
+
+# ---------------------------------------------------------------------------
+# Structural: fast path produces BoxSet in surviving partitions
+# ---------------------------------------------------------------------------
+
+def test_distributed_tile_access_fast_path_emits_box_set():
+    """When B_i and A are both boxes, C_i must be stored as a BoxSet.
+
+    Confirms that the BoxSet refactor wires end-to-end: parse-time
+    lowering turns the partition coordinate_set into BoxSet, and
+    distributed_tile_access's fast path stores the intersection as a
+    BoxSet (not a pre-enumerated point list).  A regression here would
+    silently drop us to the slow path and re-introduce the per-partition
+    enumeration cost.
+    """
+    from ktir_cpu.affine import AffineMap, BoxSet
+    from ktir_cpu.ir_types import DistributedMemRef, MemRef
+    from ktir_cpu.ops.memory_ops import MemoryOps
+    from ktir_cpu.parser_ast import parse_affine_map, parse_affine_set
+
+    # Build 2 row-band partitions of a 4×4 tensor: P0 rows 0..1, P1 rows 2..3.
+    B0 = parse_affine_set("affine_set<(d0, d1) : (d0 >= 0, -d0 + 1 >= 0, d1 >= 0, -d1 + 3 >= 0)>")
+    B1 = parse_affine_set("affine_set<(d0, d1) : (d0 - 2 >= 0, -d0 + 3 >= 0, d1 >= 0, -d1 + 3 >= 0)>")
+    assert isinstance(B0, BoxSet) and isinstance(B1, BoxSet)  # sanity
+
+    P0 = MemRef(base_ptr=0, shape=(2, 4), strides=[4, 1], memory_space="HBM", coordinate_set=B0)
+    P1 = MemRef(base_ptr=64, shape=(2, 4), strides=[4, 1], memory_space="HBM", coordinate_set=B1)
+    dist = DistributedMemRef(partitions=[P0, P1], shape=(4, 4), dtype="f16")
+
+    # Full-tile access from the origin: both partitions survive with their
+    # own extents as C_i.
+    base_map = parse_affine_map("affine_map<(d0, d1) -> (d0, d1)>")
+    assert isinstance(base_map, AffineMap)
+    out = MemoryOps.distributed_tile_access(
+        dist_ref=dist,
+        access_shape=(4, 4),
+        base_map=base_map,
+        indices=[0, 0],
+        access_tile_set=None,
+    )
+    assert len(out.partitions) == 2
+    for part in out.partitions:
+        assert isinstance(part.coordinate_set, BoxSet), (
+            f"fast path must store BoxSet in coordinate_set, got "
+            f"{type(part.coordinate_set).__name__}"
+        )
+    # P0 survives with rows 0..1 × cols 0..3; P1 with rows 2..3 × cols 0..3.
+    assert out.partitions[0].coordinate_set == BoxSet(lo=(0, 0), hi=(2, 4))
+    assert out.partitions[1].coordinate_set == BoxSet(lo=(2, 0), hi=(4, 4))
+    # partition_origin == min(B_i)
+    assert out.partitions[0].partition_origin == (0, 0)
+    assert out.partitions[1].partition_origin == (2, 0)
+
+
+# ---------------------------------------------------------------------------
+# distributed_tile_access fast/slow path: verified against a static fixture
+#
+# Scenario (shared by both tests below):
+#   - 256×512 distributed view, 4 row-band partitions of 64×512
+#     (partition_rows scaled down from the 2048×8192 Triton matmul view
+#     so the slow path's brute-force enumeration stays CI-tractable).
+#   - Access tile shape 32×128 — matches the A-tile size in
+#     examples/triton-ktir/matmul_fwd_ktir.mlir.
+#   - base_map = identity; access_tile_set = None (full box A).
+#
+# Fixture: for each indices value, the expected list of surviving partitions,
+# each described by (C_i extent as (lo, hi), expected partition_origin).
+# C_i = [max(r, r0_i), min(r+32, r1_i)) × [c, c+128) where x = (r, c).
+# ---------------------------------------------------------------------------
+
+_SHAPE = (256, 512)
+_PARTITION_ROWS = [(0, 64), (64, 128), (128, 192), (192, 256)]
+_ACCESS_SHAPE = (32, 128)
+
+# Each fixture entry: (id, indices, [(C_i_lo, C_i_hi, partition_origin), ...])
+# partition_origin = (r0_i, 0) — the lower corner of the partition's own extent.
+_FIXTURE = [
+    # Access origin inside P0, no boundary crossing.
+    ("single_partition", (10, 0), [
+        ((10, 0), (42, 128), (0, 0)),
+    ]),
+    # Access rows 50..81 span P0 (rows 50..63) and P1 (rows 64..81).
+    ("cross_boundary", (50, 64), [
+        ((50, 64), (64, 192), (0, 0)),
+        ((64, 64), (82, 192), (64, 0)),
+    ]),
+    # Access rows 200..231, cols 256..383 — lands inside P3 only.
+    ("last_partition", (200, 256), [
+        ((200, 256), (232, 384), (192, 0)),
+    ]),
+    # Access from origin: first 32 rows of P0, first 128 cols.
+    ("origin", (0, 0), [
+        ((0, 0), (32, 128), (0, 0)),
+    ]),
+]
+
+
+def _build_partitions(parser):
+    """Build 4 row-band partitions with coordinate_set parsed by *parser*.
+
+    Passing ``parse_affine_set`` lowers axis-aligned sets to BoxSet
+    (fast path); ``parse_affine_set_raw`` keeps them as AffineSet (slow path).
+    """
+    from ktir_cpu.ir_types import MemRef
+    _, ncols = _SHAPE
+    parts: List[MemRef] = []
+    for r0, r1 in _PARTITION_ROWS:
+        src = (
+            f"affine_set<(d0, d1) : "
+            f"(d0 - {r0} >= 0, -d0 + {r1 - 1} >= 0, "
+            f"d1 >= 0, -d1 + {ncols - 1} >= 0)>"
+        )
+        parts.append(MemRef(
+            base_ptr=r0 * ncols * 2,   # f16 = 2 bytes; placeholder addr
+            shape=(r1 - r0, ncols),
+            strides=[ncols, 1],
+            memory_space="HBM",
+            coordinate_set=parser(src),
+        ))
+    return parts
+
+
+def _run_and_collect(partitions, indices):
+    """Run distributed_tile_access and return [(C_i_pts_sorted, origin), ...]."""
+    from ktir_cpu.affine import AffineMap, BoxSet
+    from ktir_cpu.ir_types import DistributedMemRef
+    from ktir_cpu.ops.memory_ops import MemoryOps
+    from ktir_cpu.parser_ast import parse_affine_map
+
+    dist = DistributedMemRef(
+        partitions=partitions, shape=_SHAPE, dtype="f16",
+    )
+    base_map = parse_affine_map("affine_map<(d0, d1) -> (d0, d1)>")
+    assert isinstance(base_map, AffineMap)
+    out = MemoryOps.distributed_tile_access(
+        dist_ref=dist, access_shape=_ACCESS_SHAPE,
+        base_map=base_map, indices=list(indices), access_tile_set=None,
+    )
+    collected = []
+    for part in out.partitions:
+        cs = part.coordinate_set
+        pts = cs.enumerate() if isinstance(cs, BoxSet) else cs
+        collected.append((sorted(pts), part.partition_origin, type(cs)))
+    return collected
+
+
+def _expected_points(lo, hi):
+    """Expand a box [lo, hi) into a sorted row-major point list."""
+    import itertools as _it
+    return sorted(_it.product(*(range(lo[d], hi[d]) for d in range(len(lo)))))
+
+
+@pytest.mark.parametrize("case_id, indices, expected", _FIXTURE, ids=[c[0] for c in _FIXTURE])
+def test_distributed_tile_access_fast_path(case_id, indices, expected):
+    """Fast path (BoxSet) produces the expected C_i extents and origins."""
+    from ktir_cpu.affine import BoxSet
+    from ktir_cpu.parser_ast import parse_affine_set
+
+    got = _run_and_collect(_build_partitions(parse_affine_set), indices)
+    assert len(got) == len(expected), f"{case_id}: partition count mismatch"
+    for (pts_got, origin_got, cs_type), (exp_lo, exp_hi, exp_origin) in zip(got, expected):
+        assert cs_type is BoxSet, f"{case_id}: fast path must emit BoxSet, got {cs_type.__name__}"
+        assert origin_got == exp_origin, f"{case_id}: origin {origin_got} != {exp_origin}"
+        assert pts_got == _expected_points(exp_lo, exp_hi), (
+            f"{case_id}: C_i mismatch for partition at origin {origin_got}"
+        )
+
+
+@pytest.mark.parametrize("case_id, indices, expected", _FIXTURE, ids=[c[0] for c in _FIXTURE])
+def test_distributed_tile_access_slow_path(case_id, indices, expected):
+    """Slow path (AffineSet brute-force enumerate) produces the same C_i.
+
+    Parses partition coordinate_sets via parse_affine_set_raw, which skips
+    the BoxSet lowering, forcing distributed_tile_access onto the
+    AffineSet.enumerate path.  Exercises ~130k AST walks per partition at
+    this fixture size — slow but tractable for CI, and confirms the two
+    paths agree on real-scale inputs.
+    """
+    from ktir_cpu.affine import AffineSet
+    from ktir_cpu.parser_ast import parse_affine_set_raw
+
+    got = _run_and_collect(_build_partitions(parse_affine_set_raw), indices)
+    assert len(got) == len(expected), f"{case_id}: partition count mismatch"
+    for (pts_got, origin_got, cs_type), (exp_lo, exp_hi, exp_origin) in zip(got, expected):
+        # Slow path stores a point list in coordinate_set, not a BoxSet.
+        assert cs_type is list, f"{case_id}: slow path must emit list, got {cs_type.__name__}"
+        assert origin_got == exp_origin, f"{case_id}: origin {origin_got} != {exp_origin}"
+        assert pts_got == _expected_points(exp_lo, exp_hi), (
+            f"{case_id}: C_i mismatch for partition at origin {origin_got}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# distributed_store fast path: writes touch ONLY the C_i rectangle
+#
+# The sub-TileRef construction in distributed_store inherits the parent's
+# strides verbatim and shifts base_ptr to the box's local origin.  A bug in
+# either of those (wrong stride, wrong byte offset, wrong sub-shape) could
+# silently overwrite memory adjacent to C_i — outside the rectangle but
+# still inside the partition's allocation.  test_distributed_copy doesn't
+# catch this: it only reads back the access-tile region, so trampled data
+# elsewhere goes unnoticed.
+#
+# These tests seed the WHOLE partition with a sentinel pattern, run a
+# distributed_store that touches only a small C_i sub-rectangle, and then
+# inspect every byte: C_i must hold the new data; every other byte must
+# still be the sentinel.  Two cases exercise the row-major and
+# column-packed stride layouts.
+# ---------------------------------------------------------------------------
+
+def test_distributed_store_does_not_trample_outside_C_i():
+    """Row-major partition: distributed_store must not write outside C_i."""
+    from ktir_cpu.affine import BoxSet
+    from ktir_cpu.dtypes import bytes_per_elem
+    from ktir_cpu.grid import CoreContext
+    from ktir_cpu.ir_types import DistributedMemRef, MemRef, Tile
+    from ktir_cpu.memory import HBMSimulator, LXScratchpad
+    from ktir_cpu.ops.memory_ops import MemoryOps
+    from ktir_cpu.parser_ast import parse_affine_map, parse_affine_set
+
+    PART_SHAPE = (8, 16)
+    NCOLS = 16
+    DTYPE = "f16"
+    bpe = bytes_per_elem(DTYPE)
+    elems_per_part = PART_SHAPE[0] * PART_SHAPE[1]
+    bytes_per_part = elems_per_part * bpe
+
+    hbm = HBMSimulator(size_gb=1)
+    # Allocate two contiguous partition regions; HBM is stick-addressed
+    # (upstream PR #32) so MemRef.base_ptr is a stick index.
+    P0_STICK = hbm.allocate(bytes_per_part)
+    P1_STICK = hbm.allocate(bytes_per_part)
+    SENTINEL = np.float16(-7.0)
+
+    hbm.write(P0_STICK, np.full(elems_per_part, SENTINEL, dtype=np.float16))
+    hbm.write(P1_STICK, np.full(elems_per_part, SENTINEL, dtype=np.float16))
+    ctx = CoreContext(core_id=0, grid_pos=(0, 0, 0),
+                      lx=LXScratchpad(size_mb=1, core_id=0), hbm=hbm)
+
+    # Box-form coordinate sets → BoxSet via parse-time lowering.
+    B0 = parse_affine_set("affine_set<(d0, d1) : (d0 >= 0, -d0 + 7 >= 0, d1 >= 0, -d1 + 15 >= 0)>")
+    B1 = parse_affine_set("affine_set<(d0, d1) : (d0 - 8 >= 0, -d0 + 15 >= 0, d1 >= 0, -d1 + 15 >= 0)>")
+    assert isinstance(B0, BoxSet) and isinstance(B1, BoxSet)
+
+    P0 = MemRef(base_ptr=P0_STICK, shape=PART_SHAPE, strides=[NCOLS, 1],
+                memory_space="HBM", dtype=DTYPE, coordinate_set=B0)
+    P1 = MemRef(base_ptr=P1_STICK, shape=PART_SHAPE, strides=[NCOLS, 1],
+                memory_space="HBM", dtype=DTYPE, coordinate_set=B1)
+    dist = DistributedMemRef(partitions=[P0, P1], shape=(16, 16), dtype=DTYPE)
+
+    # 4×4 access at (2, 4) — fully inside P0; C_i = [2,6) × [4,8).
+    access_shape = (4, 4)
+    indices = (2, 4)
+    base_map = parse_affine_map("affine_map<(d0, d1) -> (d0, d1)>")
+    resolved = MemoryOps.distributed_tile_access(
+        dist_ref=dist, access_shape=access_shape, base_map=base_map,
+        indices=list(indices), access_tile_set=None,
+    )
+    assert len(resolved.partitions) == 1, "P1 should be pruned"
+    assert isinstance(resolved.partitions[0].coordinate_set, BoxSet)
+    assert resolved.partitions[0].coordinate_set == BoxSet(lo=(2, 4), hi=(6, 8))
+
+    payload_values = np.arange(1, 17, dtype=np.float16).reshape(4, 4)
+    MemoryOps.distributed_store(ctx, Tile(payload_values, DTYPE, access_shape), resolved)
+
+    p0_full = hbm.read(P0_STICK, elems_per_part, DTYPE).reshape(PART_SHAPE)
+    p1_full = hbm.read(P1_STICK, elems_per_part, DTYPE).reshape(PART_SHAPE)
+
+    # P1 entirely untouched (was pruned, must not have been visited).
+    assert np.all(p1_full == SENTINEL), \
+        "P1 was trampled — distributed_store wrote outside the surviving partition"
+
+    # Inside C_i: payload data.  Outside C_i: still sentinel.
+    c_i_slice = (slice(2, 6), slice(4, 8))
+    np.testing.assert_array_equal(
+        p0_full[c_i_slice], payload_values,
+        err_msg="C_i sub-rectangle of P0 has wrong values",
+    )
+    mask = np.zeros(PART_SHAPE, dtype=bool)
+    mask[c_i_slice] = True
+    outside = p0_full[~mask]
+    assert np.all(outside == SENTINEL), (
+        f"P0 has {(outside != SENTINEL).sum()} cell(s) outside C_i that "
+        f"differ from the sentinel — distributed_store trampled neighbouring "
+        f"memory."
+    )
+
+
+def test_distributed_store_col_packed_does_not_trample_outside_C_i():
+    """Column-packed partition (strides=[1, R]): same trample check.
+
+    Stresses the sub-TileRef stride-inheritance claim: the sub-tile must
+    reuse the parent's strides=[1, R], not synthesise row-major strides
+    for its own sub-shape.  A bug there would scatter the written data
+    across column-packed memory and trample sentinels outside C_i.
+    """
+    from ktir_cpu.affine import BoxSet
+    from ktir_cpu.dtypes import bytes_per_elem
+    from ktir_cpu.grid import CoreContext
+    from ktir_cpu.ir_types import DistributedMemRef, MemRef, Tile
+    from ktir_cpu.memory import HBMSimulator, LXScratchpad
+    from ktir_cpu.ops.memory_ops import MemoryOps
+    from ktir_cpu.parser_ast import parse_affine_map, parse_affine_set
+
+    PART_SHAPE = (8, 16)
+    NROWS = 8
+    DTYPE = "f16"
+    bpe = bytes_per_elem(DTYPE)
+    elems_per_part = PART_SHAPE[0] * PART_SHAPE[1]
+    bytes_per_part = elems_per_part * bpe
+
+    hbm = HBMSimulator(size_gb=1)
+    P0_STICK = hbm.allocate(bytes_per_part)
+    P1_STICK = hbm.allocate(bytes_per_part)
+    SENTINEL = np.float16(99.0)
+
+    hbm.write(P0_STICK, np.full(elems_per_part, SENTINEL, dtype=np.float16))
+    hbm.write(P1_STICK, np.full(elems_per_part, SENTINEL, dtype=np.float16))
+    ctx = CoreContext(core_id=0, grid_pos=(0, 0, 0),
+                      lx=LXScratchpad(size_mb=1, core_id=0), hbm=hbm)
+
+    B0 = parse_affine_set("affine_set<(d0, d1) : (d0 >= 0, -d0 + 7 >= 0, d1 >= 0, -d1 + 15 >= 0)>")
+    B1 = parse_affine_set("affine_set<(d0, d1) : (d0 - 8 >= 0, -d0 + 15 >= 0, d1 >= 0, -d1 + 15 >= 0)>")
+    assert isinstance(B0, BoxSet) and isinstance(B1, BoxSet)
+
+    # strides=[1, NROWS] → column-packed: element (r, c) at offset r + c*NROWS.
+    P0 = MemRef(base_ptr=P0_STICK, shape=PART_SHAPE, strides=[1, NROWS],
+                memory_space="HBM", dtype=DTYPE, coordinate_set=B0)
+    P1 = MemRef(base_ptr=P1_STICK, shape=PART_SHAPE, strides=[1, NROWS],
+                memory_space="HBM", dtype=DTYPE, coordinate_set=B1)
+    dist = DistributedMemRef(partitions=[P0, P1], shape=(16, 16), dtype=DTYPE)
+
+    access_shape = (4, 4)
+    indices = (2, 4)
+    base_map = parse_affine_map("affine_map<(d0, d1) -> (d0, d1)>")
+    resolved = MemoryOps.distributed_tile_access(
+        dist_ref=dist, access_shape=access_shape, base_map=base_map,
+        indices=list(indices), access_tile_set=None,
+    )
+    assert len(resolved.partitions) == 1
+    assert isinstance(resolved.partitions[0].coordinate_set, BoxSet)
+
+    payload_values = np.arange(1, 17, dtype=np.float16).reshape(4, 4)
+    MemoryOps.distributed_store(ctx, Tile(payload_values, DTYPE, access_shape), resolved)
+
+    p0_flat = hbm.read(P0_STICK, elems_per_part, DTYPE)
+    p1_flat = hbm.read(P1_STICK, elems_per_part, DTYPE)
+
+    # P1 entirely untouched.
+    assert np.all(p1_flat == SENTINEL), "P1 was trampled (col-packed case)"
+
+    # Reconstruct P0's logical grid via the column-packed strides.
+    p0_logical = np.empty(PART_SHAPE, dtype=np.float16)
+    for r in range(PART_SHAPE[0]):
+        for c in range(PART_SHAPE[1]):
+            p0_logical[r, c] = p0_flat[r * 1 + c * NROWS]
+
+    c_i_slice = (slice(2, 6), slice(4, 8))
+    np.testing.assert_array_equal(
+        p0_logical[c_i_slice], payload_values,
+        err_msg="C_i sub-rectangle has wrong values (col-packed)",
+    )
+    mask = np.zeros(PART_SHAPE, dtype=bool)
+    mask[c_i_slice] = True
+    outside = p0_logical[~mask]
+    assert np.all(outside == SENTINEL), (
+        f"P0 col-packed: {(outside != SENTINEL).sum()} cell(s) outside C_i "
+        f"differ from sentinel — strides inheritance is broken."
+    )

--- a/tests/test_distributed_view.py
+++ b/tests/test_distributed_view.py
@@ -495,23 +495,17 @@ def _seed_and_run(spec: DistCopySpec) -> Tuple[np.ndarray, np.ndarray]:
 
 
 # ---------------------------------------------------------------------------
-# RFC example (xfail: per-core LX routing not yet implemented)
+# RFC example: per-core LX routing
 # ---------------------------------------------------------------------------
 
-@pytest.mark.xfail(
-    reason="Interpreter gap: LX memory is not per-core; simulator ignores core=N "
-           "routing so LX partitions from different cores share one scratchpad and "
-           "reads return zeros instead of the seeded data.",
-    strict=True,
-)
 @pytest.mark.parametrize("path,func_name,entry", get_test_params("distributed_view_copy"))
 def test_distributed_view_copy_rfc(path, func_name, entry):
     """construct_distributed_memory_view — RFC §C.3 example file.
 
     A is a 192×64 logical tensor distributed across three regions:
       A_HBM (96×64,  HBM,          row-major strides [64, 1])  rows   0..95
-      A_LX0 (32×64,  LX core=0, col-packed strides [1, 64])   rows  96..127
-      A_LX1 (64×64,  LX core=1,  row-major strides [64, 1])   rows 128..191
+      A_LX0 (32×64,  LX core=0,    col-packed strides [1, 64]) rows  96..127
+      A_LX1 (64×64,  LX core=1,    row-major strides [64, 1])  rows 128..191
     The kernel copies A into contiguous HBM output B, also 192×64.
     """
     interp = KTIRInterpreter()
@@ -522,11 +516,18 @@ def test_distributed_view_copy_rfc(path, func_name, entry):
         _orig(grid_shape)
         hbm = interp.memory.hbm
         lx0 = interp.memory.get_lx(0)
+        lx1 = interp.memory.get_lx(1)
         full = np.arange(192 * 64, dtype=np.float16).reshape(192, 64)
         hbm.write(0, full[0:96, :].flatten())
         _write_strided(lx0, 12288, full[96:128, :].copy(), strides=[1, 64])
-        lx0.write(16384, full[128:192, :].flatten())
+        lx1.write(16384, full[128:192, :].flatten())
         hbm.write(24576, np.zeros(192 * 64, dtype=np.float16))
+        # Advance each LX next_ptr past its seeded region so that _write_to_lx
+        # staging (which bumps from next_ptr upward) does not overwrite source data.
+        # lx0 seeded at 12288, col-packed span = 31 + 63*64 + 1 = 4064 elems = 8128 bytes
+        # lx1 seeded at 16384, row-major span = 64*64 = 4096 elems = 8192 bytes
+        lx0.next_ptr = 12288 + 8128
+        lx1.next_ptr = 16384 + 8192
 
     interp._prepare_execution = _prepare_and_seed
     interp.execute_function(func_name)

--- a/tests/test_distributed_view.py
+++ b/tests/test_distributed_view.py
@@ -14,10 +14,20 @@
 
 """Unit tests for ktdp.construct_distributed_memory_view.
 
-Covers the RFC §C.3 reference example (distributed-view-copy.mlir) with
-data-correctness verification, plus a focused small-case test exercising
-mixed-memory-space routing and differing per-partition strides.
+Structure
+---------
+- test_distributed_view_copy_rfc   : RFC §C.3 reference example (xfail, per-core LX gap)
+- test_distributed_copy            : parametrized table of 2-partition copy cases
+
+The parametrized suite covers all combinations of:
+  - memory spaces: HBM/HBM, HBM/LX, LX/HBM
+  - partition strides: row-major [R,1] and column-packed [1,C]
+  - access shapes: full tile, partial tile (one partition pruned), sub-tile
+  - access indices: zero and non-zero (sub-tile spanning both partitions)
 """
+
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
 
 import numpy as np
 import pytest
@@ -26,12 +36,15 @@ from ktir_cpu import KTIRInterpreter
 from conftest import get_test_params
 
 
-def _write_strided(mem, base_ptr: int, block: np.ndarray, strides):
-    """Write ``block`` into *mem* so that element (r, c, ...) lands at
-    byte offset ``base_ptr + sum(coord_d * strides[d]) * 2`` (f16).
+# ---------------------------------------------------------------------------
+# Shared memory helpers
+# ---------------------------------------------------------------------------
 
-    Uses a single dense buffer of length ``max_offset + 1`` so holes
-    caused by non-contiguous strides are preserved as zeros.
+def _write_strided(mem, base_ptr: int, block: np.ndarray, strides: List[int]):
+    """Write *block* (f16) into *mem* at *base_ptr* using *strides* (element units).
+
+    Element (i, j) lands at byte offset ``(base_ptr + (i*strides[0] + j*strides[1])) * 2``.
+    Holes from non-contiguous layouts are left as zero.
     """
     assert block.dtype == np.float16
     ndim = block.ndim
@@ -45,114 +58,513 @@ def _write_strided(mem, base_ptr: int, block: np.ndarray, strides):
     mem.write(base_ptr, buf)
 
 
+def _get_mem(interp, space: str):
+    """Return the memory object for *space* ('HBM' or 'LX')."""
+    return interp.memory.hbm if space == "HBM" else interp.memory.get_lx(0)
+
+
 # ---------------------------------------------------------------------------
-# RFC example: distributed-view-copy.mlir
+# MLIR builder
 # ---------------------------------------------------------------------------
 
+def _affine_set_rows(r0: int, r1: int, c0: int, c1: int) -> str:
+    """Return affine_set string covering rows r0..r1, cols c0..c1 (inclusive)."""
+    return (
+        f"affine_set<(d0, d1) : "
+        f"(d0 - {r0} >= 0, -{r0} + {r1} - d0 + {r0} >= 0, "
+        f"d1 - {c0} >= 0, -{c0} + {c1} - d1 + {c0} >= 0)>"
+    ).replace("(d0 - 0 >= 0", "(d0 >= 0").replace("(d1 - 0 >= 0", "(d1 >= 0")
+
+
+def _set_rows(r0: int, r1: int, ncols: int) -> str:
+    """affine_set covering rows [r0, r1] and all cols [0, ncols-1]."""
+    row_lo = f"d0 - {r0} >= 0" if r0 > 0 else "d0 >= 0"
+    row_hi = f"-d0 + {r1} >= 0"
+    col_lo = "d1 >= 0"
+    col_hi = f"-d1 + {ncols - 1} >= 0"
+    return f"affine_set<(d0, d1) : ({row_lo}, {row_hi}, {col_lo}, {col_hi})>"
+
+
+def _set_box(r0: int, r1: int, c0: int, c1: int) -> str:
+    """affine_set covering [r0,r1] x [c0,c1] (all inclusive)."""
+    parts = []
+    parts.append(f"d0 - {r0} >= 0" if r0 > 0 else "d0 >= 0")
+    parts.append(f"-d0 + {r1} >= 0")
+    parts.append(f"d1 - {c0} >= 0" if c0 > 0 else "d1 >= 0")
+    parts.append(f"-d1 + {c1} >= 0")
+    return f"affine_set<(d0, d1) : ({', '.join(parts)})>"
+
+
+@dataclass
+class PartitionSpec:
+    """Describes one rectangular partition of the distributed view.
+
+    Attributes:
+        rows         : (first_row, last_row) inclusive in global coords
+        cols         : (first_col, last_col) inclusive in global coords
+        memory_space : "HBM" or "LX"
+        strides      : element strides [row_stride, col_stride]
+        base_ptr     : byte address of element [0,0] of this partition
+    """
+    rows: Tuple[int, int]
+    cols: Tuple[int, int]
+    memory_space: str
+    strides: List[int]
+    base_ptr: int
+
+    @property
+    def nrows(self) -> int:
+        return self.rows[1] - self.rows[0] + 1
+
+    @property
+    def ncols(self) -> int:
+        return self.cols[1] - self.cols[0] + 1
+
+
+@dataclass
+class DistCopySpec:
+    """Full specification for a 2-partition distributed copy test.
+
+    The kernel loads an access tile from distributed A and stores it to
+    contiguous HBM output B.  Both are 2-D.
+
+    Attributes:
+        global_shape  : logical shape of the full distributed tensor
+        p0, p1        : partition specs (disjoint rectangular regions in global coords)
+        access_shape  : shape of the access tile
+        indices       : [row, col] base indices for construct_access_tile
+        out_ptr       : byte address of the B output on HBM
+        id            : short human-readable label used in pytest ids
+    """
+    global_shape: Tuple[int, int]
+    p0: PartitionSpec
+    p1: PartitionSpec
+    access_shape: Tuple[int, int]
+    indices: List[int]
+    out_ptr: int
+    id: str
+
+
+def _build_mlir(spec: DistCopySpec) -> str:
+    """Generate a single-function MLIR module from *spec*."""
+    G = spec.global_shape
+    p0, p1 = spec.p0, spec.p1
+    ac = spec.access_shape
+    idx = spec.indices
+
+    p0_set = _set_box(p0.rows[0], p0.rows[1], p0.cols[0], p0.cols[1])
+    p1_set = _set_box(p1.rows[0], p1.rows[1], p1.cols[0], p1.cols[1])
+    ac_set = _set_box(0, ac[0] - 1, 0, ac[1] - 1)
+
+    idx_decls = "\n".join(
+        f"    %idx{i} = arith.constant {v} : index" for i, v in enumerate(idx)
+    )
+    idx_refs = ", ".join(f"%idx{i}" for i in range(len(idx)))
+
+    p0_ms = f"#ktdp.spyre_memory_space<{p0.memory_space}>"
+    p1_ms = f"#ktdp.spyre_memory_space<{p1.memory_space}>"
+
+    return f"""
+#P0_set   = {p0_set}
+#P1_set   = {p1_set}
+#ac_set   = {ac_set}
+#identity = affine_map<(d0, d1) -> (d0, d1)>
+module {{
+  func.func @dist_copy() {{
+    %c0 = arith.constant 0 : index
+{idx_decls}
+    %A0_addr = arith.constant {p0.base_ptr} : index
+    %A1_addr = arith.constant {p1.base_ptr} : index
+    %B_addr  = arith.constant {spec.out_ptr} : index
+
+    %A0 = ktdp.construct_memory_view %A0_addr, sizes: [{p0.nrows}, {p0.ncols}], strides: [{p0.strides[0]}, {p0.strides[1]}] {{
+        coordinate_set = #P0_set, memory_space = {p0_ms}
+    }} : memref<{p0.nrows}x{p0.ncols}xf16>
+
+    %A1 = ktdp.construct_memory_view %A1_addr, sizes: [{p1.nrows}, {p1.ncols}], strides: [{p1.strides[0]}, {p1.strides[1]}] {{
+        coordinate_set = #P1_set, memory_space = {p1_ms}
+    }} : memref<{p1.nrows}x{p1.ncols}xf16>
+
+    %A = ktdp.construct_distributed_memory_view
+        (%A0, %A1 : memref<{p0.nrows}x{p0.ncols}xf16>, memref<{p1.nrows}x{p1.ncols}xf16>)
+        : memref<{G[0]}x{G[1]}xf16>
+
+    %B = ktdp.construct_memory_view %B_addr, sizes: [{ac[0]}, {ac[1]}], strides: [{ac[1]}, 1] {{
+        coordinate_set = #ac_set, memory_space = #ktdp.spyre_memory_space<HBM>
+    }} : memref<{ac[0]}x{ac[1]}xf16>
+
+    %A_at = ktdp.construct_access_tile %A[{idx_refs}] {{
+        access_tile_set = #ac_set, access_tile_order = #identity
+    }} : memref<{G[0]}x{G[1]}xf16> -> !ktdp.access_tile<{ac[0]}x{ac[1]}xindex>
+
+    %B_at = ktdp.construct_access_tile %B[%c0, %c0] {{
+        access_tile_set = #ac_set, access_tile_order = #identity
+    }} : memref<{ac[0]}x{ac[1]}xf16> -> !ktdp.access_tile<{ac[0]}x{ac[1]}xindex>
+
+    %data = ktdp.load %A_at : !ktdp.access_tile<{ac[0]}x{ac[1]}xindex> -> tensor<{ac[0]}x{ac[1]}xf16>
+    ktdp.store %data, %B_at : tensor<{ac[0]}x{ac[1]}xf16>, !ktdp.access_tile<{ac[0]}x{ac[1]}xindex>
+    return
+  }}
+}}
+"""
+
+
+# ---------------------------------------------------------------------------
+# Test case table
+# ---------------------------------------------------------------------------
+#
+# Reference tensor: np.arange(GR*GC, dtype=f16).reshape(GR, GC)
+# All cases use a 4×4 global tensor unless noted.
+#
+# Three partition layouts are used:
+#   Row-band    : P0 rows 0..r, P1 rows r+1..3, each spanning all 4 cols
+#   Col-band    : P0 cols 0..c, P1 cols c+1..3, each spanning all 4 rows
+#   Mixed       : P0 is a 2-row block, P1 is a 2-row×2-col block beside it
+#
+# Memory pointer map (non-overlapping, 4096-byte spacing):
+_P0_PTR  = 0
+_P1_PTR  = 4096
+_OUT_PTR = 8192
+
+_CASES: List[DistCopySpec] = [
+    # -----------------------------------------------------------------------
+    # Row-band partitioning
+    #
+    #      c0   c1   c2   c3
+    # r0 [ ----  P0  ---- ]
+    # r1 [ ----  P0  ---- ]   P0: rows 0..1, all cols
+    # r2 [ ----  P1  ---- ]   P1: rows 2..3, all cols
+    # r3 [ ----  P1  ---- ]
+    # -----------------------------------------------------------------------
+
+    # Case 1: full 4×4 access — both partitions loaded
+    #
+    #      c0   c1   c2   c3
+    # r0 [ ░░░  P0  ░░░░░ ]   ░ = access tile
+    # r1 [ ░░░  P0  ░░░░░ ]
+    # r2 [ ░░░  P1  ░░░░░ ]
+    # r3 [ ░░░  P1  ░░░░░ ]
+    DistCopySpec(
+        global_shape=(4, 4),
+        p0=PartitionSpec(rows=(0, 1), cols=(0, 3), memory_space="HBM", strides=[4, 1], base_ptr=_P0_PTR),
+        p1=PartitionSpec(rows=(2, 3), cols=(0, 3), memory_space="HBM", strides=[4, 1], base_ptr=_P1_PTR),
+        access_shape=(4, 4), indices=[0, 0], out_ptr=_OUT_PTR,
+        id="row_hbm_hbm_full",
+    ),
+    # Case 2: 2×4 access at [0,0] — P1 pruned (access doesn't reach rows 2..3)
+    #
+    #      c0   c1   c2   c3
+    # r0 [ ░░░  P0  ░░░░░ ]   ░ = access tile
+    # r1 [ ░░░  P0  ░░░░░ ]
+    # r2 [ ----  P1  ---- ]   P1 pruned
+    # r3 [ ----  P1  ---- ]
+    DistCopySpec(
+        global_shape=(4, 4),
+        p0=PartitionSpec(rows=(0, 1), cols=(0, 3), memory_space="HBM", strides=[4, 1], base_ptr=_P0_PTR),
+        p1=PartitionSpec(rows=(2, 3), cols=(0, 3), memory_space="HBM", strides=[4, 1], base_ptr=_P1_PTR),
+        access_shape=(2, 4), indices=[0, 0], out_ptr=_OUT_PTR,
+        id="row_hbm_hbm_partial_p1_pruned",
+    ),
+    # Case 3: 2×2 sub-tile at [1,1] — spans both partitions (nonzero indices)
+    #
+    #      c0   c1   c2   c3
+    # r0 [ ----  P0  ---- ]
+    # r1 [  P0 | ░░░ |    ]   ░ = access tile  global[1:3, 1:3]
+    # r2 [  P1 | ░░░ |    ]
+    # r3 [ ----  P1  ---- ]
+    DistCopySpec(
+        global_shape=(4, 4),
+        p0=PartitionSpec(rows=(0, 1), cols=(0, 3), memory_space="HBM", strides=[4, 1], base_ptr=_P0_PTR),
+        p1=PartitionSpec(rows=(2, 3), cols=(0, 3), memory_space="HBM", strides=[4, 1], base_ptr=_P1_PTR),
+        access_shape=(2, 2), indices=[1, 1], out_ptr=_OUT_PTR,
+        id="row_hbm_hbm_subtile_nonzero",
+    ),
+    # Case 4: full 4×4, P1 in LX with col-packed strides [1,4]
+    #
+    #      c0   c1   c2   c3
+    # r0 [ ░░  P0(HBM)  ░ ]   ░ = access tile
+    # r1 [ ░░  P0(HBM)  ░ ]   P0 row-major:  elem[r,c] at offset r*4+c
+    # r2 [ ░░  P1(LX)   ░ ]   P1 col-packed: elem[r,c] at offset r+c*2
+    # r3 [ ░░  P1(LX)   ░ ]
+    DistCopySpec(
+        global_shape=(4, 4),
+        p0=PartitionSpec(rows=(0, 1), cols=(0, 3), memory_space="HBM", strides=[4, 1], base_ptr=_P0_PTR),
+        p1=PartitionSpec(rows=(2, 3), cols=(0, 3), memory_space="LX",  strides=[1, 4], base_ptr=_P1_PTR),
+        access_shape=(4, 4), indices=[0, 0], out_ptr=_OUT_PTR,
+        id="row_hbm_lx_col_packed_full",
+    ),
+    # Case 5: full 4×4, P0 in LX col-packed, P1 in HBM — reversed memory spaces
+    #
+    #      c0   c1   c2   c3
+    # r0 [ ░░  P0(LX)   ░ ]   P0 col-packed: elem[r,c] at offset r+c*2
+    # r1 [ ░░  P0(LX)   ░ ]   P1 row-major:  elem[r,c] at offset r*4+c
+    # r2 [ ░░  P1(HBM)  ░ ]
+    # r3 [ ░░  P1(HBM)  ░ ]
+    DistCopySpec(
+        global_shape=(4, 4),
+        p0=PartitionSpec(rows=(0, 1), cols=(0, 3), memory_space="LX",  strides=[1, 4], base_ptr=_P0_PTR),
+        p1=PartitionSpec(rows=(2, 3), cols=(0, 3), memory_space="HBM", strides=[4, 1], base_ptr=_P1_PTR),
+        access_shape=(4, 4), indices=[0, 0], out_ptr=_OUT_PTR,
+        id="row_lx_hbm_col_packed_full",
+    ),
+    # Case 6: 2×2 sub-tile at [1,1], P1 in LX col-packed — mixed spaces + nonzero indices
+    #
+    #      c0   c1   c2   c3
+    # r0 [ ----  P0(HBM)  ---- ]
+    # r1 [  P0(HBM) | ░░░ |    ]   ░ = access tile  global[1:3, 1:3]
+    # r2 [  P1(LX)  | ░░░ |    ]
+    # r3 [ ----  P1(LX)   ---- ]
+    DistCopySpec(
+        global_shape=(4, 4),
+        p0=PartitionSpec(rows=(0, 1), cols=(0, 3), memory_space="HBM", strides=[4, 1], base_ptr=_P0_PTR),
+        p1=PartitionSpec(rows=(2, 3), cols=(0, 3), memory_space="LX",  strides=[1, 4], base_ptr=_P1_PTR),
+        access_shape=(2, 2), indices=[1, 1], out_ptr=_OUT_PTR,
+        id="row_hbm_lx_subtile_nonzero",
+    ),
+    # Case 7: unequal row bands — P0 is 1 row, P1 is 3 rows; full 4×4 access
+    #
+    #      c0   c1   c2   c3
+    # r0 [ ░░░  P0  ░░░░░ ]   P0: 1 row
+    # r1 [ ░░░  P1  ░░░░░ ]   P1: 3 rows
+    # r2 [ ░░░  P1  ░░░░░ ]
+    # r3 [ ░░░  P1  ░░░░░ ]
+    DistCopySpec(
+        global_shape=(4, 4),
+        p0=PartitionSpec(rows=(0, 0), cols=(0, 3), memory_space="HBM", strides=[4, 1], base_ptr=_P0_PTR),
+        p1=PartitionSpec(rows=(1, 3), cols=(0, 3), memory_space="HBM", strides=[4, 1], base_ptr=_P1_PTR),
+        access_shape=(4, 4), indices=[0, 0], out_ptr=_OUT_PTR,
+        id="row_hbm_hbm_unequal_full",
+    ),
+    # Case 8: unequal row bands, 2×4 at [1,0] — P0 pruned (access starts at row 1)
+    #
+    #      c0   c1   c2   c3
+    # r0 [ ----  P0  ---- ]   P0 pruned
+    # r1 [ ░░░  P1  ░░░░░ ]   ░ = access tile
+    # r2 [ ░░░  P1  ░░░░░ ]
+    # r3 [ ----  P1  ---- ]
+    DistCopySpec(
+        global_shape=(4, 4),
+        p0=PartitionSpec(rows=(0, 0), cols=(0, 3), memory_space="HBM", strides=[4, 1], base_ptr=_P0_PTR),
+        p1=PartitionSpec(rows=(1, 3), cols=(0, 3), memory_space="HBM", strides=[4, 1], base_ptr=_P1_PTR),
+        access_shape=(2, 4), indices=[1, 0], out_ptr=_OUT_PTR,
+        id="row_hbm_hbm_unequal_partial_p0_pruned",
+    ),
+
+    # -----------------------------------------------------------------------
+    # Col-band partitioning
+    #
+    #      c0   c1 | c2   c3
+    # r0 [  --  P0  |  --  P1  ]
+    # r1 [  --  P0  |  --  P1  ]   P0: all rows, cols 0..1
+    # r2 [  --  P0  |  --  P1  ]   P1: all rows, cols 2..3
+    # r3 [  --  P0  |  --  P1  ]
+    # -----------------------------------------------------------------------
+
+    # Case 9: full 4×4 access — both col partitions loaded
+    #
+    #      c0   c1 | c2   c3
+    # r0 [ ░░░  P0 | ░░░  P1 ]   ░ = access tile
+    # r1 [ ░░░  P0 | ░░░  P1 ]
+    # r2 [ ░░░  P0 | ░░░  P1 ]
+    # r3 [ ░░░  P0 | ░░░  P1 ]
+    DistCopySpec(
+        global_shape=(4, 4),
+        p0=PartitionSpec(rows=(0, 3), cols=(0, 1), memory_space="HBM", strides=[2, 1], base_ptr=_P0_PTR),
+        p1=PartitionSpec(rows=(0, 3), cols=(2, 3), memory_space="HBM", strides=[2, 1], base_ptr=_P1_PTR),
+        access_shape=(4, 4), indices=[0, 0], out_ptr=_OUT_PTR,
+        id="col_hbm_hbm_full",
+    ),
+    # Case 10: 4×2 access at [0,0] — P1 pruned (access stays in left cols 0..1)
+    #
+    #      c0   c1 | c2   c3
+    # r0 [ ░░░  P0 |  --  P1 ]   P1 pruned
+    # r1 [ ░░░  P0 |  --  P1 ]
+    # r2 [ ░░░  P0 |  --  P1 ]
+    # r3 [ ░░░  P0 |  --  P1 ]
+    DistCopySpec(
+        global_shape=(4, 4),
+        p0=PartitionSpec(rows=(0, 3), cols=(0, 1), memory_space="HBM", strides=[2, 1], base_ptr=_P0_PTR),
+        p1=PartitionSpec(rows=(0, 3), cols=(2, 3), memory_space="HBM", strides=[2, 1], base_ptr=_P1_PTR),
+        access_shape=(4, 2), indices=[0, 0], out_ptr=_OUT_PTR,
+        id="col_hbm_hbm_partial_p1_pruned",
+    ),
+    # Case 11: 2×2 sub-tile at [1,1] — straddles col boundary (col 1 in P0, col 2 in P1)
+    #
+    #      c0   c1 | c2   c3
+    # r0 [  --  P0 |  --  P1 ]
+    # r1 [  P0 |░░ | ░░| P1  ]   ░ = access tile  global[1:3, 1:3]
+    # r2 [  P0 |░░ | ░░| P1  ]
+    # r3 [  --  P0 |  --  P1 ]
+    DistCopySpec(
+        global_shape=(4, 4),
+        p0=PartitionSpec(rows=(0, 3), cols=(0, 1), memory_space="HBM", strides=[2, 1], base_ptr=_P0_PTR),
+        p1=PartitionSpec(rows=(0, 3), cols=(2, 3), memory_space="HBM", strides=[2, 1], base_ptr=_P1_PTR),
+        access_shape=(2, 2), indices=[1, 1], out_ptr=_OUT_PTR,
+        id="col_hbm_hbm_subtile_nonzero",
+    ),
+    # Case 12: full 4×4, P0 HBM row-major, P1 LX col-packed — mixed spaces, col-band
+    #
+    #      c0     c1   |   c2     c3
+    # r0 [ ░  P0(HBM) ░ | ░  P1(LX) ░ ]   P0 row-major:  elem[r,c] at offset r*2+c
+    # r1 [ ░  P0(HBM) ░ | ░  P1(LX) ░ ]   P1 col-packed: elem[r,c] at offset r+c*4
+    # r2 [ ░  P0(HBM) ░ | ░  P1(LX) ░ ]
+    # r3 [ ░  P0(HBM) ░ | ░  P1(LX) ░ ]
+    DistCopySpec(
+        global_shape=(4, 4),
+        p0=PartitionSpec(rows=(0, 3), cols=(0, 1), memory_space="HBM", strides=[2, 1], base_ptr=_P0_PTR),
+        p1=PartitionSpec(rows=(0, 3), cols=(2, 3), memory_space="LX",  strides=[1, 4], base_ptr=_P1_PTR),
+        access_shape=(4, 4), indices=[0, 0], out_ptr=_OUT_PTR,
+        id="col_hbm_lx_col_packed_full",
+    ),
+
+    # -----------------------------------------------------------------------
+    # Mixed layout: P0 is a tall left block (4 rows × 2 cols),
+    #               P1 is a small bottom-right block (2 rows × 2 cols).
+    # Top-right corner (rows 0..1, cols 2..3) is uncovered — access tiles
+    # in these cases are designed to avoid it.
+    #
+    #      c0   c1 | c2   c3
+    # r0 [  --  P0 |  --  -- ]
+    # r1 [  --  P0 |  --  -- ]   P0: rows 0..3, cols 0..1
+    # r2 [  --  P0 |  --  P1 ]   P1: rows 2..3, cols 2..3
+    # r3 [  --  P0 |  --  P1 ]
+    # -----------------------------------------------------------------------
+
+    # Case 13: 4×2 access at [0,0] — spans full left block P0; P1 pruned
+    #
+    #      c0   c1 | c2   c3
+    # r0 [ ░░░  P0 |  --  -- ]
+    # r1 [ ░░░  P0 |  --  -- ]
+    # r2 [ ░░░  P0 |  --  P1 ]
+    # r3 [ ░░░  P0 |  --  P1 ]
+    DistCopySpec(
+        global_shape=(4, 4),
+        p0=PartitionSpec(rows=(0, 3), cols=(0, 1), memory_space="HBM", strides=[2, 1], base_ptr=_P0_PTR),
+        p1=PartitionSpec(rows=(2, 3), cols=(2, 3), memory_space="HBM", strides=[2, 1], base_ptr=_P1_PTR),
+        access_shape=(4, 2), indices=[0, 0], out_ptr=_OUT_PTR,
+        id="mixed_left_block_only",
+    ),
+    # Case 14: 2×2 at [2,0] — bottom-left corner, only P0 contributes; P1 pruned
+    #
+    #      c0   c1 | c2   c3
+    # r0 [  --  P0 |  --  -- ]
+    # r1 [  --  P0 |  --  -- ]
+    # r2 [ ░░░  P0 |  --  P1 ]   ░ = access tile  global[2:4, 0:2]
+    # r3 [ ░░░  P0 |  --  P1 ]
+    DistCopySpec(
+        global_shape=(4, 4),
+        p0=PartitionSpec(rows=(0, 3), cols=(0, 1), memory_space="HBM", strides=[2, 1], base_ptr=_P0_PTR),
+        p1=PartitionSpec(rows=(2, 3), cols=(2, 3), memory_space="HBM", strides=[2, 1], base_ptr=_P1_PTR),
+        access_shape=(2, 2), indices=[2, 0], out_ptr=_OUT_PTR,
+        id="mixed_bottom_left_only",
+    ),
+    # Case 15: 2×2 at [2,0], P0 in LX col-packed, P1 in HBM — mixed spaces, mixed layout
+    #
+    #      c0   c1 | c2   c3
+    # r0 [  -- P0(LX) |  --  --     ]
+    # r1 [  -- P0(LX) |  --  --     ]
+    # r2 [ ░░ P0(LX) ░|  --  P1(HBM)]   ░ = access tile  global[2:4, 0:2]
+    # r3 [ ░░ P0(LX) ░|  --  P1(HBM)]
+    DistCopySpec(
+        global_shape=(4, 4),
+        p0=PartitionSpec(rows=(0, 3), cols=(0, 1), memory_space="LX",  strides=[1, 4], base_ptr=_P0_PTR),
+        p1=PartitionSpec(rows=(2, 3), cols=(2, 3), memory_space="HBM", strides=[2, 1], base_ptr=_P1_PTR),
+        access_shape=(2, 2), indices=[2, 0], out_ptr=_OUT_PTR,
+        id="mixed_lx_left_hbm_right_bottom_only",
+    ),
+]
+
+
+def _seed_and_run(spec: DistCopySpec) -> Tuple[np.ndarray, np.ndarray]:
+    """Seed memory from spec, execute the generated kernel, return (expected, actual).
+
+    The reference tensor is np.arange(16, dtype=f16).reshape(4,4).
+    The expected slice is full[indices[0]:indices[0]+access_shape[0],
+                               indices[1]:indices[1]+access_shape[1]].
+    """
+    full = np.arange(16, dtype=np.float16).reshape(spec.global_shape)
+    mlir = _build_mlir(spec)
+    interp = KTIRInterpreter()
+    interp.load(mlir)
+    _orig = interp._prepare_execution
+
+    p0, p1 = spec.p0, spec.p1
+    ac = spec.access_shape
+    idx = spec.indices
+
+    def _prepare_and_seed(grid_shape):
+        _orig(grid_shape)
+        p0_block = full[p0.rows[0]:p0.rows[1] + 1, p0.cols[0]:p0.cols[1] + 1]
+        p1_block = full[p1.rows[0]:p1.rows[1] + 1, p1.cols[0]:p1.cols[1] + 1]
+        p0_mem = _get_mem(interp, p0.memory_space)
+        p1_mem = _get_mem(interp, p1.memory_space)
+        _write_strided(p0_mem, p0.base_ptr, p0_block.copy(), p0.strides)
+        _write_strided(p1_mem, p1.base_ptr, p1_block.copy(), p1.strides)
+        interp.memory.hbm.write(spec.out_ptr, np.zeros(ac[0] * ac[1], dtype=np.float16))
+
+    interp._prepare_execution = _prepare_and_seed
+    interp.execute_function("dist_copy")
+
+    r0, c0 = idx[0], idx[1]
+    expected = full[r0:r0 + ac[0], c0:c0 + ac[1]]
+    n_out = ac[0] * ac[1]
+    actual = interp.memory.hbm.read(spec.out_ptr, n_out, "f16").reshape(ac)
+    return expected, actual
+
+
+# ---------------------------------------------------------------------------
+# RFC example (xfail: per-core LX routing not yet implemented)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.xfail(
+    reason="Interpreter gap: LX memory is not per-core; simulator ignores core=N "
+           "routing so LX partitions from different cores share one scratchpad and "
+           "reads return zeros instead of the seeded data.",
+    strict=True,
+)
 @pytest.mark.parametrize("path,func_name,entry", get_test_params("distributed_view_copy"))
 def test_distributed_view_copy_rfc(path, func_name, entry):
     """construct_distributed_memory_view — RFC §C.3 example file.
 
     A is a 192×64 logical tensor distributed across three regions:
-      A_HBM (96×64, HBM,         row-major strides [64, 1])  rows   0..95
-      A_LX0 (32×64, LX,          col-packed strides [1, 64]) rows  96..127
-      A_LX1 (64×64, LX,          row-major strides [64, 1])  rows 128..191
+      A_HBM (96×64,  HBM,          row-major strides [64, 1])  rows   0..95
+      A_LX0 (32×64,  LX core=0, col-packed strides [1, 64])   rows  96..127
+      A_LX1 (64×64,  LX core=1,  row-major strides [64, 1])   rows 128..191
     The kernel copies A into contiguous HBM output B, also 192×64.
-
-    The example file uses a single LX (no ``core = N`` annotation), so
-    A_LX0 and A_LX1 share the same scratchpad — A_LX1_addr=16384 collides
-    with A_LX0's strided footprint (max offset 31+63·64 = 4063 → reaches
-    byte 20416 from base 12288).  Skip until per-core LX routing lands.
-    """
-    pytest.skip(
-        "RFC distributed-view-copy.mlir aliases A_LX0 and A_LX1 in a single "
-        "LX scratchpad; needs per-core LX routing (forthcoming) to honor "
-        "#ktdp.spyre_memory_space<LX, core = N>"
-    )
-
-
-# ---------------------------------------------------------------------------
-# Focused small unit test: 2 partitions, mixed memory spaces, differing strides
-# ---------------------------------------------------------------------------
-
-_SMALL_MLIR = """
-#A0_set = affine_set<(d0, d1) : (d0 >= 0,   -d0 + 1 >= 0, d1 >= 0, -d1 + 3 >= 0)>
-#A1_set = affine_set<(d0, d1) : (d0 - 2 >= 0, -d0 + 3 >= 0, d1 >= 0, -d1 + 3 >= 0)>
-#B_set  = affine_set<(d0, d1) : (d0 >= 0,   -d0 + 3 >= 0, d1 >= 0, -d1 + 3 >= 0)>
-#identity = affine_map<(d0, d1) -> (d0, d1)>
-
-module {
-  func.func @small_distributed_copy() {
-    %c0 = arith.constant 0 : index
-    %A0_addr = arith.constant 0     : index
-    %A1_addr = arith.constant 4096  : index
-    %B_addr  = arith.constant 8192  : index
-
-    // A0: rows 0..1, HBM, row-major (strides [4, 1])
-    %A0 = ktdp.construct_memory_view %A0_addr, sizes: [2, 4], strides: [4, 1] {
-        coordinate_set = #A0_set,
-        memory_space = #ktdp.spyre_memory_space<HBM>
-    } : memref<2x4xf16>
-
-    // A1: rows 2..3, LX, column-packed (strides [1, 4])
-    %A1 = ktdp.construct_memory_view %A1_addr, sizes: [2, 4], strides: [1, 4] {
-        coordinate_set = #A1_set,
-        memory_space = #ktdp.spyre_memory_space<LX>
-    } : memref<2x4xf16>
-
-    %A_global = ktdp.construct_distributed_memory_view
-        (%A0, %A1 : memref<2x4xf16>, memref<2x4xf16>) : memref<4x4xf16>
-
-    // Output B on HBM, row-major
-    %B = ktdp.construct_memory_view %B_addr, sizes: [4, 4], strides: [4, 1] {
-        coordinate_set = #B_set,
-        memory_space = #ktdp.spyre_memory_space<HBM>
-    } : memref<4x4xf16>
-
-    %A_at = ktdp.construct_access_tile %A_global[%c0, %c0] {
-        access_tile_set = #B_set,
-        access_tile_order = #identity
-    } : memref<4x4xf16> -> !ktdp.access_tile<4x4xindex>
-
-    %B_at = ktdp.construct_access_tile %B[%c0, %c0] {
-        access_tile_set = #B_set,
-        access_tile_order = #identity
-    } : memref<4x4xf16> -> !ktdp.access_tile<4x4xindex>
-
-    %data = ktdp.load %A_at : !ktdp.access_tile<4x4xindex> -> tensor<4x4xf16>
-    ktdp.store %data, %B_at : tensor<4x4xf16>, !ktdp.access_tile<4x4xindex>
-    return
-  }
-}
-"""
-
-
-def test_small_distributed_copy_mixed_spaces_and_strides():
-    """2-partition distributed view: HBM row-major + LX column-packed.
-
-    Verifies end-to-end that (1) each global coord routes to the correct
-    partition, (2) HBM and LX partitions coexist in one view, and
-    (3) differing stride patterns per partition are honored.
     """
     interp = KTIRInterpreter()
-    interp.load(_SMALL_MLIR)
+    interp.load(path)
     _orig = interp._prepare_execution
 
     def _prepare_and_seed(grid_shape):
         _orig(grid_shape)
         hbm = interp.memory.hbm
         lx0 = interp.memory.get_lx(0)
-        full = np.arange(16, dtype=np.float16).reshape(4, 4)
-        # A0: rows 0..1 of full, row-major in HBM.
-        hbm.write(0, full[0:2, :].flatten())
-        # A1: rows 2..3 of full, strided [1, 4] in LX.
-        _write_strided(lx0, 4096, full[2:4, :].copy(), strides=[1, 4])
-        # B output zeroed.
-        hbm.write(8192, np.zeros(16, dtype=np.float16))
+        full = np.arange(192 * 64, dtype=np.float16).reshape(192, 64)
+        hbm.write(0, full[0:96, :].flatten())
+        _write_strided(lx0, 12288, full[96:128, :].copy(), strides=[1, 64])
+        lx0.write(16384, full[128:192, :].flatten())
+        hbm.write(24576, np.zeros(192 * 64, dtype=np.float16))
 
     interp._prepare_execution = _prepare_and_seed
-    interp.execute_function("small_distributed_copy")
+    interp.execute_function(func_name)
 
-    b = interp.memory.hbm.read(8192, 16, "f16").reshape(4, 4)
-    expected = np.arange(16, dtype=np.float16).reshape(4, 4)
+    expected = np.arange(192 * 64, dtype=np.float16).reshape(192, 64)
+    b = interp.memory.hbm.read(24576, 192 * 64, "f16").reshape(192, 64)
     np.testing.assert_array_equal(b, expected)
+
+
+# ---------------------------------------------------------------------------
+# Parametrized 2-partition copy suite
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("spec", _CASES, ids=[c.id for c in _CASES])
+def test_distributed_copy(spec: DistCopySpec):
+    """2-partition distributed copy — data-correctness check.
+
+    Generates a single-function MLIR kernel from *spec*, seeds the partitions
+    in the appropriate memory spaces and strides, runs the kernel, and asserts
+    that the output matches the corresponding slice of the reference tensor.
+    """
+    expected, actual = _seed_and_run(spec)
+    np.testing.assert_array_equal(actual, expected)

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -177,7 +177,7 @@ module {
         regions=[],
     )
     with pytest.raises(ValueError, match="totally.unknown_op"):
-        interp._execute_operation(unknown_op, core, interp.ring_network)
+        interp._execute_operation(unknown_op, core)
 
 
 # ---------------------------------------------------------------------------
@@ -214,7 +214,7 @@ module {
             result_type=None,
             regions=[],
         )
-        interp._execute_operation(op, core, interp.ring_network)
+        interp._execute_operation(op, core)
 
     assert core.get_value("%x") == 10
     assert core.get_value("%y") == 20
@@ -256,4 +256,4 @@ module {
             regions=[],
         )
         with pytest.raises(TypeError):
-            interp._execute_operation(op, core, interp.ring_network)
+            interp._execute_operation(op, core)

--- a/tests/test_ktir_cpu.py
+++ b/tests/test_ktir_cpu.py
@@ -271,6 +271,7 @@ def test_grid_boundary_max_position():
     assert grid._grid_to_linear(*core.grid_pos) == last_id
 
 
+@pytest.mark.xfail(reason="BSP multi-round execution removed; RingTransferBackend not yet implemented (gap_analysis.md K1/K2)")
 def test_execute_with_communication_multi_round():
     """execute_with_communication runs multiple rounds and converges once all messages are consumed.
 
@@ -309,6 +310,7 @@ def test_execute_with_communication_multi_round():
     assert call_counts[0] == 4
 
 
+@pytest.mark.xfail(reason="BSP multi-round execution removed; RingTransferBackend not yet implemented (gap_analysis.md K1/K2)")
 def test_execute_with_communication_exceeds_max_rounds():
     """execute_with_communication raises RuntimeError when messages never drain."""
     from ktir_cpu.memory import SpyreMemoryHierarchy

--- a/tests/test_spec_gaps.py
+++ b/tests/test_spec_gaps.py
@@ -110,18 +110,8 @@ def test_paged_tensor_indirect_access(path, func_name, entry):
 
 # ===========================================================================
 # ktdp.construct_distributed_memory_view
-# RFC §C.3: compose per-partition views (HBM + LX) into one logical view.
+# Implemented; positive coverage moved to tests/test_distributed_view.py.
 # ===========================================================================
-
-@pytest.mark.spec_gap
-@pytest.mark.xfail(strict=True, reason="ktdp.construct_distributed_memory_view not implemented")
-@pytest.mark.parametrize("path,func_name,entry", get_test_params("distributed_view_copy"))
-def test_distributed_memory_view(path, func_name, entry):
-    """construct_distributed_memory_view is not yet supported."""
-    interp = KTIRInterpreter()
-    interp.load(path)
-    interp.execute_function(func_name)
-
 
 # ===========================================================================
 # RFC-explicit non-ktdp ops


### PR DESCRIPTION
# Distributed memory views + per-core LX routing

Closes #1.

## Summary

Lands `ktdp.construct_distributed_memory_view` end-to-end:

- **New types** — `DistributedMemRef` and `DistributedTileRef`, mirroring
  upstream's `MemRef` / `TileRef` split for distributed views.
- **`BoxSet`** — axis-aligned specialisation of `AffineSet`; parse-time
  lowering puts partition resolution and load/store on an O(ndim) fast
  path. ~58,000× speedup of `distributed_tile_access` on a 256×512
  fixture; ~315× end-to-end including `distributed_load`.
- **Per-core LX routing** — `#ktdp.spyre_memory_space<LX, core = N>`
  reads and writes route to core N's scratchpad via a new `RingBackend`
  transport seam (Phase 1: `DirectLXBackend`, no ring latency).

5 commits; **714 passed, 1 skipped, 7 xfailed**. The 2 new xfails are
BSP multi-round tests that un-xfail once the generator-based scheduler
lands ([#50](https://github.com/torch-spyre/ktir-cpu/issues/50)).

## Type model: distributed analogue of upstream's MemRef/TileRef split

Single-allocation memory views are already separated:

```
construct_memory_view  →  MemRef  (owns memory_space, base_ptr, coordinate_set)
                              ↓
construct_access_tile  →  TileRef (byte-addressed sub-view; .memref points back)
```

Distributed views mirror that:

```
single allocation:                          distributed:

  MemRef                                      DistributedMemRef
   ├ memory_space                              └ partitions: List[MemRef]
   ├ base_ptr                                    (each carries its own
   ├ coordinate_set      ←──────────────────      coordinate_set = B_i)
   └ lx_core_id (NEW)
       ↓ tile_access                          ↓ distributed_tile_access
  TileRef                                     DistributedTileRef
   ├ memref → MemRef                           ├ partitions: List[TileRef]
   ├ base_ptr (byte addr)                      │   (each survivor TileRef
   ├ strides                                   │    carries C_i and p_i,
   └ ...                                       │    .memref → P_i)
                                               ├ shape (global)
                                               └ global_base = x
```

**Key invariant.** Each surviving `TileRef`'s `.memref` points to its
**partition's** `MemRef` (`P_i`), never to the wrapper that holds it. So
at load/store time `_MemAccessor` reads `tile_ref.memref.memory_space`
and `tile_ref.memref.lx_core_id` from a single concrete MemRef — no
distributed-aware code at the call site.

## Notation

```
  x      = global_base = base_map.eval(indices)         (access tile origin in global coords)
  A      = access_tile_set, in local coords [0, access_shape)
  x + A  = global footprint of the access tile
  B_i    = partition i's coordinate_set (in global coords; = C_i source)
  C_i    = (x + A) ∩ B_i                                (per-survivor coord set)
  p_i    = min(B_i)                                     (partition origin in global coords)

  load coords (partition-local) = C_i - p_i
  output coords (access-local)  = C_i - x
```

`distributed_tile_access` resolves all of this once and stores `C_i` and
`p_i` on each survivor; load/store consume them directly.

## Key updates

### Partition resolution at access-tile construction, not at load

Resolving "which partition owns this global coord, and how does the
local coord map back" used to happen on every load. Now
`MemoryOps.distributed_tile_access` does it once: enumerates `B_i`,
filters to `C_i = B_i ∩ (x + A)`, computes `p_i`, and stores both on
each surviving `TileRef`. Load/store walk `C_i` and `p_i` directly.

### `BoxSet` for axis-aligned sets

Every coordinate set we actually construct in distributed views — `B_i`,
`A`, and `C_i` — is an axis-aligned integer box. `AffineSet.enumerate`
on those is brute-force O(∏shape · n_constraints) per call.

`BoxSet` is the **axis-aligned specialisation of `AffineSet`** — peer
dataclasses under a `Union`, NOT a class hierarchy (a prior subclass
attempt failed because polymorphism over a slow parent hid the slow
path). `parse_affine_set` returns `BoxSet` if the set is axis-aligned,
fully-pinned, unit-coefficient, and non-symbolic; otherwise `AffineSet`.

```
distributed_tile_access:
  if B_i is BoxSet and (x + A) is BoxSet:
      C_i = B_i.intersect(BoxSet.translate(x + A))   # O(ndim), no enumeration
  else:
      enumerate B_i, filter by membership in x + A   # AffineSet slow path preserved

distributed_load / distributed_store:
  if survivor.coordinate_set is BoxSet:
      sub_tile_ref = _subtile_ref(survivor, box=C_i)  # inherits parent strides
      out[lo - x : hi - x] = MemoryOps.load(ctx, sub_tile_ref).data  # one slice paste
  else:
      per-coord scatter (slow path preserved)
```

| Stage (256×512 view, 4 partitions, 32×128 access tile) | Fast (BoxSet) | Slow (AffineSet) | Speedup |
|---|---|---|---|
| `distributed_tile_access` | ~8 µs | ~455 ms | ~58,000× |
| Full (access + `distributed_load`) | ~1.5 ms | ~470 ms | ~315× |

Sub-TileRef construction inherits the partition's strides verbatim, so
row-major and column-packed partitions both work uniformly with no
caller-side transposes — verified by
`test_distributed_store_col_packed_does_not_trample_outside_C_i`.

### Per-core LX routing via `RingBackend`

`#ktdp.spyre_memory_space<LX, core = N>` now actually routes to core
N's scratchpad. `RingBackend` is the transport seam between the memory
op (which says "this byte address lives in core N's LX") and how the
data physically arrives:

```
  MLIR:  #ktdp.spyre_memory_space<LX, core = N>
                      │
                      ▼
  MemRef.lx_core_id = N
                      │
                      ▼
  _MemAccessor(ctx, "LX", byte_addr, lx_core_id=N)
                      │
                      ▼
  ctx.get_lx(N) ──────┬─── N is None or N == self.core_id ──► ctx.lx (local)
                      │
                      └─── N != self.core_id ──► ring_backend.get_lx(N)
                                                          │
                                                          ▼
                                  ┌──────────────────────────────────────┐
                                  │  RingBackend (ABC)                   │
                                  │    get_lx(N), send, recv             │
                                  └──────────────┬───────────────────────┘
                                                 │
                                  ┌──────────────┴──────────────┐
                                  ▼                             ▼
                       ┌──────────────────────┐     ┌──────────────────────┐
                       │ DirectLXBackend      │     │ RingTransferBackend  │
                       │  (Phase 1, this PR)  │     │  (future)            │
                       │                      │     │                      │
                       │ get_lx(N):           │     │ get_lx(N):           │
                       │  scratchpad lookup,  │     │  hop-counted send+   │
                       │  no latency          │     │  recv via RingNetwork│
                       └──────────────────────┘     └──────────────────────┘
```

Phase 1 ships `DirectLXBackend` only — direct lookup, valid for
distributed memory views where partitions are pre-seeded by the host.
RFC §C.3's `distributed-view-copy.mlir` now executes correctly with two
LX partitions tagged `core = 0` / `core = 1` (was xfailed before). No
transport latency yet — see [#50](https://github.com/torch-spyre/ktir-cpu/issues/50).

## Tests

| Test | Status |
|---|---|
| `test_distributed_view_copy_rfc` | ✅ passes (was xfail pre-C4) |
| `test_distributed_copy[*]` (15 cases) | ✅ row/col-band × full/partial/sub-tile × HBM/LX × row-major/col-packed |
| `test_distributed_tile_access_fast_path[*]` | ✅ structural BoxSet emission |
| `test_distributed_tile_access_slow_path[*]` | ✅ same C_i via AffineSet brute-force |
| `test_distributed_store_does_not_trample_outside_C_i` | ✅ row-major no-trample |
| `test_distributed_store_col_packed_does_not_trample_outside_C_i` | ✅ col-packed no-trample |
| `test_affine.py` | ✅ +42 BoxSet / try_from_affine_set / parse-time-lowering cases |
| `test_execute_with_communication_*` | ⚠️ xfail (BSP multi-round; pending [#50](https://github.com/torch-spyre/ktir-cpu/issues/50)) |

Full suite: **714 passed, 1 skipped, 7 xfailed**.

## Follow-ups

- **[#50](https://github.com/torch-spyre/ktir-cpu/issues/50)** — real
  `RingBackend` with working cross-core reduce. Generator-based
  scheduler so `ktdp.reduce` / `ktdp.transfer` actually exchange tiles
  (today `CommOps.reduce` reaches past `CoreContext` into `RingNetwork`
  inside one core's handler — sibling cores haven't run, so receives
  find empty buffers; K1/K2 in `docs/gap_analysis.md`). Then
  `RingTransferBackend` adds hop-count latency. Closes the two BSP
  multi-round xfails introduced here.

- **[#51](https://github.com/torch-spyre/ktir-cpu/issues/51)** — BoxSet
  × dynamic shapes. PR #42 added symbolic affine sets
  (`AffineSet.n_syms`, `symbols` argument); `BoxSet.try_from_affine_set`
  rejects `n_syms > 0` and lets symbolic sets fall through to the
  AffineSet slow path. Fix: symbolic `BoxSet.lo`/`hi` and a `symbols`
  argument on box ops.

- **[#52](https://github.com/torch-spyre/ktir-cpu/issues/52)** —
  rectangular `BoxSet` fast paths in direct `ktdp.load`/`store` and
  indirect-access. The distributed paths are box-aware end-to-end; the
  single-allocation paths still enumerate to a coord list even when the
  access is a box. Depends on PR #49 (`indirect_store`) so the
  indirect-load and indirect-store fast paths can land symmetrically.

- **[#53](https://github.com/torch-spyre/ktir-cpu/issues/53)** — open
  question on whether `ktdp.construct_indirect_access_tile` should
  compose with `DistributedMemRef`. Today `IndirectAccessTile`'s type
  signatures only accept `MemRef` and the composition isn't checked —
  needs an explicit reject or a design.
