### PR TITLE
[Feature] Add ktdp.store with IndirectAccessTile (scatter)

### DIFF
--- a/docs/gap_analysis.md
+++ b/docs/gap_analysis.md
@@ -12,7 +12,7 @@
 | # | Spec Operation | Status | Notes |
 |---|---------------|--------|-------|
 | 1 | `ktdp.construct_distributed_memory_view` | ✅ | Handler and parser implemented in `ktir_cpu/dialects/ktdp_ops.py`; produces `DistributedMemRef` (composition of N per-partition `MemRef`s). Per-partition routing at access time via `MemoryOps.distributed_tile_access` → `DistributedTileRef`. Tests in `tests/test_distributed_view.py`. |
-| 2 | `ktdp.construct_indirect_access_tile` | ✅ | Handler and parser implemented in `ktir_cpu/dialects/ktdp_ops.py`; tests passing in `tests/test_indirect_access.py`. |
+| 2 | `ktdp.construct_indirect_access_tile` | ✅ | Handler and parser implemented in `ktir_cpu/dialects/ktdp_ops.py`; tests passing in `tests/test_indirect_access.py`. Both `ktdp.load` (gather, via `MemoryOps.indirect_load`) and `ktdp.store` (scatter, via `MemoryOps.indirect_store`) accept `IndirectAccessTile` (#44 closed). |
 
 ## B. `ktdp` Types & Attributes
 

--- a/examples/rfc/indirect-scatter.mlir
+++ b/examples/rfc/indirect-scatter.mlir
@@ -1,0 +1,72 @@
+// RFC 0682 Section C.5 — construct_indirect_access_tile (scatter)
+// Symmetric counterpart to indirect-access-copy.mlir.
+// indirect-access-copy:  Y[m, k] = X[ IDX1[m, k], IDX2[m, k] ]   (gather via load)
+// indirect-scatter:      Y[ IDX1[m, k], IDX2[m, k] ] = X[m, k]   (scatter via store)
+
+// X input  = 2D tensor, shape {64, 64}                          (source, direct access)
+// IDX1     = 2D tensor, shape {64, 64}, provides row indices into Y
+// IDX2     = 2D tensor, shape {64, 64}, provides column indices into Y
+// Y output = 2D tensor, shape {64, 64}                          (destination, indirect access)
+
+#X_coord_set   = affine_set<(d0, d1) : (d0 >= 0, -d0 + 63 >= 0, d1 >= 0, -d1 + 63 >= 0)>
+#IDX_coord_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 63 >= 0, d1 >= 0, -d1 + 63 >= 0)>
+#Y_coord_set   = affine_set<(d0, d1) : (d0 >= 0, -d0 + 63 >= 0, d1 >= 0, -d1 + 63 >= 0)>
+#var_space_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 63 >= 0, d1 >= 0, -d1 + 63 >= 0)>
+#var_space_order = affine_map<(d0, d1) -> (d0, d1)>
+
+module {
+  func.func @indirect_scatter() {
+        // Stick-indexed addresses (HBM); same layout convention as indirect-access-copy.mlir.
+        %X_addr    = arith.constant 0   : index   // stick 0   = byte 0
+        %IDX1_addr = arith.constant 64  : index   // stick 64  = byte 8192
+        %IDX2_addr = arith.constant 128 : index   // stick 128 = byte 16384
+        %Y_addr    = arith.constant 192 : index   // stick 192 = byte 24576
+
+        // (1) Construct memory view for X (source)
+        %X_view = ktdp.construct_memory_view %X_addr, sizes: [64, 64], strides: [64, 1] {
+            coordinate_set = #X_coord_set,
+            memory_space = #ktdp.spyre_memory_space<HBM>
+        } : memref<64x64xf16>
+
+        // (1) Construct memory view for IDX1 (row indices into Y)
+        %IDX1 = ktdp.construct_memory_view %IDX1_addr, sizes: [64, 64], strides: [64, 1] {
+            coordinate_set = #IDX_coord_set,
+            memory_space = #ktdp.spyre_memory_space<HBM>
+        } : memref<64x64xi32>
+
+        // (1) Construct memory view for IDX2 (column indices into Y)
+        %IDX2 = ktdp.construct_memory_view %IDX2_addr, sizes: [64, 64], strides: [64, 1] {
+            coordinate_set = #IDX_coord_set,
+            memory_space = #ktdp.spyre_memory_space<HBM>
+        } : memref<64x64xi32>
+
+        // (1) Construct memory view for Y (destination)
+        %Y_view = ktdp.construct_memory_view %Y_addr, sizes: [64, 64], strides: [64, 1] {
+            coordinate_set = #Y_coord_set,
+            memory_space = #ktdp.spyre_memory_space<HBM>
+        } : memref<64x64xf16>
+
+        // (2) Direct access tile for X[m, k] — load source contiguously
+        %c0 = arith.constant 0 : index
+        %X_access_tile = ktdp.construct_access_tile %X_view[%c0, %c0] {
+            access_tile_set   = #X_coord_set,
+            access_tile_order = #var_space_order
+        } : memref<64x64xf16> -> !ktdp.access_tile<64x64xindex>
+
+        // (2) Indirect access tile for Y[IDX1[m,k], IDX2[m,k]] — scatter destination
+        %Y_access_tile = ktdp.construct_indirect_access_tile
+            intermediate_variables(%m, %k)
+            %Y_view[ind(%IDX1[%m, %k]), ind(%IDX2[%m, %k])] {
+                variables_space_set = #var_space_set,
+                variables_space_order = #var_space_order
+            } : memref<64x64xf16>, memref<64x64xi32>, memref<64x64xi32> -> !ktdp.access_tile<64x64xindex>
+
+        // (3) Load source tile X[m, k]
+        %X_data_tile = ktdp.load %X_access_tile : !ktdp.access_tile<64x64xindex> -> tensor<64x64xf16>
+
+        // (4) Scatter: Y[IDX1[m, k], IDX2[m, k]] = X[m, k]
+        ktdp.store %X_data_tile, %Y_access_tile : tensor<64x64xf16>, !ktdp.access_tile<64x64xindex>
+
+        return
+  }
+}

--- a/examples/rfc/paged-tensor-write.mlir
+++ b/examples/rfc/paged-tensor-write.mlir
@@ -7,17 +7,17 @@
 // Idx input = 2D tensor, shape {Nb, Ntkv/Ptkv} = {4, 32} i32
 // Y output = paged 4D tensor, shape {Npages, Nh, Ptkv, Ndkv} = {10000, 8, 64, 128} f16
 //
-// Affine declarations are kept verbatim from paged-tensor-copy.mlir; the
-// `var_space` qualifier refers to the iteration variable layout, not to which
-// tensor the IAT acts on. So `#X_var_space_*` continues to describe the
+// The `var_space` declarations are kept verbatim from paged-tensor-copy.mlir;
+// the `var_space` qualifier refers to the iteration variable layout, not to
+// which tensor the IAT acts on. So `#X_var_space_*` continues to describe the
 // indirect-access (b, h, tkv, dkv) iteration even though X is now the
 // (contiguous) source.
 
-#X_coord_set = affine_set<(d0, d1, d2, d3) : (d0 >= 0, -d0 + 9999 >= 0,
+#paged_coord_set = affine_set<(d0, d1, d2, d3) : (d0 >= 0, -d0 + 9999 >= 0,
                                               d1 >= 0, -d1 + 7 >=0,
                                               d2 >= 0, -d2 + 63 >= 0,
                                               d3 >= 0, -d3 + 127>= 0)>
