### PR TITLE
[Refactor] Delete RingNetwork and dead RingBackend send/recv methods

### DIFF
--- a/ktir_cpu/interpreter.py
+++ b/ktir_cpu/interpreter.py
@@ -27,7 +27,7 @@ from .ir_types import Operation, IRModule, Tile
 from .parser import KTIRParser, KTIRParserBase
 from .memory import SpyreMemoryHierarchy
 from .grid import GridExecutor, CoreContext
-from .ops.comm_ops import DirectLXBackend, RingBackend, RingNetwork
+from .ops.comm_ops import DirectLXBackend, RingBackend
 from .latency import HardwareConfig, LatencyTracker, LatencyReport
 from .dialects import dispatch, ExecutionEnv
 
@@ -65,7 +65,6 @@ class KTIRInterpreter:
         self.module: Optional[IRModule] = None
         self.memory: Optional[SpyreMemoryHierarchy] = None
         self.grid_executor: Optional[GridExecutor] = None
-        self.ring_network: Optional[RingNetwork] = None
         self.ring_backend: Optional[RingBackend] = None
         self._env: Optional[ExecutionEnv] = None
         self._parser: Optional[KTIRParserBase] = parser
@@ -100,7 +99,6 @@ class KTIRInterpreter:
         # distributed memory views. Cross-core comm goes through the
         # scheduler protocol (CoreContext.send_to + RecvRequest), not
         # through a backend. See docs/cross_core_scheduling.md.
