### PR TITLE
Parse MLIR-standard bundled multi-result form for get_compute_tile_id

### DIFF
--- a/ktir_cpu/dialects/arith_ops.py
+++ b/ktir_cpu/dialects/arith_ops.py
@@ -19,6 +19,7 @@ import re
 import numpy as np
 
 from ..dtypes import to_np_dtype
+from ..parser_utils import find_ssa_names
 from ..ir_types import Operation, Tile
 from ..latency import LatencyCategory as LC
 from ..ops.arith_ops import ArithOps, arith_cast
@@ -448,7 +449,7 @@ def parse_arith_cmpi(op_text, parse_ctx):
         raise ValueError(f"arith.cmpi: no valid predicate found in: {op_text!r}")
     predicate = pred_match.group(1)
 
-    operands = re.findall(r'%\w+', op_text)
+    operands = find_ssa_names(op_text)
     operands = [o for o in operands if o != result_name]
 
     result_type = "unknown"
@@ -479,7 +480,7 @@ def parse_arith_cmpf(op_text, parse_ctx):
         raise ValueError(f"arith.cmpf: no valid predicate found in: {op_text!r}")
     predicate = pred_match.group(1)
 
-    operands = re.findall(r'%\w+', op_text)
+    operands = find_ssa_names(op_text)
     operands = [o for o in operands if o != result_name]
 
     result_type = "unknown"

--- a/ktir_cpu/dialects/ktdp_ops.py
+++ b/ktir_cpu/dialects/ktdp_ops.py
@@ -209,7 +209,13 @@ def parse_get_compute_tile_id(op_text, parse_ctx: ParseContext):
     if not m:
         return None
     names = parse_multi_result_lhs(m.group(1))