-#Y_coord_set = affine_set<(d0, d1, d2, d3) : (d0 >= 0, -d0 + 3 >= 0,
+#contiguous_coord_set = affine_set<(d0, d1, d2, d3) : (d0 >= 0, -d0 + 3 >= 0,
                                               d1 >= 0, -d1 + 2047 >=0,
                                               d2 >= 0, -d2 + 7 >= 0,
                                               d3 >= 0, -d3 + 127>= 0)>
@@ -65,7 +65,7 @@ module {
         %X_str_Nb = arith.muli %X_str_Ntkv, %Ntkv : index
         %X_mem_view = ktdp.construct_memory_view %X_start_address,
                         sizes: [%Nb, %Ntkv, %Nhkv, %Ndkv], strides: [%X_str_Nb, %X_str_Ntkv, %Ndkv, 1] {
-                        coordinate_set = #Y_coord_set,
+                        coordinate_set = #contiguous_coord_set,
                         memory_space = #ktdp.spyre_memory_space<HBM>
         } : memref<4x2048x8x128xf16>
 
@@ -73,7 +73,7 @@ module {
         // dim order (outermost to innermost) {Npages, Nh, Ptkv, Ndkv}
         %Y_mem_view = ktdp.construct_memory_view %Y_start_address,
                         sizes: [%Npages, %Nhkv, %Ptkv, %Ndkv], strides: [65536, 8192, %Ndkv, 1] {
-                        coordinate_set = #X_coord_set,
+                        coordinate_set = #paged_coord_set,
                         memory_space = #ktdp.spyre_memory_space<HBM>
         } : memref<10000x8x64x128xf16>
 

--- a/examples/rfc/paged-tensor-write.mlir
+++ b/examples/rfc/paged-tensor-write.mlir
@@ -1,0 +1,105 @@
+// Scatter dual of paged-tensor-copy.mlir.
+// Same semantics, X and Y roles swapped:
+//   paged-tensor-copy:  Y[b][tkv][h][dkv] = X[Idx[b][tkv/Ptkv]][h][tkv%Ptkv][dkv]
+//   paged-tensor-write: Y[Idx[b][tkv/Ptkv]][h][tkv%Ptkv][dkv] = X[b][tkv][h][dkv]
+//
+// X input  = contiguous 4D tensor, shape {Nb, Ntkv, Nh, Ndkv} = {4, 2048, 8, 128} f16
+// Idx input = 2D tensor, shape {Nb, Ntkv/Ptkv} = {4, 32} i32
+// Y output = paged 4D tensor, shape {Npages, Nh, Ptkv, Ndkv} = {10000, 8, 64, 128} f16
+//
+// Affine declarations are kept verbatim from paged-tensor-copy.mlir; the
+// `var_space` qualifier refers to the iteration variable layout, not to which
+// tensor the IAT acts on. So `#X_var_space_*` continues to describe the
+// indirect-access (b, h, tkv, dkv) iteration even though X is now the
+// (contiguous) source.
+
+#X_coord_set = affine_set<(d0, d1, d2, d3) : (d0 >= 0, -d0 + 9999 >= 0,
+                                              d1 >= 0, -d1 + 7 >=0,
+                                              d2 >= 0, -d2 + 63 >= 0,
+                                              d3 >= 0, -d3 + 127>= 0)>
+#Y_coord_set = affine_set<(d0, d1, d2, d3) : (d0 >= 0, -d0 + 3 >= 0,
+                                              d1 >= 0, -d1 + 2047 >=0,
+                                              d2 >= 0, -d2 + 7 >= 0,
+                                              d3 >= 0, -d3 + 127>= 0)>
+#X_var_space_set = affine_set<(d0, d1, d2, d3) : (d0 >= 0, -d0 + 3 >= 0,
+                                                  d1 >= 0, -d1 + 7 >= 0,
+                                                  d2 >= 0, -d2 + 2047>= 0,
+                                                  d3 >= 0, -d3 + 127 >= 0)>
+#Y_var_space_set = affine_set<(d0, d1, d2, d3) : (d0 >= 0, -d0 + 3 >= 0,
+                                                  d1 >= 0, -d1 + 2047>= 0,
+                                                  d2 >= 0, -d2 + 7 >= 0,
+                                                  d3 >= 0, -d3 + 127 >= 0)>
+#X_var_space_order = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+#Y_var_space_order = affine_map<(d0, d1, d2, d3) -> (d0, d2, d1, d3)>
+
+module {
+  func.func @paged_tensor_write_1core() {
+        %Nb = arith.constant 4 : index
+        %Ntkv = arith.constant 2048 : index
+        %Ptkv = arith.constant 64 : index
+        %Ndkv = arith.constant 128 : index
+        %Nhkv = arith.constant 8 : index
+        %Npages = arith.constant 10000 : index
+        %Ntkv_Ptkv = arith.divui %Ntkv, %Ptkv : index
+
+        // Memory layout: addresses are spaced so all three tensors are byte-disjoint.
+        //   X  spans [10M, 26.78M)  — 4*2048*8*128 f16 = 16.78 MB (contiguous source)
+        //   Idx spans [30M, 30M+512] — 4*32 i32 = 512 B (page table)
+        //   Y  starts at 40M         — 10000*8*64*128 f16 = 1.31 GB (paged dest)
+        // (paged-tensor-copy.mlir uses overlapping addresses; we don't replicate
+        // that here — see test_spec_gaps.py for the matching seed values.)
+        %X_start_address = arith.constant 10000000 : index   // X (contiguous source)
+        %Idx_start_address = arith.constant 30000000 : index // Idx (page table)
+        %Y_start_address = arith.constant 40000000 : index   // Y (paged destination)
+
+        // (1) Construct memory view for Index tensor
+        %Idx_mem_view = ktdp.construct_memory_view %Idx_start_address,
+                        sizes: [%Nb, %Ntkv_Ptkv], strides: [%Ntkv_Ptkv, 1] {
+                        coordinate_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 3 >= 0, d1 >= 0, -d1 + 31 >= 0)>,
+                        memory_space = #ktdp.spyre_memory_space<HBM>
+        } : memref<4x32xi32>
+
+        // (1) Construct memory view for input X (contiguous)
+        // dim order (outermost to innermost) {Nb, Ntkv, Nh, Ndkv}
+        %X_str_Ntkv = arith.muli %Ndkv, %Nhkv : index
+        %X_str_Nb = arith.muli %X_str_Ntkv, %Ntkv : index
+        %X_mem_view = ktdp.construct_memory_view %X_start_address,
+                        sizes: [%Nb, %Ntkv, %Nhkv, %Ndkv], strides: [%X_str_Nb, %X_str_Ntkv, %Ndkv, 1] {
+                        coordinate_set = #Y_coord_set,
+                        memory_space = #ktdp.spyre_memory_space<HBM>
+        } : memref<4x2048x8x128xf16>
+
+        // (1) Construct memory view for output Y (paged)
+        // dim order (outermost to innermost) {Npages, Nh, Ptkv, Ndkv}
+        %Y_mem_view = ktdp.construct_memory_view %Y_start_address,
+                        sizes: [%Npages, %Nhkv, %Ptkv, %Ndkv], strides: [65536, 8192, %Ndkv, 1] {
+                        coordinate_set = #X_coord_set,
+                        memory_space = #ktdp.spyre_memory_space<HBM>
+        } : memref<10000x8x64x128xf16>
+
+        // (2) Direct access tile for X[b, tkv, h, dkv] — load source contiguously
+        // access_tile_set/order use the (b, tkv, h, dkv) iteration so flatten()
+        // of the loaded tile aligns with the (b, h, tkv, dkv) IAT enumeration.
+        %c0 = arith.constant 0 : index
+        %X_access_tile = ktdp.construct_access_tile %X_mem_view[%c0, %c0, %c0, %c0] {
+            access_tile_set   = #Y_var_space_set,
+            access_tile_order = #Y_var_space_order
+        } : memref<4x2048x8x128xf16> -> !ktdp.access_tile<4x8x2048x128xindex>
+
+        // (3) Indirect access tile for Y[Idx[b, tkv/Ptkv], h, tkv%Ptkv, dkv]
+        %Y_access_tile = ktdp.construct_indirect_access_tile
+            intermediate_variables(%b, %h, %tkv, %dkv)
+            %Y_mem_view[ind(%Idx_mem_view[%b, %tkv floordiv 64]), (%h), (%tkv mod 64), (%dkv)] {
+                variables_space_set   = #X_var_space_set,
+                variables_space_order = #X_var_space_order
+            } : memref<10000x8x64x128xf16>, memref<4x32xi32> -> !ktdp.access_tile<4x8x2048x128xindex>
+
+        // (4) Load X[b, tkv, h, dkv]
+        %X_data_tile = ktdp.load %X_access_tile : !ktdp.access_tile<4x8x2048x128xindex> -> tensor<4x8x2048x128xf16>
+
+        // (5) Scatter: Y[Idx[b, tkv/Ptkv], h, tkv%Ptkv, dkv] = X[b, tkv, h, dkv]
+        ktdp.store %X_data_tile, %Y_access_tile : tensor<4x8x2048x128xf16>, !ktdp.access_tile<4x8x2048x128xindex>
+
+        return
+  }
+}

