### PR TITLE
[Fix] Support 1-D grid attribute in parser (grid = [X])

### DIFF
--- a/ktir_cpu/parser.py
+++ b/ktir_cpu/parser.py
@@ -194,11 +194,15 @@ class KTIRParser(KTIRParserBase):
         Returns:
             (x, y, z) grid dimensions
         """
-        # Pattern: grid = [X, Y, Z] or grid = [X, Y]
-        grid_match = re.search(r'grid\s*=\s*\[(\d+),\s*(\d+)(?:,\s*(\d+))?\]', func_header)
+        # Pattern: grid = [X] or grid = [X, Y] or grid = [X, Y, Z].
+        # Missing dims default to 1.
+        grid_match = re.search(
+            r'grid\s*=\s*\[(\d+)(?:,\s*(\d+))?(?:,\s*(\d+))?\]',
+            func_header,
+        )
         if grid_match:
             x = int(grid_match.group(1))
-            y = int(grid_match.group(2))
+            y = int(grid_match.group(2)) if grid_match.group(2) else 1
             z = int(grid_match.group(3)) if grid_match.group(3) else 1
             return (x, y, z)
         return (1, 1, 1)  # Default: single-core when no grid attribute is present

--- a/tests/test_dialects_parse.py
+++ b/tests/test_dialects_parse.py
@@ -200,6 +200,18 @@ class TestModuleParser:
         assert func.grid == (1, 1, 1)
         assert len(func.operations) >= 2
 
+    def test_parser_1d_grid(self):
+        # grid = [X] — single element; Y and Z should default to 1
+        parser = KTIRParser()
+        module = parser.parse_module("""
+        module {
+          func.func @single() attributes { grid = [4] } {
+            return
+          }
+        }
+        """)
+        assert module.get_function("single").grid == (4, 1, 1)
+
     def test_parser_multiple_functions(self):
         # module with two functions each gets its own grid shape
         parser = KTIRParser()


### PR DESCRIPTION
## Summary

- Extends `_parse_grid_dimensions` in `ktir_cpu/parser.py` to accept a single-element `grid = [X]` form, treating missing Y and Z as 1
- Previously, `grid = [X]` silently fell through to the `(1, 1, 1)` default instead of returning `(X, 1, 1)`
- Adds `TestModuleParser::test_parser_1d_grid` to cover the regression

Fixes #41

## Test plan

- [ ] `uv run pytest tests/test_dialects_parse.py -v -k test_parser_1d_grid` passes
- [ ] Full test suite `uv run pytest tests/ -v` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)