-    type_count = sum(1 for t in m.group(2).split(",") if t.strip())
+    types_text = m.group(2).strip()
+    if not types_text:
+        raise ValueError("no result types specified")
+    type_list = [t.strip() for t in types_text.split(",")]
+    if any(not t for t in type_list):
+        raise ValueError(f"empty type in list: {types_text!r}")
+    type_count = len(type_list)
     if len(names) != type_count:
         raise ValueError(
             f"ktdp.get_compute_tile_id: {len(names)} result name(s) but "

--- a/ktir_cpu/dialects/ktdp_ops.py
+++ b/ktir_cpu/dialects/ktdp_ops.py
@@ -118,23 +118,81 @@ def ktdp__store(op, context, env):
 # ---------------------------------------------------------------------------
 # Parsers
 # ---------------------------------------------------------------------------
-
-@register_parser("ktdp.get_compute_tile_id")
-def parse_get_compute_tile_id(op_text, parse_ctx: ParseContext):
-    multi_match = re.match(
-        r'((?:%\w+,\s*)*%\w+)\s*=\s*ktdp\.get_compute_tile_id\s*:\s*(.*)', op_text
+# A multi-result op has two MLIR surface forms:
+#   Comma   : "%x, %y = op : index, index"     — referenced as %x, %y
+#   Bundled : "%g:2  = op : index, index"      — referenced as %g#0, %g#1
+#
+# Comma form keeps result names verbatim ("%x", "%y").
+# Bundled form synthesizes "%g#0", "%g#1" so downstream operand lookup
+# finds distinct keys.
+_GET_COMPUTE_TILE_ID_RE = re.compile(
+    r"""
+    ^\s*
+    (?:
+        (?P<comma> %\w+ (?: \s*,\s* %\w+ )* )                # %x  or  %x, %y, ...
+      |
+        (?P<base>  %\w+ ) : (?P<result_count> [1-9]\d* )     # %g:N  (N >= 1)
     )
-    if not multi_match:
-        return None
+    \s*=\s*
+    ktdp\.get_compute_tile_id
+    \s*:\s*
+    (?P<types> [^{(]* )                                      # trailing type list
+    \s*$
+    """,
+    re.VERBOSE,
+)
 
-    result_names = [r.strip() for r in multi_match.group(1).split(',')]
-    result = result_names[0] if len(result_names) == 1 else result_names
+
+def _make_compute_tile_id_op(result: str | list[str]) -> Operation:
     return Operation(
         result=result,
         op_type="ktdp.get_compute_tile_id",
         operands=[],
         attributes={},
-        result_type="index"
+        result_type="index",
+    )
+
+
+@register_parser("ktdp.get_compute_tile_id")
+def parse_get_compute_tile_id(op_text, parse_ctx: ParseContext):
+    match = _GET_COMPUTE_TILE_ID_RE.match(op_text)
+    if not match:
+        return None
+
+    # Trailing ": index, index, ..." must agree with the result
+    # name count. A mismatch is malformed will fail at parse time rather than
+    # silently store the wrong number of names.
+    type_count = sum(1 for t in match["types"].split(",") if t.strip())
+
+    if match["comma"] is not None:
+        names = [r.strip() for r in match["comma"].split(",")]
+        if len(names) != type_count:
+            raise ValueError(
+                f"ktdp.get_compute_tile_id: {len(names)} result name(s) but "
+                f"{type_count} result type(s) in: {op_text!r}"
+            )
+        result = names[0] if len(names) == 1 else names
+        return _make_compute_tile_id_op(result)
+
+    # Bundled form — synthesize the use-site reference names.
+    declared_result_count = int(match["result_count"])
+    if declared_result_count != type_count:
+        raise ValueError(
+            f"ktdp.get_compute_tile_id: bundled form declares "
+            f"{declared_result_count} result(s) but {type_count} result type(s) "
+            f"in: {op_text!r}"
+        )
+    base = match["base"]
+    # Honor the codebase-wide invariant: single result ⇔ bare string,
+    # multi-result ⇔ list[≥2]. The "%base#0" suffix is preserved so that
+    # downstream operands written as "%base#0" still resolve via env lookup.
+    # The MLIR-frontend backend collapses bundled N=1 to a single SSA value
+    # at parse time; emitting a string here keeps both backends consistent
+    # and avoids a list[1] shape that no other producer/consumer expects.
+    if declared_result_count == 1:
+        return _make_compute_tile_id_op(f"{base}#0")
+    return _make_compute_tile_id_op(
+        [f"{base}#{i}" for i in range(declared_result_count)]
     )
 
 

--- a/ktir_cpu/dialects/ktdp_ops.py
+++ b/ktir_cpu/dialects/ktdp_ops.py
@@ -22,7 +22,7 @@ from ..latency import LatencyCategory as LC
 from ..ops.grid_ops import GridOps
 from ..ops.memory_ops import MemoryOps
 from ..parser_ast import parse_affine_map, parse_affine_set
-from ..parser_utils import _extract_bracket_content, parse_attr_block, split_top_level
+from ..parser_utils import _extract_bracket_content, find_ssa_names, parse_attr_block, parse_multi_result_lhs, split_top_level
 from .registry import ParseContext, register, register_parser
 
 
@@ -125,24 +125,6 @@ def ktdp__store(op, context, env):
 # Comma form keeps result names verbatim ("%x", "%y").
 # Bundled form synthesizes "%g#0", "%g#1" so downstream operand lookup
 # finds distinct keys.
-_GET_COMPUTE_TILE_ID_RE = re.compile(
-    r"""
-    ^\s*
-    (?:
-        (?P<comma> %\w+ (?: \s*,\s* %\w+ )* )                # %x  or  %x, %y, ...
-      |
-        (?P<base>  %\w+ ) : (?P<result_count> [1-9]\d* )     # %g:N  (N >= 1)
-    )
-    \s*=\s*
-    ktdp\.get_compute_tile_id
-    \s*:\s*
-    (?P<types> [^{(]* )                                      # trailing type list
-    \s*$
-    """,
-    re.VERBOSE,
-)
-
-
 def _make_compute_tile_id_op(result: str | list[str]) -> Operation:
     return Operation(
         result=result,
@@ -155,45 +137,20 @@ def _make_compute_tile_id_op(result: str | list[str]) -> Operation:
 
 @register_parser("ktdp.get_compute_tile_id")
 def parse_get_compute_tile_id(op_text, parse_ctx: ParseContext):
-    match = _GET_COMPUTE_TILE_ID_RE.match(op_text)
-    if not match:
-        return None
-
-    # Trailing ": index, index, ..." must agree with the result
-    # name count. A mismatch is malformed will fail at parse time rather than
-    # silently store the wrong number of names.
-    type_count = sum(1 for t in match["types"].split(",") if t.strip())
-
-    if match["comma"] is not None:
-        names = [r.strip() for r in match["comma"].split(",")]
-        if len(names) != type_count:
-            raise ValueError(
-                f"ktdp.get_compute_tile_id: {len(names)} result name(s) but "
-                f"{type_count} result type(s) in: {op_text!r}"
-            )
-        result = names[0] if len(names) == 1 else names
-        return _make_compute_tile_id_op(result)
-
-    # Bundled form — synthesize the use-site reference names.
-    declared_result_count = int(match["result_count"])
-    if declared_result_count != type_count:
-        raise ValueError(
-            f"ktdp.get_compute_tile_id: bundled form declares "
-            f"{declared_result_count} result(s) but {type_count} result type(s) "
-            f"in: {op_text!r}"
-        )
-    base = match["base"]
-    # Honor the codebase-wide invariant: single result ⇔ bare string,
-    # multi-result ⇔ list[≥2]. The "%base#0" suffix is preserved so that
-    # downstream operands written as "%base#0" still resolve via env lookup.
-    # The MLIR-frontend backend collapses bundled N=1 to a single SSA value
-    # at parse time; emitting a string here keeps both backends consistent
-    # and avoids a list[1] shape that no other producer/consumer expects.
-    if declared_result_count == 1:
-        return _make_compute_tile_id_op(f"{base}#0")
-    return _make_compute_tile_id_op(
-        [f"{base}#{i}" for i in range(declared_result_count)]
+    m = re.match(
+        r"^(.*?)\s*=\s*ktdp\.get_compute_tile_id\s*:\s*([^{(]*)\s*$", op_text
     )
+    if not m:
+        return None
+    names = parse_multi_result_lhs(m.group(1))
+    type_count = sum(1 for t in m.group(2).split(",") if t.strip())
+    if len(names) != type_count:
+        raise ValueError(
+            f"ktdp.get_compute_tile_id: {len(names)} result name(s) but "
+            f"{type_count} result type(s) in: {op_text!r}"
+        )
+    result = names[0] if len(names) == 1 else names
+    return _make_compute_tile_id_op(result)
 
 
 @register_parser("ktdp.construct_memory_view")
@@ -294,7 +251,7 @@ def parse_construct_access_tile(op_text, parse_ctx: ParseContext):
     result_name = result_match.group(1)
 
     after_eq = op_text[op_text.index('=') + 1:]
-    operands = re.findall(r'%\w+', after_eq)
+    operands = find_ssa_names(after_eq)
 
     tile_match = re.search(r'!ktdp\.access_tile<([^>]+)>', op_text)
     if not tile_match:

--- a/ktir_cpu/dialects/linalg_ops.py
+++ b/ktir_cpu/dialects/linalg_ops.py
@@ -22,7 +22,7 @@ from ..ir_types import Operation, Tile
 from ..latency import LatencyCategory as LC
 from ..ops.arith_ops import ArithOps
 from ..parser_ast import parse_affine_map
-from ..parser_utils import parse_attr_list
+from ..parser_utils import find_ssa_names, parse_attr_list
 from .registry import register, register_parser
 
 
@@ -338,9 +338,9 @@ def parse_linalg_fill(op_text, parse_ctx):
 
     operands = []
     if ins_match:
-        operands.extend(re.findall(r'%\w+', ins_match.group(1)))
+        operands.extend(find_ssa_names(ins_match.group(1)))
     if outs_match:
-        operands.extend(re.findall(r'%\w+', outs_match.group(1)))
+        operands.extend(find_ssa_names(outs_match.group(1)))
 
     return Operation(
         result=result_name,
@@ -397,12 +397,12 @@ def parse_linalg_generic(op_text, parse_ctx):
     ins_operands = []
     ins_match = re.search(r'\bins\s*\(([^)]+)\)', op_text)
     if ins_match:
-        ins_operands = re.findall(r'%\w+', ins_match.group(1).split(':')[0])
+        ins_operands = find_ssa_names(ins_match.group(1).split(':')[0])
 
     outs_operands = []
     outs_match = re.search(r'\bouts\s*\(([^)]+)\)', op_text)
     if outs_match:
-        outs_operands = re.findall(r'%\w+', outs_match.group(1).split(':')[0])
+        outs_operands = find_ssa_names(outs_match.group(1).split(':')[0])
 
     return Operation(
         result=result_name,
@@ -434,7 +434,7 @@ def parse_linalg_yield(op_text, parse_ctx):
     m = re.match(r'linalg\.yield\s+(.*)', op_text)
     if not m:
         return None
-    operands = re.findall(r'%\w+', m.group(1).split(':')[0])
+    operands = find_ssa_names(m.group(1).split(':')[0])
     return Operation(
         result=None,
         op_type="linalg.yield",
@@ -458,9 +458,9 @@ def parse_linalg_broadcast(op_text, parse_ctx):
 
     operands = []
     if ins_match:
-        operands.extend(re.findall(r'%\w+', ins_match.group(1)))
+        operands.extend(find_ssa_names(ins_match.group(1)))
     if outs_match:
-        operands.extend(re.findall(r'%\w+', outs_match.group(1)))
+        operands.extend(find_ssa_names(outs_match.group(1)))
 
     dims = []
     dims_match = re.search(r'dimensions\s*=\s*\[([^\]]*)\]', op_text)

--- a/ktir_cpu/dialects/scf_ops.py
+++ b/ktir_cpu/dialects/scf_ops.py
@@ -21,6 +21,7 @@ from ..latency import LatencyCategory as LC
 from ..ops.comm_ops import CommOps
 from ..ops.arith_ops import ArithOps
 from ..ops.control_ops import ControlOps
+from ..parser_utils import find_ssa_names
 from .registry import register, register_parser
 
 
@@ -184,7 +185,7 @@ def parse_scf_yield(op_text, parse_ctx):
     if yield_match:
         rest = yield_match.group(1)
     operand_text = rest.split(':')[0] if ':' in rest else rest
-    operands = re.findall(r'%\w+', operand_text)
+    operands = find_ssa_names(operand_text)
     return Operation(
         result=None,
         op_type="scf.yield",

--- a/ktir_cpu/dialects/tensor_ops.py
+++ b/ktir_cpu/dialects/tensor_ops.py
@@ -22,6 +22,7 @@ import numpy as np
 from ..grid import CoreContext
 from ..dtypes import to_np_dtype
 from ..ir_types import Operation, Tile
+from ..parser_utils import find_ssa_names
 from .registry import register, register_parser
 
 
@@ -265,7 +266,7 @@ def parse_tensor_extract(op_text, parse_ctx):
     if bracket_match:
         bracket_content = bracket_match.group(1).strip()
         if bracket_content:
-            indices = re.findall(r'%\w+', bracket_content)
+            indices = find_ssa_names(bracket_content)
 
     return Operation(
         result=result_name,
@@ -334,7 +335,7 @@ def parse_tensor_yield(op_text, parse_ctx):
         rest = yield_match.group(1)
     # Operands are before the `:` type annotation
     operand_text = rest.split(':')[0] if ':' in rest else rest
-    operands = re.findall(r'%\w+', operand_text)
+    operands = find_ssa_names(operand_text)
     return Operation(
         result=None,
         op_type="tensor.yield",

--- a/ktir_cpu/parser.py
+++ b/ktir_cpu/parser.py
@@ -598,7 +598,9 @@ class KTIRParser(KTIRParserBase):
         # attribute blocks.
         cleaned = re.sub(r'\{[^}]*\}', '', text)
 
-        operands = re.findall(r'%\w+', cleaned)
+        # "%name#N" is MLIR's multi-result of N ops defined as 
+        # "%base:N = ..." — keep the "#N" attached so results are distinct keys.
+        operands = re.findall(r'%\w+(?:#\d+)?', cleaned)
 
         # Remove result name if present
         if result:

--- a/ktir_cpu/parser.py
+++ b/ktir_cpu/parser.py
@@ -26,6 +26,7 @@ from typing import Dict, List, Optional, Tuple
 from .ir_types import Operation, IRFunction, IRModule
 from .dialects import dispatch_parser, make_parse_context, ParseContext
 from .parser_utils import parse_attr_block, parse_tensor_type, parse_numeric
+from .parser_utils import find_ssa_names
 
 
 class KTIRParserBase(ABC):
@@ -604,7 +605,7 @@ class KTIRParser(KTIRParserBase):
 
         # "%name#N" is MLIR's multi-result of N ops defined as 
         # "%base:N = ..." — keep the "#N" attached so results are distinct keys.
-        operands = re.findall(r'%\w+(?:#\d+)?', cleaned)
+        operands = find_ssa_names(cleaned)
 
         # Remove result name if present
         if result:

--- a/ktir_cpu/parser.py
+++ b/ktir_cpu/parser.py
@@ -603,8 +603,6 @@ class KTIRParser(KTIRParserBase):
         # attribute blocks.
         cleaned = re.sub(r'\{[^}]*\}', '', text)
 
-        # "%name#N" is MLIR's multi-result of N ops defined as 
-        # "%base:N = ..." — keep the "#N" attached so results are distinct keys.
         operands = find_ssa_names(cleaned)
 
         # Remove result name if present

--- a/ktir_cpu/parser_utils.py
+++ b/ktir_cpu/parser_utils.py
@@ -22,6 +22,34 @@ either side without creating a circular import.
 import re
 from typing import Any, Dict, List, Optional
 
+_SSA_RE = re.compile(r'%\w+(?:#\d+)?')
+
+
+def find_ssa_names(text: str) -> list[str]:
+    """Find all SSA value references in *text*, including multi-result ``%base#N`` forms."""
+    return _SSA_RE.findall(text)
+
+
+def parse_multi_result_lhs(lhs_text: str) -> list[str]:
+    """Parse the LHS of a multi-result MLIR assignment.
+
+    Accepts:
+      bundled form  ``"%g:2"``    -> ``["%g#0", "%g#1"]``
+      comma form    ``"%x, %y"``  -> ``["%x", "%y"]``
+      single        ``"%x"``      -> ``["%x"]``
+
+    Raises ``ValueError`` on malformed input.
+    """
+    m = re.fullmatch(r'(%\w+):([1-9]\d*)', lhs_text.strip())
+    if m:
+        base, n = m.group(1), int(m.group(2))
+        return [f"{base}#{i}" for i in range(n)]
+    parts = [p.strip() for p in lhs_text.split(",")]
+    if all(re.fullmatch(r'%\w+', p) for p in parts):
+        return parts
+    raise ValueError(f"cannot parse multi-result LHS: {lhs_text!r}")
+
+
 def parse_tensor_type(type_str: str) -> Optional[Dict]:
     """Parse a tensor type string, returning shape and dtype if it matches.
 

--- a/tests/test_dialects_parse.py
+++ b/tests/test_dialects_parse.py
@@ -595,31 +595,6 @@ class TestKtdpParsers(ParseTestMixin):
         with pytest.raises(Exception, match=self._COUNT_MISMATCH_MSG):
             self._parse("%x, %y = ktdp.get_compute_tile_id : index")
 
-    def test_bundled_result_referenced_via_hash_index(self):
-        # Regression for bundled definition + "%base#N" references.
-        #
-        # Regex backend: the op parses; verify the "#0" suffix is preserved
-        # as part of operand identity (operand string is "%pid#0", not "%pid").
-        #
-        # MLIR-frontend backend: the adapter wraps op_text in a func.func
-        # and declares each ``args`` entry as a function parameter — but
-        # MLIR's grammar reserves "%name#N" for *references* to multi-
-        # result ops, so it can't appear in an argument list. That parse
-        # rejection is itself proof that "#N" is a structural part of the
-        # SSA name, not a stripped suffix — which is exactly what this
-        # test guards.
-        op_text = "%c = arith.index_cast %pid#0 : index to i32"
-        try:
-            op = self._parse(op_text, args={"%pid#0": "index"})
-        except Exception as e:
-            assert "result number not allowed in argument list" in str(e)
-            return
-        self.assert_op_type(op, "arith.index_cast")
-        self.assert_num_operands(op, 1)
-        self.assert_operand_names(op, "%pid#0")
-        # And the un-suffixed base name must NOT appear as an operand.
-        assert "%pid" not in op.operands
-
     def test_construct_memory_view(self):
         # construct_memory_view records shape, strides, dtype, memory_space, and pointer operand
         op = self._parse(

--- a/tests/test_dialects_parse.py
+++ b/tests/test_dialects_parse.py
@@ -534,20 +534,24 @@ class TestKtdpParsers(ParseTestMixin):
         assert isinstance(op.result, list)
         assert len(op.result) == 2
 
-    def test_get_compute_tile_id_bundled(self):
+    @pytest.mark.parametrize("n", [2, 3])
+    def test_get_compute_tile_id_bundled(self, n):
         # One base name with a ":N" suffix declaring N results. The parser
         # must canonicalize this into N distinct SSA result names — backends
         # disagree on the exact spelling (regex preserves "%pid#0/#1";
         # MLIR-frontend rewrites to canonical "%N"), so we only assert
         # structural shape: N entries, each a non-empty "%..." SSA name.
-        op = self._parse("%pid:2 = ktdp.get_compute_tile_id : index, index")
+        # Parametrized over N to cover both the minimum multi-result case
+        # (N=2) and N>2, since the bundled grammar admits any [1-9]\d*.
+        types = ", ".join(["index"] * n)
+        op = self._parse(f"%pid:{n} = ktdp.get_compute_tile_id : {types}")
         self.assert_op_type(op, "ktdp.get_compute_tile_id")
         assert isinstance(op.result, list)
-        assert len(op.result) == 2
+        assert len(op.result) == n
         assert all(isinstance(r, str) and r.startswith("%") and len(r) > 1
                    for r in op.result)
         # The N names must be distinct.
-        assert len(set(op.result)) == 2
+        assert len(set(op.result)) == n
 
     def test_get_compute_tile_id_bundled_single_result(self):
         # N=1 is the lower endpoint of the bundled grammar — the regex
@@ -562,30 +566,33 @@ class TestKtdpParsers(ParseTestMixin):
         assert op.result.startswith("%")
         assert len(op.result) > 1
 
-    def test_get_compute_tile_id_bundled_three_results(self):
-        # Bundled form works for N > 2, not just N == 2.
-        op = self._parse(
-            "%g:3 = ktdp.get_compute_tile_id : index, index, index"
-        )
-        assert isinstance(op.result, list)
-        assert len(op.result) == 3
-        assert all(isinstance(r, str) and r.startswith("%") and len(r) > 1
-                   for r in op.result)
-        assert len(set(op.result)) == 3
+    # Both surface forms (bundled "%pid:2" and comma "%x, %y") flow
+    # through the shared parse_multi_result_lhs helper and raise the same
+    # regex-parser diagnostic. The MLIR frontend (used by future
+    # BindingsParseTestMixin subclasses) raises a different but equally
+    # specific diagnostic. Match each backend's full phrasing rather than
+    # a tiny substring — short patterns like "result type" can match
+    # unrelated future error messages and silently let regressions slip
+    # through.
+    _COUNT_MISMATCH_MSG = (
+        # Regex parser:
+        # "ktdp.get_compute_tile_id: N result name(s) but M result
+        #  type(s) in: ..."
+        r"\d+ result name\(s\) but \d+ result type\(s\)"
+        r"|"
+        # MLIR frontend:
+        # "operation defines N results but was provided M to bind"
+        r"operation defines \d+ results but was provided \d+ to bind"
+    )
 
     def test_get_compute_tile_id_bundled_count_mismatch_rejected(self):
-        # Regex parser raises ValueError("result type ..."); MLIR frontend
-        # raises MLIRError("operation defines N results but was provided M
-        # to bind"). Both pinpoint the same defect (result-count mismatch),
-        # so accept either by widening to Exception and matching either
-        # message.
-        with pytest.raises(Exception, match="result type|results but was provided"):
+        # Bundled form "%pid:2 = ... : index" — 2 results declared, 1 type.
+        with pytest.raises(Exception, match=self._COUNT_MISMATCH_MSG):
             self._parse("%pid:2 = ktdp.get_compute_tile_id : index")
 
     def test_get_compute_tile_id_comma_count_mismatch_rejected(self):
-        # Two names, one type — must fail at parse. Same dual-backend
-        # message handling as above.
-        with pytest.raises(Exception, match="result type|results but was provided"):
+        # Comma form "%x, %y = ... : index" — 2 names, 1 type.
+        with pytest.raises(Exception, match=self._COUNT_MISMATCH_MSG):
             self._parse("%x, %y = ktdp.get_compute_tile_id : index")
 
     def test_bundled_result_referenced_via_hash_index(self):

--- a/tests/test_dialects_parse.py
+++ b/tests/test_dialects_parse.py
@@ -454,6 +454,85 @@ class TestKtdpParsers(ParseTestMixin):
         assert isinstance(op.result, list)
         assert len(op.result) == 2
 
+    def test_get_compute_tile_id_bundled(self):
+        # One base name with a ":N" suffix declaring N results. The parser
+        # must canonicalize this into N distinct SSA result names — backends
+        # disagree on the exact spelling (regex preserves "%pid#0/#1";
+        # MLIR-frontend rewrites to canonical "%N"), so we only assert
+        # structural shape: N entries, each a non-empty "%..." SSA name.
+        op = self._parse("%pid:2 = ktdp.get_compute_tile_id : index, index")
+        self.assert_op_type(op, "ktdp.get_compute_tile_id")
+        assert isinstance(op.result, list)
+        assert len(op.result) == 2
+        assert all(isinstance(r, str) and r.startswith("%") and len(r) > 1
+                   for r in op.result)
+        # The N names must be distinct.
+        assert len(set(op.result)) == 2
+
+    def test_get_compute_tile_id_bundled_single_result(self):
+        # N=1 is the lower endpoint of the bundled grammar — the regex
+        # admits "%x:1" via [1-9]\d*, and "%x:1 = op : index" is valid
+        # MLIR. Both backends collapse bundled-N=1 to the bare-string
+        # form (regex emits "%base#0"; MLIR-frontend emits the SSA value
+        # the C++ parser produces, e.g. "%0"), honoring the codebase-
+        # wide convention: single result ⇔ str; multi-result ⇔ list[≥2].
+        op = self._parse("%x:1 = ktdp.get_compute_tile_id : index")
+        self.assert_op_type(op, "ktdp.get_compute_tile_id")
+        assert isinstance(op.result, str)
+        assert op.result.startswith("%")
+        assert len(op.result) > 1
+
+    def test_get_compute_tile_id_bundled_three_results(self):
+        # Bundled form works for N > 2, not just N == 2.
+        op = self._parse(
+            "%g:3 = ktdp.get_compute_tile_id : index, index, index"
+        )
+        assert isinstance(op.result, list)
+        assert len(op.result) == 3
+        assert all(isinstance(r, str) and r.startswith("%") and len(r) > 1
+                   for r in op.result)
+        assert len(set(op.result)) == 3
+
+    def test_get_compute_tile_id_bundled_count_mismatch_rejected(self):
+        # Regex parser raises ValueError("result type ..."); MLIR frontend
+        # raises MLIRError("operation defines N results but was provided M
+        # to bind"). Both pinpoint the same defect (result-count mismatch),
+        # so accept either by widening to Exception and matching either
+        # message.
+        with pytest.raises(Exception, match="result type|results but was provided"):
+            self._parse("%pid:2 = ktdp.get_compute_tile_id : index")
+
+    def test_get_compute_tile_id_comma_count_mismatch_rejected(self):
+        # Two names, one type — must fail at parse. Same dual-backend
+        # message handling as above.
+        with pytest.raises(Exception, match="result type|results but was provided"):
+            self._parse("%x, %y = ktdp.get_compute_tile_id : index")
+
+    def test_bundled_result_referenced_via_hash_index(self):
+        # Regression for bundled definition + "%base#N" references.
+        #
+        # Regex backend: the op parses; verify the "#0" suffix is preserved
+        # as part of operand identity (operand string is "%pid#0", not "%pid").
+        #
+        # MLIR-frontend backend: the adapter wraps op_text in a func.func
+        # and declares each ``args`` entry as a function parameter — but
+        # MLIR's grammar reserves "%name#N" for *references* to multi-
+        # result ops, so it can't appear in an argument list. That parse
+        # rejection is itself proof that "#N" is a structural part of the
+        # SSA name, not a stripped suffix — which is exactly what this
+        # test guards.
+        op_text = "%c = arith.index_cast %pid#0 : index to i32"
+        try:
+            op = self._parse(op_text, args={"%pid#0": "index"})
+        except Exception as e:
+            assert "result number not allowed in argument list" in str(e)
+            return
+        self.assert_op_type(op, "arith.index_cast")
+        self.assert_num_operands(op, 1)
+        self.assert_operand_names(op, "%pid#0")
+        # And the un-suffixed base name must NOT appear as an operand.
+        assert "%pid" not in op.operands
+
     def test_construct_memory_view(self):
         # construct_memory_view records shape, strides, dtype, memory_space, and pointer operand
         op = self._parse(


### PR DESCRIPTION
Previous regex parser handles typical situation of `%pid_m, %pid_n = ktdp.get_compute_tile_id : index, index` but failed to  handle valid syntax of `%pid_m:2 = ktdp.get_compute_tile_id : index, index`. This PR aims to fix that.