--- a/ktir_cpu/dialects/ktdp_ops.py
+++ b/ktir_cpu/dialects/ktdp_ops.py
@@ -163,7 +163,8 @@ def ktdp__store(op, context, env):
     assert isinstance(value, Tile), f"ktdp.store expects a Tile, got {type(value)}"
     access_tile = context.get_value(op.operands[1])
     if isinstance(access_tile, IndirectAccessTile):
-        raise NotImplementedError("ktdp.store with IndirectAccessTile is not yet supported")
+        MemoryOps.indirect_store(context, value, access_tile)
+        return None
     if isinstance(access_tile.parent_ref, DistributedTileRef):
         MemoryOps.distributed_store(context, value, access_tile.parent_ref)
         return None

--- a/ktir_cpu/ops/memory_ops.py
+++ b/ktir_cpu/ops/memory_ops.py
@@ -347,19 +347,15 @@ class MemoryOps:
         (direct dims use the variable value, indirect dims look up the
         index in an index memref), then delegates to :meth:`load`.
 
-        Raises NotImplementedError if ``variables_space_order`` is non-identity
-        (rebinding intermediate variables under a permutation is unimplemented).
+        Raises NotImplementedError if ``variables_space_order`` is non-identity.
         """
         vss = iat.variables_space_set
         vso = iat.variables_space_order
 
-        # Reject permuted vso: applying it in-place would corrupt the variable
-        # bindings consumed below and would not reorder the enumeration anyway.
         if vso is not None and not vso.is_identity():
             raise NotImplementedError(
-                "indirect_load: non-identity variables_space_order is not yet "
-                "supported (rebinding intermediate variables under a permutation "
-                "is unimplemented)"
+                "indirect_load: output tile permutation via non-identity "
+                "variables_space_order is not yet implemented"
             )
 
         # Pre-compile per-dim resolvers so branch dispatch and constant lookups
@@ -394,7 +390,15 @@ class MemoryOps:
                     idx_coords = tuple(eval_subscript_expr(e, pt) for e in idx_exprs)
                     offset = sum(c * s for c, s in zip(idx_coords, idx_view.strides))
                     addr = idx_view.byte_address + offset * bpe
-                    coord.append(int(_MemAccessor(context, idx_view.memory_space, addr, idx_view.lx_core_id).read(1, idx_view.dtype)[0]))
+                    raw_idx = int(_MemAccessor(context, idx_view.memory_space, addr, idx_view.lx_core_id).read(1, idx_view.dtype)[0])
+                    # NumPy fancy-index reads silently wrap negative
+                    # indices; reject them here. Use raise so the check
+                    # survives python -O.
+                    if raw_idx < 0:
+                        raise IndexError(
+                            f"indirect index {raw_idx} from {idx_view} is negative"
+                        )
+                    coord.append(raw_idx)
             coords.append(tuple(coord))
 
         out_shape = result_shape if result_shape is not None else iat.shape
@@ -686,12 +690,10 @@ class MemoryOps:
         vss = iat.variables_space_set
         vso = iat.variables_space_order
 
-        # See indirect_load for the rationale on rejecting permuted vso.
         if vso is not None and not vso.is_identity():
             raise NotImplementedError(
-                "indirect_store: non-identity variables_space_order is not yet "
-                "supported (rebinding intermediate variables under a permutation "
-                "is unimplemented)"
+                "indirect_store: output tile permutation via non-identity "
+                "variables_space_order is not yet implemented"
             )
 
         # Pre-compile per-dim resolvers (loop-invariant hoisting): branch

--- a/ktir_cpu/ops/memory_ops.py
+++ b/ktir_cpu/ops/memory_ops.py
@@ -304,6 +304,12 @@ class MemoryOps:
         to those local coordinates via a read-modify-write on the allocation.
         When *coords* is None, stores the full tile (contiguous or strided).
 
+        Source data layout: ``tile.data`` is read in C-order via
+        ``numpy.ndarray.flatten()``, which always returns a contiguous copy.
+        Non-contiguous source arrays are handled internally — callers do not
+        need to pre-``ascontiguousarray`` the tile. When *coords* is supplied,
+        ``coords[i]`` receives the i-th element of ``tile.data`` in C-order.
+
         A single ``mem.read`` + ``mem.write`` covers the entire footprint;
         no per-element dict scans occur.
 
@@ -731,12 +737,4 @@ class MemoryOps:
                     coord.append(raw_idx)
             coords.append(tuple(coord))
 
-        # Make the C-order contract with MemoryOps.store explicit; no-op when
-        # the source is already contiguous.
-        src_data = np.ascontiguousarray(tile.data)
-        if src_data is not tile.data:
-            src_tile = Tile(src_data, tile.dtype, tile.shape, tile.unique_sticks)
-        else:
-            src_tile = tile
-
-        MemoryOps.store(context, src_tile, iat.parent_ref.to_tile_ref(), coords=coords)
+        MemoryOps.store(context, tile, iat.parent_ref.to_tile_ref(), coords=coords)

--- a/ktir_cpu/ops/memory_ops.py
+++ b/ktir_cpu/ops/memory_ops.py
@@ -340,35 +340,55 @@ class MemoryOps:
         Enumerates the variable space, resolves each coordinate tuple
         (direct dims use the variable value, indirect dims look up the
         index in an index memref), then delegates to :meth:`load`.
+
+        Raises NotImplementedError if ``variables_space_order`` is non-identity
+        (rebinding intermediate variables under a permutation is unimplemented).
         """
         vss = iat.variables_space_set
         vso = iat.variables_space_order
 