-        self.ring_network = RingNetwork(num_cores)
         self.ring_backend = DirectLXBackend(self.memory)
         self.grid_executor = GridExecutor(grid_shape, self.memory, ring_backend=self.ring_backend)
         self._env = ExecutionEnv(

--- a/ktir_cpu/ops/__init__.py
+++ b/ktir_cpu/ops/__init__.py
@@ -18,7 +18,7 @@ from .grid_ops import GridOps
 from .memory_ops import MemoryOps
 from .arith_ops import ArithOps
 from .math_ops import MathOps
-from .comm_ops import CommOps, RingNetwork
+from .comm_ops import CommOps
 from .control_ops import ControlOps
 
 __all__ = [
@@ -27,6 +27,5 @@ __all__ = [
     "ArithOps",
     "MathOps",
     "CommOps",
-    "RingNetwork",
     "ControlOps",
 ]

--- a/ktir_cpu/ops/comm_ops.py
+++ b/ktir_cpu/ops/comm_ops.py
@@ -19,62 +19,37 @@ Inter-core tile transfer and ring-based reduction primitives used by
 dialect handlers in ``ktir_cpu.dialects``.
 """
 
-from typing import Dict, Generator, List, Tuple, Callable, Optional
-import numpy as np
+from typing import Callable, Generator, List
 from ..ir_types import Tile
 from ..grid import CoreContext, RecvRequest
 from ..memory import LXScratchpad, SpyreMemoryHierarchy
 
 
 class RingBackend:
-    """Abstract backend for inter-core LX access and ring communication.
+    """Abstract backend for remote LX scratchpad access.
 
-    The backend is the single seam between memory operations that need
-    remote LX data and the communication model used to obtain it.
-
-    Two implementations are planned:
-
-    DirectLXBackend (this file, first pass):
-        Returns the target scratchpad directly from SpyreMemoryHierarchy.
-        No ring messages, no latency modelling.  Valid when LX partitions
-        are pre-seeded by the host before kernel execution (e.g. the RFC
-        distributed-view-copy test).
-
-    RingTransferBackend (future):
-        When a core requests remote LX data, it issues a send on
-        RingNetwork and suspends execution at that point (coroutine model).
-        The scheduler resumes the core once the sender has delivered the
-        message.  This models actual ring hop cost and enables correct
-        cyclic communication.
+    The single seam between memory ops that need a remote core's LX
+    data and the model used to obtain it. Cross-core comm is *not* on
+    this path — it goes through the scheduler protocol
+    (``CoreContext.send_to`` + ``RecvRequest``); see
+    ``docs/cross_core_scheduling.md``.
     """
 
     def get_lx(self, core_id: int) -> LXScratchpad:
         """Return the LXScratchpad for *core_id*."""
         raise NotImplementedError
 
-    def send(self, src_core: int, dst_core: int, tile: Tile) -> None:
-        """Send *tile* from *src_core* to *dst_core* via the ring."""
-        raise NotImplementedError
-
-    def recv(self, src_core: int, dst_core: int) -> Optional[Tile]:
-        """Receive a tile sent from *src_core* to *dst_core*."""
-        raise NotImplementedError
-
 
 class DirectLXBackend(RingBackend):
-    """First-pass backend: direct scratchpad access, no ring modelling.
+    """Direct scratchpad access — no ring messages, no latency model.
 
-    get_lx(N) returns memory.lx_scratchpads[N] directly — valid for the
+    Returns ``memory.lx_scratchpads[N]`` by index. Valid for the
     distributed-view use case where LX partitions are pre-seeded by the
     host and no cross-core data movement occurs at runtime.
-
-    send/recv delegate to the provided RingNetwork so that ktdp.transfer
-    and ktdp.reduce continue to work as before.
     """
 
-    def __init__(self, memory: SpyreMemoryHierarchy, ring: Optional["RingNetwork"] = None):
+    def __init__(self, memory: SpyreMemoryHierarchy):
         self._memory = memory
-        self._ring = ring
 
     def get_lx(self, core_id: int) -> LXScratchpad:
         """Return the LXScratchpad for *core_id* via direct lookup."""
@@ -84,91 +59,6 @@ class DirectLXBackend(RingBackend):
                 f"get_lx: core_id={core_id} is out of range [0, {num}) for this grid"
             )
         return self._memory.get_lx(core_id)
-
-    def send(self, src_core: int, dst_core: int, tile: Tile) -> None:
-        if self._ring is None:
-            raise NotImplementedError(
-                "DirectLXBackend was constructed without a RingNetwork — "
-                "ktdp.transfer/reduce require one"
-            )
-        self._ring.send(src_core, dst_core, tile)
-
-    def recv(self, src_core: int, dst_core: int) -> Optional[Tile]:
-        if self._ring is None:
-            raise NotImplementedError(
-                "DirectLXBackend was constructed without a RingNetwork — "
-                "ktdp.transfer/reduce require one"
-            )
-        return self._ring.recv_from(src_core, dst_core)
-
-
-class RingNetwork:
-    """Simulates inter-core ring network topology.
-
-    Spyre's 32 cores are connected via two rings:
-    - One clockwise ring (4 TB/s)
-    - One anti-clockwise ring (4 TB/s)
-
-    Both rings connect all 32 cores. We simulate a single logical ring
-    since directionality doesn't affect correctness in CPU simulation.
-    """
-
-    def __init__(self, num_cores: int):
-        self.num_cores = num_cores
-        self.message_buffers: Dict[Tuple[int, int], List[Tile]] = {}  # (src, dst) -> [tiles]
-        self.pending_messages = []
-
-    def send(self, src_core: int, dst_core: int, tile: Tile):
-        """Send tile from source core to destination core.
-
-        Messages are buffered until deliver_all() is called.
-
-        Args:
-            src_core: Source core ID
-            dst_core: Destination core ID
-            tile: Tile to send
-        """
-        key = (src_core, dst_core)
-        if key not in self.message_buffers:
-            self.message_buffers[key] = []
-        self.message_buffers[key].append(tile.copy())
-        self.pending_messages.append(key)
-
-    def recv_from(self, src_core: int, dst_core: int) -> Optional[Tile]:
-        """Receive tile from specific source.
-
-        Args:
-            src_core: Source core ID
-            dst_core: Destination core ID (receiver)
-
-        Returns:
-            Tile if available, None otherwise
-        """
-        key = (src_core, dst_core)
-        if key in self.message_buffers and self.message_buffers[key]:
-            return self.message_buffers[key].pop(0)
-        return None
-
-    def deliver_all(self):
-        """Deliver all pending messages.
-
-        In sequential simulation, this is a no-op since messages
-        are immediately available after send().
-        """
-        self.pending_messages.clear()
-
-    def has_pending_messages(self) -> bool:
-        """Check if there are pending messages."""
-        return any(len(msgs) > 0 for msgs in self.message_buffers.values())
-
-    def pending_message_count(self) -> int:
-        """Count pending messages."""
-        return sum(len(msgs) for msgs in self.message_buffers.values())
-
-    def clear(self):
-        """Clear all messages."""
-        self.message_buffers.clear()
-        self.pending_messages.clear()
 
 
 class CommOps:

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -16,7 +16,7 @@
 Tests for ktir_cpu/ops/ layer.
 
 Covers: ArithOps, MathOps, GridOps, ControlOps.
-comm_ops (RingNetwork.reduce) skipped — tied to the replay bug (see docs/gap_analysis.md section K).
+CommOps is exercised via the scheduler in tests/test_grid_scheduler.py.
 """
 
 import numpy as np
@@ -27,7 +27,6 @@ from ktir_cpu.ops.arith_ops import ArithOps
 from ktir_cpu.ops.math_ops import MathOps
 from ktir_cpu.ops.grid_ops import GridOps
 from ktir_cpu.ops.control_ops import ControlOps
-from ktir_cpu.ops.comm_ops import RingNetwork
 from ktir_cpu.grid import CoreContext, GridExecutor
 from ktir_cpu.memory import HBMSimulator, LXScratchpad, SpyreMemoryHierarchy
 
@@ -387,21 +386,3 @@ class TestControlOps:
         ControlOps.while_op(ctx, "before", "after", executor)
         assert count[0] == 3
 
-# ---------------------------------------------------------------------------
-# RingNetwork
-# ---------------------------------------------------------------------------
-
-class TestRingNetwork:
-    def test_send_recv(self):
-        # message sent from core 0 to core 1 is received intact
-        ring = RingNetwork(num_cores=4)
-        tile = _tile([1, 2])
-        ring.send(src_core=0, dst_core=1, tile=tile)
-        received = ring.recv_from(src_core=0, dst_core=1)
-        assert received is not None
-        assert np.array_equal(received.data, tile.data)
-
-    def test_recv_empty(self):
-        # receiving from an empty channel returns None
-        ring = RingNetwork(num_cores=4)
-        assert ring.recv_from(src_core=0, dst_core=1) is None


### PR DESCRIPTION
## Summary

- Delete `RingNetwork`, `RingBackend.send/.recv`, and `DirectLXBackend.send/.recv` — none of them are on the live scheduler path. Cross-core comm goes through `CoreContext.send_to` + `RecvRequest`, owned by `GridExecutor`'s message queue.
- Slim `RingBackend` and `DirectLXBackend` to remote-LX-peek (`get_lx`) only, with refreshed docstrings.
- Drop the now-dead `RingNetwork` allocation from `interpreter._prepare_execution`, the `RingNetwork` export from `ktir_cpu.ops`, and `TestRingNetwork` from `tests/test_ops.py`.
- Update `docs/cross_core_scheduling.md` to remove the "Marked for deletion" section and reflect the slimmer `RingBackend`.

> **Stacked on #59** — this branch is built on top of `grid-network`. Will rebase onto `main` once #59 merges. Review the diff against `grid-network` for just the deletion changes.

## Test plan

- [x] `uv run pytest tests/` — 813 passed, 7 skipped, 6 xfailed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)