-        # Enumerate all points in the variable space
-        points = vss.enumerate(iat.shape)
-        if vso is not None:
-            points = [vso.eval(pt) for pt in points]
+        # Reject permuted vso: applying it in-place would corrupt the variable
+        # bindings consumed below and would not reorder the enumeration anyway.
+        if vso is not None and not vso.is_identity():
+            raise NotImplementedError(
+                "indirect_load: non-identity variables_space_order is not yet "
+                "supported (rebinding intermediate variables under a permutation "
+                "is unimplemented)"
+            )
 
-        # For each point, resolve the actual coordinates in the parent memref
+        # Pre-compile per-dim resolvers so branch dispatch and constant lookups
+        # happen once instead of per enumerated point.
+        resolvers = []
+        for sub in iat.dim_subscripts:
+            kind = sub["kind"]
+            if kind == "direct":
+                resolvers.append(("direct", sub["var_index"]))
+            elif kind == "direct_expr":
+                resolvers.append(("direct_expr", sub["subscript"]))
+            elif kind == "indirect":
+                idx_view = iat.index_views[sub["index_view_idx"]]
+                bpe = _bytes_per_elem(idx_view.dtype)
+                resolvers.append(("indirect", sub["idx_exprs"], idx_view, bpe))
+            else:
+                raise ValueError(f"Unknown indirect subscript kind: {kind}")
+
+        points = vss.enumerate(iat.shape)
+
         coords = []
         for pt in points:
             coord = []
-            for sub in iat.dim_subscripts:
-                if sub["kind"] == "indirect":
-                    # Look up the index from the index memref
-                    idx_view = iat.index_views[sub["index_view_idx"]]
-                    # Compute address into the index tensor
-                    idx_coords = tuple(
-                        eval_subscript_expr(e, pt) for e in sub["idx_exprs"]
-                    )
+            for res in resolvers:
+                tag = res[0]
+                if tag == "direct":
+                    coord.append(pt[res[1]])
+                elif tag == "direct_expr":
+                    coord.append(eval_subscript_expr(res[1], pt))
+                else:  # indirect
+                    _, idx_exprs, idx_view, bpe = res
+                    idx_coords = tuple(eval_subscript_expr(e, pt) for e in idx_exprs)
                     offset = sum(c * s for c, s in zip(idx_coords, idx_view.strides))
-                    addr = idx_view.byte_address + offset * _bytes_per_elem(idx_view.dtype)
-                    raw = _MemAccessor(context, idx_view.memory_space, addr, idx_view.lx_core_id).read(1, idx_view.dtype)
-                    coord.append(int(raw[0]))
-                elif sub["kind"] == "direct":
-                    coord.append(pt[sub["var_index"]])
-                elif sub["kind"] == "direct_expr":
-                    coord.append(eval_subscript_expr(sub["subscript"], pt))
+                    addr = idx_view.byte_address + offset * bpe
+                    coord.append(int(_MemAccessor(context, idx_view.memory_space, addr, idx_view.lx_core_id).read(1, idx_view.dtype)[0]))
             coords.append(tuple(coord))
 
         out_shape = result_shape if result_shape is not None else iat.shape
@@ -631,3 +651,92 @@ class MemoryOps:
             for ac, off in zip(access_coords, offsets):
                 flat[off] = tile.data[ac]
             mgr.write(flat)
+
+    @staticmethod
+    def indirect_store(
+        context: CoreContext,
+        tile: Tile,
+        iat: "IndirectAccessTile",
+    ) -> None:
+        """Store data using an indirect access tile (scatter pattern).
+
+        Mirror of :meth:`indirect_load`. Enumerates the variable space,
+        resolves each coordinate tuple (direct dims use the variable value,
+        indirect dims look up the index in an index memref), then delegates
+        to :meth:`store`.
+
+        Coordinate collisions (multiple source elements mapping to the same
+        destination coordinate) are *implementation-defined*; the current
+        behavior is last-writer-wins via NumPy fancy-index assignment.
+        """
+        # MLIR type system should already enforce shape match; raise here so a
+        # mismatch surfaces clearly instead of as an opaque NumPy shape error.
+        if tuple(tile.shape) != tuple(iat.shape):
+            raise ValueError(
+                f"indirect_store: source tile shape {tuple(tile.shape)} does not "
+                f"match IAT shape {tuple(iat.shape)}"
+            )
+
+        vss = iat.variables_space_set
+        vso = iat.variables_space_order
+
+        # See indirect_load for the rationale on rejecting permuted vso.
+        if vso is not None and not vso.is_identity():
+            raise NotImplementedError(
+                "indirect_store: non-identity variables_space_order is not yet "
+                "supported (rebinding intermediate variables under a permutation "
+                "is unimplemented)"
+            )
+
+        # Pre-compile per-dim resolvers (loop-invariant hoisting): branch
+        # dispatch and constant lookups happen once, not per enumerated point.
+        resolvers = []
+        for sub in iat.dim_subscripts:
+            kind = sub["kind"]
+            if kind == "direct":
+                resolvers.append(("direct", sub["var_index"]))
+            elif kind == "direct_expr":
+                resolvers.append(("direct_expr", sub["subscript"]))
+            elif kind == "indirect":
+                idx_view = iat.index_views[sub["index_view_idx"]]
+                bpe = _bytes_per_elem(idx_view.dtype)
+                resolvers.append(("indirect", sub["idx_exprs"], idx_view, bpe))
+            else:
+                raise ValueError(f"Unknown indirect subscript kind: {kind}")
+
+        points = vss.enumerate(iat.shape)
+
+        coords = []
+        for pt in points:
+            coord = []
+            for res in resolvers:
+                tag = res[0]
+                if tag == "direct":
+                    coord.append(pt[res[1]])
+                elif tag == "direct_expr":
+                    coord.append(eval_subscript_expr(res[1], pt))
+                else:  # indirect
+                    _, idx_exprs, idx_view, bpe = res
+                    idx_coords = tuple(eval_subscript_expr(e, pt) for e in idx_exprs)
+                    offset = sum(c * s for c, s in zip(idx_coords, idx_view.strides))
+                    addr = idx_view.byte_address + offset * bpe
+                    raw_idx = int(_MemAccessor(context, idx_view.memory_space, addr, idx_view.lx_core_id).read(1, idx_view.dtype)[0])
+                    # NumPy fancy-index assignment silently wraps negative
+                    # indices; reject them here. Use raise so the check
+                    # survives python -O.
+                    if raw_idx < 0:
+                        raise IndexError(
+                            f"indirect index {raw_idx} from {idx_view} is negative"
+                        )
+                    coord.append(raw_idx)
+            coords.append(tuple(coord))
+
+        # Make the C-order contract with MemoryOps.store explicit; no-op when
+        # the source is already contiguous.
+        src_data = np.ascontiguousarray(tile.data)
+        if src_data is not tile.data:
+            src_tile = Tile(src_data, tile.dtype, tile.shape, tile.unique_sticks)
+        else:
+            src_tile = tile
+
+        MemoryOps.store(context, src_tile, iat.parent_ref.to_tile_ref(), coords=coords)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -216,11 +216,28 @@ EXAMPLE_PARAMS: dict[str, list[dict]] = {
             "execute_kwargs": {},
         },
     ],
+    "indirect_scatter": [
+        {
+            "path": "rfc/indirect-scatter.mlir",
+            # Scatter dual of indirect-access-copy: Y[IDX1[m,k], IDX2[m,k]] = X[m,k].
+            # Requires ktdp.store with IndirectAccessTile.
+            "execute_kwargs": {},
+        },
+    ],
     "paged_tensor_copy_1core": [
         {
             "path": "rfc/paged-tensor-copy.mlir",
             # RFC §C.5 Example 2: paged-attention 4-D indirect gather
             # Requires ktdp.construct_indirect_access_tile.
+            "execute_kwargs": {},
+        },
+    ],
+    "paged_tensor_write_1core": [
+        {
+            "path": "rfc/paged-tensor-write.mlir",
+            # Scatter dual of paged-tensor-copy:
+            # Y[Idx[b, tkv/Ptkv], h, tkv%Ptkv, dkv] = X[b, tkv, h, dkv].
+            # Same LX-overflow constraint as paged-tensor-copy.
             "execute_kwargs": {},
         },
     ],

--- a/tests/test_indirect_access.py
+++ b/tests/test_indirect_access.py
@@ -270,3 +270,172 @@ def test_ssa_intermediate_var_zero_range_ok():
 
     # Should complete without error (result correctness is not the focus here)
     interp.execute_function("ok_indirect")
+
+
+# ---------------------------------------------------------------------------
+# ktdp.store with IndirectAccessTile (scatter)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("path,func_name,entry", get_test_params("indirect_scatter"))
+def test_indirect_scatter_rfc(path, func_name, entry):
+    """ktdp.store with IndirectAccessTile (2-D scatter) — RFC-sized fixture.
+
+    Smoke test only: all inputs are zero-seeded, so this verifies the kernel
+    parses and executes end-to-end at production size, not data correctness.
+    Correctness is covered by `test_small_indirect_scatter` (bijection) and
+    `test_small_indirect_scatter_collision` on a 4x4 fixture.
+    """
+    interp = KTIRInterpreter()
+    interp.load(path)
+    _orig = interp._prepare_execution
+    def _prepare_and_seed(grid_shape):
+        _orig(grid_shape)
+        hbm = interp.memory.hbm
+        hbm.write(0, np.zeros(64 * 64, dtype=np.float16))    # X (stick 0)
+        hbm.write(64, np.zeros(64 * 64, dtype=np.int32))     # IDX1 (stick 64)
+        hbm.write(128, np.zeros(64 * 64, dtype=np.int32))    # IDX2 (stick 128)
+        hbm.write(192, np.zeros(64 * 64, dtype=np.float16))  # Y (stick 192)
+    interp._prepare_execution = _prepare_and_seed
+    interp.execute_function(func_name)
+
+
+# ---------------------------------------------------------------------------
+# Small 4x4 indirect scatter with data verification (bijection)
+# ---------------------------------------------------------------------------
+# X    = 4x4 matrix at stick 0, values X[i,j] = i*4+j  (0..15)
+# IDX1 = 4x4 matrix at stick 1, IDX1[m,k] = 3-m  (rows: [3,3,3,3],[2,2,2,2],...)
+# IDX2 = 4x4 matrix at stick 2, IDX2[m,k] = 3-k  (each row [3,2,1,0])
+# Y    = 4x4 matrix at stick 3
+#
+# Kernel: Y[IDX1[m,k], IDX2[m,k]] = X[m,k]  (scatter)
+# Mapping (m,k) → (3-m, 3-k) is a bijection, so every source element lands at
+# a distinct destination — the result is X rotated 180°: Y[3-m, 3-k] = X[m, k].
+#   Y[3,3] = X[0,0] = 0      Y[3,0] = X[0,3] = 3
+#   Y[2,3] = X[1,0] = 4      Y[0,0] = X[3,3] = 15
+#   etc.
+
+SMALL_INDIRECT_SCATTER_MLIR = """
+#coord_set_4x4 = affine_set<(d0, d1) : (d0 >= 0, -d0 + 3 >= 0, d1 >= 0, -d1 + 3 >= 0)>
+#var_space_set  = affine_set<(d0, d1) : (d0 >= 0, -d0 + 3 >= 0, d1 >= 0, -d1 + 3 >= 0)>
+#var_space_order = affine_map<(d0, d1) -> (d0, d1)>
+
+module {
+  func.func @small_indirect_scatter() attributes {grid = [1, 1]} {
+    %X_addr    = arith.constant 0 : index
+    %IDX1_addr = arith.constant 1 : index
+    %IDX2_addr = arith.constant 2 : index
+    %Y_addr    = arith.constant 3 : index
+
+    %X_view = ktdp.construct_memory_view %X_addr, sizes: [4, 4], strides: [4, 1] {
+        coordinate_set = #coord_set_4x4,
+        memory_space = #ktdp.spyre_memory_space<HBM>
+    } : memref<4x4xf16>
+
+    %IDX1 = ktdp.construct_memory_view %IDX1_addr, sizes: [4, 4], strides: [4, 1] {
+        coordinate_set = #coord_set_4x4,
+        memory_space = #ktdp.spyre_memory_space<HBM>
+    } : memref<4x4xi32>
+
+    %IDX2 = ktdp.construct_memory_view %IDX2_addr, sizes: [4, 4], strides: [4, 1] {
+        coordinate_set = #coord_set_4x4,
+        memory_space = #ktdp.spyre_memory_space<HBM>
+    } : memref<4x4xi32>
+
+    %Y_view = ktdp.construct_memory_view %Y_addr, sizes: [4, 4], strides: [4, 1] {
+        coordinate_set = #coord_set_4x4,
+        memory_space = #ktdp.spyre_memory_space<HBM>
+    } : memref<4x4xf16>
+
+    %c0 = arith.constant 0 : index
+    %X_access_tile = ktdp.construct_access_tile %X_view[%c0, %c0] {
+        access_tile_set   = #coord_set_4x4,
+        access_tile_order = #var_space_order
+    } : memref<4x4xf16> -> !ktdp.access_tile<4x4xindex>
+
+    %Y_access_tile = ktdp.construct_indirect_access_tile
+        intermediate_variables(%m, %k)
+        %Y_view[ind(%IDX1[%m, %k]), ind(%IDX2[%m, %k])] {
+            variables_space_set = #var_space_set,
+            variables_space_order = #var_space_order
+        } : memref<4x4xf16>, memref<4x4xi32>, memref<4x4xi32> -> !ktdp.access_tile<4x4xindex>
+
+    %X_data_tile = ktdp.load %X_access_tile : !ktdp.access_tile<4x4xindex> -> tensor<4x4xf16>
+    ktdp.store %X_data_tile, %Y_access_tile : tensor<4x4xf16>, !ktdp.access_tile<4x4xindex>
+
+    return
+  }
+}
+"""
+
+
+def test_small_indirect_scatter():
+    """Verify scatter Y[IDX1[m,k], IDX2[m,k]] = X[m,k] produces correct data
+    when (IDX1, IDX2) form a bijection (no coordinate collisions)."""
+    interp = KTIRInterpreter()
+    interp.load(SMALL_INDIRECT_SCATTER_MLIR)
+
+    _orig = interp._prepare_execution
+    def _prepare_and_seed(grid_shape):
+        _orig(grid_shape)
+        hbm = interp.memory.hbm
+        # X: 4x4, values 0..15 as f16
+        hbm.write(0, np.arange(16, dtype=np.float16))
+        # IDX1[m,k] = 3-m: rows are [3,3,3,3], [2,2,2,2], [1,1,1,1], [0,0,0,0]
+        idx1 = np.repeat(np.array([3, 2, 1, 0], dtype=np.int32), 4)
+        hbm.write(1, idx1)
+        # IDX2[m,k] = 3-k: each row is [3,2,1,0]
+        idx2 = np.tile(np.array([3, 2, 1, 0], dtype=np.int32), 4)
+        hbm.write(2, idx2)
+        # Y: 4x4, zeros
+        hbm.write(3, np.zeros(16, dtype=np.float16))
+    interp._prepare_execution = _prepare_and_seed
+
+    interp.execute_function("small_indirect_scatter")
+
+    y_data = interp.memory.hbm.read(3, 16, "f16").reshape(4, 4)
+
+    # Y[3-m, 3-k] = X[m, k] = m*4+k → Y[r, c] = (3-r)*4 + (3-c)
+    expected = np.array(
+        [[(3 - r) * 4 + (3 - c) for c in range(4)] for r in range(4)],
+        dtype=np.float16,
+    )
+    np.testing.assert_array_equal(y_data, expected)
+
+
+def test_small_indirect_scatter_collision():
+    """All source elements map to Y[0,0] (IDX1 and IDX2 are all zeros).
+
+    Locks the current implementation behavior: last source element written
+    in row-major (vss.enumerate) order wins. This is *implementation-defined*
+    behavior inherited from NumPy fancy-index assignment — it is **not** a
+    spec guarantee. Future RFC changes (e.g. add/max reduction) may invalidate
+    this test, in which case the assertion should be revised, not removed.
+    """
+    interp = KTIRInterpreter()
+    interp.load(SMALL_INDIRECT_SCATTER_MLIR)
+
+    _orig = interp._prepare_execution
+    def _prepare_and_seed(grid_shape):
+        _orig(grid_shape)
+        hbm = interp.memory.hbm
+        # X: 4x4, values 0..15 as f16
+        hbm.write(0, np.arange(16, dtype=np.float16))
+        # IDX1, IDX2 all zeros → every (m,k) writes to Y[0,0]
+        hbm.write(1, np.zeros(16, dtype=np.int32))
+        hbm.write(2, np.zeros(16, dtype=np.int32))
+        # Y: 4x4 sentinel value (-1) so we can verify untouched cells stay put
+        hbm.write(3, np.full(16, -1, dtype=np.float16))
+    interp._prepare_execution = _prepare_and_seed
+
+    interp.execute_function("small_indirect_scatter")
+
+    y_data = interp.memory.hbm.read(3, 16, "f16").reshape(4, 4)
+
+    # Last writer in vss.enumerate order is (m=3, k=3), value X[3,3] = 15.
+    assert y_data[0, 0] == 15.0
+    # All other cells should remain at the sentinel value (untouched).
+    for r in range(4):
+        for c in range(4):
+            if (r, c) == (0, 0):
+                continue
+            assert y_data[r, c] == -1.0, f"Y[{r},{c}] = {y_data[r, c]}, expected -1"

--- a/tests/test_indirect_access.py
+++ b/tests/test_indirect_access.py
@@ -439,3 +439,36 @@ def test_small_indirect_scatter_collision():
             if (r, c) == (0, 0):
                 continue
             assert y_data[r, c] == -1.0, f"Y[{r},{c}] = {y_data[r, c]}, expected -1"
+
+
+# ---------------------------------------------------------------------------
+# Negative-index guard (covers both indirect_load and indirect_store)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "mlir,func_name",
+    [
+        (SMALL_INDIRECT_MLIR, "small_indirect_gather"),
+        (SMALL_INDIRECT_SCATTER_MLIR, "small_indirect_scatter"),
+    ],
+    ids=["indirect_load", "indirect_store"],
+)
+def test_negative_indirect_index_raises(mlir, func_name):
+    """A negative entry in the index tensor must raise IndexError, not silently wrap."""
+    interp = KTIRInterpreter()
+    interp.load(mlir)
+
+    _orig = interp._prepare_execution
+    def _prepare_and_seed(grid_shape):
+        _orig(grid_shape)
+        hbm = interp.memory.hbm
+        hbm.write(0, np.zeros(16, dtype=np.float16))
+        idx1 = np.zeros(16, dtype=np.int32)
+        idx1[0] = -1
+        hbm.write(1, idx1)
+        hbm.write(2, np.zeros(16, dtype=np.int32))
+        hbm.write(3, np.zeros(16, dtype=np.float16))
+    interp._prepare_execution = _prepare_and_seed
+
+    with pytest.raises(IndexError, match="is negative"):
+        interp.execute_function(func_name)

--- a/tests/test_spec_gaps.py
+++ b/tests/test_spec_gaps.py
@@ -108,6 +108,33 @@ def test_paged_tensor_indirect_access(path, func_name, entry):
 # (Phase 2: 4-D paged indirect access with linalg.generic complete)
 
 
+@pytest.mark.spec_gap
+@pytest.mark.xfail(strict=True, reason="ktdp.load of 4x8x2048x128 f16 tile (16 MB) exceeds 2 MB LX scratchpad")
+@pytest.mark.parametrize("path,func_name,entry", get_test_params("paged_tensor_write_1core"))
+def test_paged_tensor_indirect_scatter(path, func_name, entry):
+    """paged-tensor-write.mlir is the scatter dual of paged-tensor-copy.mlir.
+    Same production-sized tensors and the same single ktdp.load of the full
+    4x8x2048x128 source tile (16 MB) overflows the 2 MB LX scratchpad. Once
+    that capacity gap is addressed, the scatter path (MemoryOps.indirect_store)
+    will execute end-to-end on this fixture.
+    """
+    interp = KTIRInterpreter()
+    interp.load(path)
+    _orig = interp._prepare_execution
+    def _prepare_and_seed(grid_shape):
+        _orig(grid_shape)
+        hbm = interp.memory.hbm
+        # X tensor at 10000000: contiguous source, 4*2048*8*128 = 8388608 f16 elements
+        # (16.78 MB, ends at 26777216). We don't expect the load to succeed (LX
+        # overflow), but back X with zeros so any pre-load read paths see valid memory.
+        hbm.write(10000000, np.zeros(4 * 2048 * 8 * 128, dtype=np.float16))
+        # Idx tensor at 30000000: shape 4x32 i32 (512 B), placed past the end of X
+        # to avoid byte overlap. All zeros → every page ID = 0.
+        hbm.write(30000000, np.zeros(4 * 32, dtype=np.int32))
+    interp._prepare_execution = _prepare_and_seed
+    interp.execute_function(func_name)
+
+
 # ===========================================================================
 # ktdp.construct_distributed_memory_view
 # Implemented; positive coverage moved to tests/test_distributed_view.py.


### PR DESCRIPTION
## Summary

Closes #44.

`ktdp.store` previously raised `NotImplementedError` for `IndirectAccessTile`. This PR adds `MemoryOps.indirect_store`, mirroring `MemoryOps.indirect_load`, and wires it into `ktdp__store`.

## Changes

### Main: scatter support (Issue #44)

- `MemoryOps.indirect_store` — enumerates `variables_space_set`, resolves each per-dim subscript (`direct` / `direct_expr` / `indirect`), and delegates to `MemoryOps.store` with the resolved coordinate list.
- `ktdp__store` dispatches to `indirect_store` for `IndirectAccessTile`.
- Source-tile shape is validated against IAT shape on entry (raises `ValueError` instead of an opaque downstream NumPy error).
- Negative indirect indices raise `IndexError` (NumPy fancy-index assignment would otherwise silently wrap from the tail).
- New MLIR fixtures:
  - `examples/rfc/indirect-scatter.mlir` — 64×64 scatter dual of `indirect-access-copy.mlir`.
  - `examples/rfc/paged-tensor-write.mlir` — scatter dual of `paged-tensor-copy.mlir` (LX-overflow `xfail`, same constraint as gather).

### Additional fix: `indirect_load` `vso` path

While writing the scatter mirror I noticed `indirect_load`'s non-identity `variables_space_order` branch was broken: it does `points = [vso.eval(pt) for pt in points]`, which permutes the components of `pt` in place — this corrupts the downstream `pt[sub["var_index"]]` and `eval_subscript_expr(..., pt)` bindings, and does not reorder the enumeration either.

Grep of `examples/` and `tests/` confirms **no fixture exercises non-identity `variables_space_order` on an IAT** today. (The non-identity `affine_map` in `paged-tensor-copy.mlir` is on `access_tile_order` of a `construct_access_tile`, which is a different operand on a different op.) So this is dead-but-broken code, not a regression risk.

Two changes:
- Tightened to `raise NotImplementedError(...)` with a clear message, guarded by `not vso.is_identity()` as belt-and-suspenders against parser changes (parser currently nullifies identity `vso`, but the explicit check is free).
- Backported the per-dim resolver pre-compilation (loop-invariant hoisting) from `indirect_store` to keep the two paths structurally aligned.

Happy to split this into a separate PR if reviewers prefer.

### Tests

- `test_small_indirect_scatter` — 4×4 bijection scatter, verifies data correctness (X rotated 180°).
- `test_small_indirect_scatter_collision` — all source elements map to `Y[0,0]`; pins current last-writer-wins behavior with a docstring noting it is implementation-defined (see open question below).
- `test_indirect_scatter_rfc` — 64×64 smoke test (zero-seeded); verifies the RFC fixture parses and runs end-to-end. Correctness is covered by the 4×4 tests above.
- `test_paged_tensor_indirect_scatter` — `xfail(strict=True)` for the production-sized paged variant; same LX-overflow constraint as the gather counterpart.

## Open question: coordinate collision semantics

When two source points `(m, k)` map to the same destination `Y[r, c]`, this PR currently exhibits **last-writer-wins** behavior, inherited directly from NumPy fancy-index assignment. This is documented as *implementation-defined* in the `indirect_store` docstring and locked by `test_small_indirect_scatter_collision` (with an explicit comment that the test pins NumPy behavior, not a spec guarantee).

Worth flagging: NumPy itself documents the duplicate-index assignment case as **undefined** — the CPython implementation is stable last-writer-wins, but not contractual. The collision test therefore depends on a NumPy implementation detail; the docstring's *implementation-defined* hedge reflects that.

RFC 0682 does not specify collision semantics. I picked last-writer-wins for this PR because:

1. The intended use cases (permutation, reordering) are bijections — collisions don't occur in well-formed inputs.
2. Reduction variants (add / max / error-on-collision) are user-driven design choices; without a concrete need, picking one risks over-design.
3. Hardware support for atomic-reduction scatter on Spyre is unclear — I'd rather not commit interpreter semantics ahead of the hardware story.

**Which option do you prefer for this PR?**

- (a) raise on collision (strictest, catches bugs early)
- (b) commit to last-writer-wins as spec behavior (drop the *implementation-defined* hedge in the docstring)
- (c) add a `reduction=` kwarg now with `overwrite` as default (forward-compat, but more surface area)
- (d) stay with the current "implementation-defined, currently last-writer-wins" stance and revisit when a user need surfaces

**Update**: See #60 for the ongoing discussion; this PR implements (d) as a placeholder pending that decision.

## Suggested follow-ups (not in this PR)

While implementing this PR I noticed several issues — `MemoryOps` interface limitations and gather-side cleanups. None are caused by `indirect_store` (the architectural ones exist symmetrically in `indirect_load`); none are triggered by current MLIR fixtures (all rectangular, identity-vso). Flagging them here for reviewer judgment: **if you agree any of these are worth addressing, I'm happy to open follow-up issues to track them.** Otherwise feel free to tell me to drop any that aren't worth the bookkeeping.

I'd suggest two follow-up issues — one architectural, one tactical — since each group shares a coherent scope.

### Architectural (one umbrella issue; shared root: `MemoryOps`'s "per-point coords + dense rectangular shape" contract is a poor fit for non-trivial iteration patterns)

1. **Non-identity `variables_space_order` proper support.** Currently `raise NotImplementedError` in both `indirect_load` and `indirect_store`. Correct handling: keep `vss.enumerate` order unchanged and apply `vso.eval(pt)` on the **tile-side** index (post-gather permutation for load, dual for store) — `vso` is a tile-layout map, not a rebinding of variables. **Tracked in #58.**

2. **`MemoryOps.bulk_read` / vectorized index gather.** Both `indirect_load` and `indirect_store` instantiate a `_MemAccessor` and call `.read()` once per inner-loop iteration. For a 64×64 IAT with one indirect dim that's 4096 per-point reads; for production paged kernels it would be millions. A bulk read API that returns the full index ndarray once, with NumPy fancy indexing in the loop, is the right fix — must touch gather and scatter together. **Covered by #52.**

3. **Mask / non-rectangular `variables_space_set` contract.** If `vss.enumerate(shape)` returns fewer points than `shape.prod()` (e.g. a triangular constraint), `MemoryOps.store(coords=...)`'s `flat[offsets] = tile.data.flatten()` raises `ValueError: shape mismatch` — and even if it didn't, the positional alignment between the dense source tile and the masked coords is undefined. The same issue exists symmetrically in `MemoryOps.load` (`reshape(out_shape)` on the gathered values). All current MLIR uses rectangular sets so this never trips, but the contract needs a defined semantic. **Tracked in #56.**

### Gather-side cleanup (one paired issue)

4. **Symmetric negative-index check for `indirect_load` + Idx/Y address overlap in `paged-tensor-copy.mlir`.** Two independent gather-side bugs that pair naturally:
   - **Negative-index check on `indirect_load`**: mirror of the store-side check this PR adds. `indirect_load` reads `raw_idx` at `memory_ops.py:381` with no guard against negative values, so a negative index from the lookup would silently wrap from the tail (NumPy fancy-indexing semantics). One-line `raise IndexError` fix, same shape as the store-side guard at `memory_ops.py:459-462`. **Directly addressed in this PR (commit `dd84f61`).**
   - **Idx/Y address overlap in `paged-tensor-copy.mlir`**: latent test-fixture bug. `Y_start_address = 10000000`, `Idx_start_address = 20000000`, but Y's footprint (`128 × 8 × 4 × 2048` f16 elements ≈ 16 MB) extends past 20000000, so Y physically overlaps Idx. The current zero-seed masks it (zeros are benign in either tensor); a non-zero seed would let Y writes corrupt the gather indices. Fix is to relayout the fixture's address constants. **Tracked in #57.**

cc  @fabianlim @kiszk  @lchu6 @nwang-ibm