### PR TITLE
[Fix] idx tensor stick accounting in indirect_load / indirect_store

### DIFF
--- a/ktir_cpu/dialects/ktdp_ops.py
+++ b/ktir_cpu/dialects/ktdp_ops.py
@@ -159,15 +159,20 @@ def ktdp__load(op, context, env):
 
 @register("ktdp.store", latency_category=LC.MEMORY)
 def ktdp__store(op, context, env):
+    """Stores have no IR result, but the handler returns the HBM
+    ``unique_sticks`` (``int``, ``0`` for LX) from ``MemoryOps.store`` /
+    ``indirect_store`` / ``distributed_store`` as a latency sideband.
+    :meth:`LatencyTracker._data_size` reads it via ``isinstance(result,
+    int)`` and charges HBM traffic at stick granularity, matching the
+    load-side carrier on ``Tile.unique_sticks``.
+    """
     value = context.get_value(op.operands[0])
     assert isinstance(value, Tile), f"ktdp.store expects a Tile, got {type(value)}"
     access_tile = context.get_value(op.operands[1])
     if isinstance(access_tile, IndirectAccessTile):
-        MemoryOps.indirect_store(context, value, access_tile)
-        return None
+        return MemoryOps.indirect_store(context, value, access_tile)
     if isinstance(access_tile.parent_ref, DistributedTileRef):
-        MemoryOps.distributed_store(context, value, access_tile.parent_ref)
-        return None
+        return MemoryOps.distributed_store(context, value, access_tile.parent_ref)
     tile_ref = access_tile.parent_ref
     css = access_tile.coordinate_set
     cso = access_tile.coordinate_order
@@ -175,10 +180,8 @@ def ktdp__store(op, context, env):
         coords = css.enumerate(access_tile.shape)
         if cso is not None:
             coords = [cso.eval(pt) for pt in coords]
-        MemoryOps.store(context, value, tile_ref, coords=coords)
-    else:
-        MemoryOps.store(context, value, tile_ref)
-    return None
+        return MemoryOps.store(context, value, tile_ref, coords=coords)
+    return MemoryOps.store(context, value, tile_ref)
 
 
 # ---------------------------------------------------------------------------

--- a/ktir_cpu/ir_types.py
+++ b/ktir_cpu/ir_types.py
@@ -242,6 +242,11 @@ class Tile:
     # tile.  Set by ``MemoryOps.load`` for all access patterns.  None only
     # for tiles produced by compute ops (not loaded from memory).
     unique_sticks: Optional[int] = None
+    # Number of distinct HBM sticks touched by index-tensor reads during
+    # an indirect load/store.  Tracked separately from ``unique_sticks``
+    # so that ``coalescing_efficiency`` retains its data-layout meaning.
+    # None for direct loads (no index tensors) and compute-produced tiles.
+    index_unique_sticks: Optional[int] = None
 
     def copy(self) -> 'Tile':
         """Create a deep copy of this tile.
@@ -252,7 +257,10 @@ class Tile:
         target device's base_ptr — currently we propagate the source
         value since the memory layout is abstracted away from Tile.
         """
-        return Tile(self.data.copy(), self.dtype, self.shape, self.unique_sticks)
+        return Tile(
+            self.data.copy(), self.dtype, self.shape,
+            self.unique_sticks, self.index_unique_sticks,
+        )
 
     def size_bytes(self) -> int:
         """Return size in bytes."""

--- a/ktir_cpu/latency.py
+++ b/ktir_cpu/latency.py
@@ -32,6 +32,7 @@ import numpy as np
 from .ir_types import AccessTile, IndirectAccessTile, MemRef, Tile, TileRef
 from .dtypes import bytes_per_elem
 from .memory import HBMSimulator
+from .ops.memory_ops import _idx_unique_sticks_no_reads
 
 
 from .dialects.registry import get_latency_category
@@ -298,11 +299,27 @@ class LatencyTracker:
                 total += result.unique_sticks * HBMSimulator.STICK_BYTES
             else:
                 total += result.data.nbytes
+            if result.index_unique_sticks is not None:
+                total += result.index_unique_sticks * HBMSimulator.STICK_BYTES
         for v in operands:
             if isinstance(v, IndirectAccessTile):
-                for iv in v.index_views:
-                    if iv.memory_space == "HBM":
-                        total += int(np.prod(iv.shape)) * bytes_per_elem(iv.dtype)
+                # Load case (result is a Tile): idx sticks already charged
+                # via result.index_unique_sticks above. The IAT-load
+                # contract requires the handler to set the field to an
+                # integer (0 for an all-LX IAT, positive for HBM); a
+                # surviving None means the handler skipped
+                # ``_resolve_idx_reads``, which would silently undercount.
+                if isinstance(result, Tile):
+                    if result.index_unique_sticks is None:
+                        raise RuntimeError(
+                            "IAT operand with Tile result must populate "
+                            "index_unique_sticks; got None. This indicates "
+                            "the op handler skipped _resolve_idx_reads."
+                        )
+                    continue
+                # Store case: no result Tile carries the count, so
+                # recompute from the IAT. Always int (0 for all-LX).
+                total += _idx_unique_sticks_no_reads(v) * HBMSimulator.STICK_BYTES
             elif isinstance(v, Tile):
                 if result is not None:
                     raise ValueError(

--- a/ktir_cpu/latency.py
+++ b/ktir_cpu/latency.py
@@ -308,20 +308,17 @@ class LatencyTracker:
 
         total = 0
         if isinstance(result, Tile):
-            if result.unique_sticks is not None:
-                total += result.unique_sticks * HBMSimulator.STICK_BYTES
-            else:
-                total += result.data.nbytes
+            if result.unique_sticks is None:
+                raise RuntimeError(
+                    "Tile result on HBM path must populate unique_sticks; "
+                    "got None. Load handlers must set unique_sticks for "
+                    "stick-granular HBM accounting."
+                )
+            total += result.unique_sticks * HBMSimulator.STICK_BYTES
             if result.index_unique_sticks is not None:
                 total += result.index_unique_sticks * HBMSimulator.STICK_BYTES
         for v in operands:
             if isinstance(v, IndirectAccessTile):
-                # Only the load path reaches here — store ops returned
-                # via the int sideband above. The IAT-load contract
-                # requires the handler to set ``index_unique_sticks`` to
-                # an integer (0 for an all-LX IAT, positive for HBM); a
-                # surviving None means the handler skipped
-                # ``_resolve_idx_reads``, which would silently undercount.
                 if not isinstance(result, Tile):
                     raise RuntimeError(
                         "IAT operand without Tile result and without int "
@@ -342,12 +339,6 @@ class LatencyTracker:
                         f"_data_size: Tile in operands but result is also "
                         f"{type(result).__name__}; no ktdp op should produce both"
                     )
-                # Tile-operand-without-result reaches here only if a memory
-                # op handler returned None instead of the int from its
-                # underlying MemoryOps call. Reject rather than fall back
-                # to v.data.nbytes — the source tile's logical size is not
-                # a valid proxy for HBM traffic on a stick-addressed bus
-                # (would undercount any non-stick-aligned scatter).
                 raise RuntimeError(
                     "Tile operand with None result: store handler must "
                     "propagate MemoryOps.store's int return as op result "

--- a/ktir_cpu/latency.py
+++ b/ktir_cpu/latency.py
@@ -32,7 +32,6 @@ import numpy as np
 from .ir_types import AccessTile, IndirectAccessTile, MemRef, Tile, TileRef
 from .dtypes import bytes_per_elem
 from .memory import HBMSimulator
-from .ops.memory_ops import _idx_unique_sticks_no_reads
 
 
 from .dialects.registry import get_latency_category
@@ -287,12 +286,26 @@ class LatencyTracker:
     def _data_size(result: Any, operands: List[Any]) -> int:
         """Estimate bytes transferred by a memory operation.
 
-        Counts result bytes (loads), operand Tile bytes (stores), and
-        index tensor bytes (indirect access loads and scatter stores).
-
         HBM traffic is always charged at stick granularity:
         ``unique_sticks * HBMSimulator.STICK_BYTES``.
+
+        Two carriers convey ``unique_sticks`` from the op handler:
+
+        * **Loads** stamp ``unique_sticks`` (data) and
+          ``index_unique_sticks`` (idx, when an IAT is involved) on the
+          result :class:`Tile`. ``_data_size`` reads them off the result.
+        * **Stores** have no result Tile — the dialect handler instead
+          returns the int from ``MemoryOps.store`` /
+          ``indirect_store`` / ``distributed_store`` as the op result.
+          ``_data_size`` consumes it via ``isinstance(result, int)``.
+          For an indirect store, the int already aggregates both the
+          parent destination's sticks and the idx-side sticks.
         """
+        # Store sideband: the handler propagated MemoryOps.{store,
+        # indirect_store, distributed_store}'s int return as op result.
+        if isinstance(result, int):
+            return result * HBMSimulator.STICK_BYTES
+
         total = 0
         if isinstance(result, Tile):
             if result.unique_sticks is not None:
@@ -303,30 +316,43 @@ class LatencyTracker:
                 total += result.index_unique_sticks * HBMSimulator.STICK_BYTES
         for v in operands:
             if isinstance(v, IndirectAccessTile):
-                # Load case (result is a Tile): idx sticks already charged
-                # via result.index_unique_sticks above. The IAT-load
-                # contract requires the handler to set the field to an
-                # integer (0 for an all-LX IAT, positive for HBM); a
+                # Only the load path reaches here — store ops returned
+                # via the int sideband above. The IAT-load contract
+                # requires the handler to set ``index_unique_sticks`` to
+                # an integer (0 for an all-LX IAT, positive for HBM); a
                 # surviving None means the handler skipped
                 # ``_resolve_idx_reads``, which would silently undercount.
-                if isinstance(result, Tile):
-                    if result.index_unique_sticks is None:
-                        raise RuntimeError(
-                            "IAT operand with Tile result must populate "
-                            "index_unique_sticks; got None. This indicates "
-                            "the op handler skipped _resolve_idx_reads."
-                        )
-                    continue
-                # Store case: no result Tile carries the count, so
-                # recompute from the IAT. Always int (0 for all-LX).
-                total += _idx_unique_sticks_no_reads(v) * HBMSimulator.STICK_BYTES
+                if not isinstance(result, Tile):
+                    raise RuntimeError(
+                        "IAT operand without Tile result and without int "
+                        f"sideband; got result={type(result).__name__}. "
+                        "Store handlers must return MemoryOps.indirect_store's "
+                        "int as the op result for stick-granular accounting."
+                    )
+                if result.index_unique_sticks is None:
+                    raise RuntimeError(
+                        "IAT operand with Tile result must populate "
+                        "index_unique_sticks; got None. This indicates "
+                        "the op handler skipped _resolve_idx_reads."
+                    )
+                continue
             elif isinstance(v, Tile):
                 if result is not None:
                     raise ValueError(
-                        f"_data_size: Tile in operands but result is also a Tile ({type(result)}); "
-                        "no ktdp op should produce both"
+                        f"_data_size: Tile in operands but result is also "
+                        f"{type(result).__name__}; no ktdp op should produce both"
                     )
-                total += v.data.nbytes
+                # Tile-operand-without-result reaches here only if a memory
+                # op handler returned None instead of the int from its
+                # underlying MemoryOps call. Reject rather than fall back
+                # to v.data.nbytes — the source tile's logical size is not
+                # a valid proxy for HBM traffic on a stick-addressed bus
+                # (would undercount any non-stick-aligned scatter).
+                raise RuntimeError(
+                    "Tile operand with None result: store handler must "
+                    "propagate MemoryOps.store's int return as op result "
+                    "for stick-granular HBM accounting."
+                )
         return total
 
     @staticmethod

--- a/ktir_cpu/ops/memory_ops.py
+++ b/ktir_cpu/ops/memory_ops.py
@@ -19,7 +19,7 @@ Tile view construction, sub-tile access, and HBM/LX load/store
 primitives used by dialect handlers in ``ktir_cpu.dialects``.
 """
 
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 import numpy as np
 from ..affine import AffineMap, AffineSet, BoxSet
 from ..dialects.ktdp_helpers import eval_subscript_expr
@@ -57,6 +57,7 @@ class _MemAccessor:
         byte_addr: int,
         lx_core_id: Optional[int] = None,
     ):
+        self._memory_space = memory_space
         if memory_space == "HBM":
             self.stick_bytes: Optional[int] = HBMSimulator.STICK_BYTES
             self._sim = context.hbm
@@ -72,11 +73,227 @@ class _MemAccessor:
             self._args = (byte_addr,)
             self._kwargs = {}
 
+    @classmethod
+    def count_sticks(
+        cls, memory_space: str, byte_addresses: Iterable[int],
+    ) -> Optional[int]:
+        """Distinct HBM sticks touched by ``byte_addresses``.
+
+        HBM returns ``len({addr // STICK_BYTES})``; LX returns ``None``
+        (the address space has no stick concept). An empty input on the
+        HBM path returns ``0`` — a defined "no stick traffic" answer,
+        kept distinct from ``None`` which is reserved for "not computed".
+
+        Single source of truth for stick counting: callers route through
+        here so ``addr // STICK_BYTES`` arithmetic stays encapsulated.
+        """
+        if memory_space != "HBM":
+            return None
+        return len({a // HBMSimulator.STICK_BYTES for a in byte_addresses})
+
     def read(self, n: int, dtype: str) -> np.ndarray:
         return self._sim.read(*self._args, n, dtype, **self._kwargs)
 
+    def read_scattered(
+        self, byte_addresses: List[int], dtype: str,
+    ) -> Tuple[np.ndarray, Optional[int]]:
+        """Per-element scatter read; returns ``(values, unique_sticks)``.
+
+        Issues one ``self._sim.read(addr, 1, dtype)`` per unique address
+        (set-deduped), then assembles ``values`` in the caller's order.
+        ``unique_sticks`` comes from :meth:`count_sticks` over
+        ``byte_addresses`` (HBM: ``int``; LX: ``None``).
+
+        Reads are addressed by elements of ``byte_addresses`` directly;
+        the accessor's ``byte_addr`` (used by :meth:`read`) is unused on
+        this path. Full migration to a tuple-returning ``read()`` is a
+        follow-up.
+
+        Raises ``ValueError`` on empty ``byte_addresses`` — empty is
+        ambiguous in a read context (zero-traffic vs caller bug); use
+        :meth:`count_sticks` directly for the pure query.
+        """
+        if not byte_addresses:
+            raise ValueError("read_scattered called with empty address list")
+        unique_sticks = type(self).count_sticks(self._memory_space, byte_addresses)
+        np_dtype = _to_np_dtype(dtype)
+        cache: Dict[int, Any] = {}
+        for a in set(byte_addresses):
+            if self.stick_bytes is not None:
+                stick, intra = divmod(a, self.stick_bytes)
+                cache[a] = self._sim.read(stick, 1, dtype, intra_byte=intra)[0]
+            else:
+                cache[a] = self._sim.read(a, 1, dtype)[0]
+        values = np.fromiter(
+            (cache[a] for a in byte_addresses), dtype=np_dtype,
+            count=len(byte_addresses),
+        )
+        return values, unique_sticks
+
     def write(self, data: np.ndarray) -> None:
         self._sim.write(*self._args, data, **self._kwargs)
+
+
+def _resolve_idx_reads(
+    context: CoreContext, iat: "IndirectAccessTile",
+) -> Tuple[Dict[int, np.ndarray], int]:
+    """Read every idx-tensor value the IAT enumeration needs.
+
+    For each indirect dimension, enumerates its address in pt order, then
+    issues one ``_MemAccessor.read_scattered`` per index view (so all
+    reads to one view share a single accessor and a single dedup pass).
+
+    Returns ``(per_view_values, total_idx_unique_sticks)``:
+
+    * ``per_view_values[idx_view_idx]`` is an ``np.ndarray`` whose ``i``-th
+      entry is the idx value resolved for the ``i``-th enumerated point's
+      use of that view.  Indirect dims sharing the same view share the
+      array (consumed in pt-major, dim-minor order).
+    * ``total_idx_unique_sticks`` is the sum across HBM views; ``0`` when
+      every idx view lives in LX (LX has no stick concept). The return
+      type is always ``int``: callers receiving ``None`` would have to
+      special-case it, and the LX-only case is a defined "zero HBM
+      traffic" answer, so the function returns the integer directly.
+
+    Performance note: per-view loop-invariants (``bpe``, ``strides``,
+    ``byte_address``) are hoisted out of the pt loop. With the
+    per-element ``read_scattered``, paged-attention-scale IATs (millions
+    of points) would otherwise pay function-call + bpe-lookup overhead
+    on each enumerated point.
+
+    This is the canonical idx-side resolver: ``indirect_load`` and
+    ``indirect_store`` both call it so their stick accounting stays in
+    sync (guard symmetry).
+    """
+    points = iat.variables_space_set.enumerate(iat.shape)
+    indirect_subs = [s for s in iat.dim_subscripts if s.get("kind") == "indirect"]
+
+    # Hoist per-view loop-invariants once before enumerating points.
+    per_view_consts: Dict[int, Tuple[int, List[int], int]] = {}
+    per_view_addrs: Dict[int, List[int]] = {}
+    for sub in indirect_subs:
+        iv_idx = sub["index_view_idx"]
+        if iv_idx in per_view_consts:
+            continue
+        iv = iat.index_views[iv_idx]
+        per_view_consts[iv_idx] = (
+            _bytes_per_elem(iv.dtype), list(iv.strides), iv.byte_address,
+        )
+        per_view_addrs[iv_idx] = []
+
+    for pt in points:
+        for sub in indirect_subs:
+            iv_idx = sub["index_view_idx"]
+            bpe, strides, base = per_view_consts[iv_idx]
+            offset = sum(
+                eval_subscript_expr(e, pt) * s
+                for e, s in zip(sub["idx_exprs"], strides)
+            )
+            per_view_addrs[iv_idx].append(base + offset * bpe)
+
+    per_view_values: Dict[int, np.ndarray] = {}
+    total_sticks = 0
+    for iv_idx, addrs in per_view_addrs.items():
+        idx_view = iat.index_views[iv_idx]
+        accessor = _MemAccessor(
+            context, idx_view.memory_space, idx_view.byte_address,
+            idx_view.lx_core_id,
+        )
+        values, sticks = accessor.read_scattered(addrs, idx_view.dtype)
+        per_view_values[iv_idx] = values
+        if sticks is not None:
+            total_sticks += sticks
+
+    return per_view_values, total_sticks
+
+
+def _build_indirect_coords(
+    iat: "IndirectAccessTile", idx_values: Dict[int, np.ndarray],
+) -> List[Tuple[int, ...]]:
+    """Materialize the parent-tensor coordinate list for an IAT.
+
+    For each enumerated point of ``iat.variables_space_set``, walks
+    ``dim_subscripts`` to fill the coordinate tuple:
+
+    * ``direct`` dims read directly from the variable-space point.
+    * ``direct_expr`` dims evaluate a quasi-affine expression over the point.
+    * ``indirect`` dims consume the next pre-resolved value from
+      ``idx_values[iv_idx]`` (set up by :func:`_resolve_idx_reads` in the
+      same pt-major, dim-minor order).
+
+    Raises ``IndexError`` on a negative idx value — NumPy fancy-indexing
+    silently wraps negatives, so we reject them here.  The check survives
+    ``python -O`` (uses ``raise``, not ``assert``).
+
+    Shared by ``indirect_load`` and ``indirect_store`` so their coord
+    construction stays in lockstep (guard symmetry).
+    """
+    points = iat.variables_space_set.enumerate(iat.shape)
+    idx_iters = {iv_idx: iter(values) for iv_idx, values in idx_values.items()}
+
+    coords: List[Tuple[int, ...]] = []
+    for pt in points:
+        coord: List[int] = []
+        for sub in iat.dim_subscripts:
+            kind = sub["kind"]
+            if kind == "direct":
+                coord.append(pt[sub["var_index"]])
+            elif kind == "direct_expr":
+                coord.append(eval_subscript_expr(sub["subscript"], pt))
+            elif kind == "indirect":
+                iv_idx = sub["index_view_idx"]
+                raw_idx = int(next(idx_iters[iv_idx]))
+                if raw_idx < 0:
+                    raise IndexError(
+                        f"indirect index {raw_idx} from "
+                        f"{iat.index_views[iv_idx]} is negative"
+                    )
+                coord.append(raw_idx)
+            else:
+                raise ValueError(f"Unknown indirect subscript kind: {kind}")
+        coords.append(tuple(coord))
+    return coords
+
+
+def _idx_unique_sticks_no_reads(iat: "IndirectAccessTile") -> int:
+    """Total HBM sticks an IAT's idx-side reads would touch — without reading.
+
+    Mirrors the stick-counting half of :func:`_resolve_idx_reads` without
+    issuing any simulator reads. Used by latency evaluation paths that
+    lack a result Tile to read ``index_unique_sticks`` from (e.g.
+    ``ktdp.store`` with an indirect access tile).
+
+    Returns ``0`` when every idx view lives in LX (LX has no stick
+    concept). Stick counting itself is delegated to
+    :meth:`_MemAccessor.count_sticks` so this function holds zero
+    knowledge of ``STICK_BYTES``.
+
+    Per-view loop-invariants (``bpe``, ``strides``, ``byte_address``)
+    are hoisted out of the pt loop to mirror ``_resolve_idx_reads``'s
+    paged-attention-friendly iteration shape.
+    """
+    points = iat.variables_space_set.enumerate(iat.shape)
+    total = 0
+    for sub in iat.dim_subscripts:
+        if sub.get("kind") != "indirect":
+            continue
+        iv = iat.index_views[sub["index_view_idx"]]
+        bpe = _bytes_per_elem(iv.dtype)
+        strides = list(iv.strides)
+        base = iv.byte_address
+        idx_exprs = sub["idx_exprs"]
+        addrs = [
+            base + bpe * sum(
+                eval_subscript_expr(e, pt) * s
+                for e, s in zip(idx_exprs, strides)
+            )
+            for pt in points
+        ]
+        sticks = _MemAccessor.count_sticks(iv.memory_space, addrs)
+        if sticks is not None:
+            total += sticks
+    return total
+
 
 class MemoryOps:
     """Tile memory helpers — view, access, load, store."""
@@ -349,60 +566,25 @@ class MemoryOps:
 
         Raises NotImplementedError if ``variables_space_order`` is non-identity.
         """
-        vss = iat.variables_space_set
         vso = iat.variables_space_order
-
         if vso is not None and not vso.is_identity():
             raise NotImplementedError(
                 "indirect_load: output tile permutation via non-identity "
                 "variables_space_order is not yet implemented"
             )
 
-        # Pre-compile per-dim resolvers so branch dispatch and constant lookups
-        # happen once instead of per enumerated point.
-        resolvers = []
-        for sub in iat.dim_subscripts:
-            kind = sub["kind"]
-            if kind == "direct":
-                resolvers.append(("direct", sub["var_index"]))
-            elif kind == "direct_expr":
-                resolvers.append(("direct_expr", sub["subscript"]))
-            elif kind == "indirect":
-                idx_view = iat.index_views[sub["index_view_idx"]]
-                bpe = _bytes_per_elem(idx_view.dtype)
-                resolvers.append(("indirect", sub["idx_exprs"], idx_view, bpe))
-            else:
-                raise ValueError(f"Unknown indirect subscript kind: {kind}")
-
-        points = vss.enumerate(iat.shape)
-
-        coords = []
-        for pt in points:
-            coord = []
-            for res in resolvers:
-                tag = res[0]
-                if tag == "direct":
-                    coord.append(pt[res[1]])
-                elif tag == "direct_expr":
-                    coord.append(eval_subscript_expr(res[1], pt))
-                else:  # indirect
-                    _, idx_exprs, idx_view, bpe = res
-                    idx_coords = tuple(eval_subscript_expr(e, pt) for e in idx_exprs)
-                    offset = sum(c * s for c, s in zip(idx_coords, idx_view.strides))
-                    addr = idx_view.byte_address + offset * bpe
-                    raw_idx = int(_MemAccessor(context, idx_view.memory_space, addr, idx_view.lx_core_id).read(1, idx_view.dtype)[0])
-                    # NumPy fancy-index reads silently wrap negative
-                    # indices; reject them here. Use raise so the check
-                    # survives python -O.
-                    if raw_idx < 0:
-                        raise IndexError(
-                            f"indirect index {raw_idx} from {idx_view} is negative"
-                        )
-                    coord.append(raw_idx)
-            coords.append(tuple(coord))
+        # Resolve every idx-tensor read up front: one accessor per index
+        # view, one read_scattered call, sticks deduped inside the accessor.
+        idx_values, idx_unique_sticks = _resolve_idx_reads(context, iat)
+        coords = _build_indirect_coords(iat, idx_values)
 
         out_shape = result_shape if result_shape is not None else iat.shape
-        return MemoryOps.load(context, iat.parent_ref.to_tile_ref(), coords=coords, result_shape=out_shape)
+        result = MemoryOps.load(
+            context, iat.parent_ref.to_tile_ref(),
+            coords=coords, result_shape=out_shape,
+        )
+        result.index_unique_sticks = idx_unique_sticks
+        return result
 
     # ------------------------------------------------------------------
     # Distributed memory views (RFC 0682 §3.3)
@@ -687,56 +869,18 @@ class MemoryOps:
                 f"match IAT shape {tuple(iat.shape)}"
             )
 
-        vss = iat.variables_space_set
         vso = iat.variables_space_order
-
         if vso is not None and not vso.is_identity():
             raise NotImplementedError(
                 "indirect_store: output tile permutation via non-identity "
                 "variables_space_order is not yet implemented"
             )
 
-        # Pre-compile per-dim resolvers (loop-invariant hoisting): branch
-        # dispatch and constant lookups happen once, not per enumerated point.
-        resolvers = []
-        for sub in iat.dim_subscripts:
-            kind = sub["kind"]
-            if kind == "direct":
-                resolvers.append(("direct", sub["var_index"]))
-            elif kind == "direct_expr":
-                resolvers.append(("direct_expr", sub["subscript"]))
-            elif kind == "indirect":
-                idx_view = iat.index_views[sub["index_view_idx"]]
-                bpe = _bytes_per_elem(idx_view.dtype)
-                resolvers.append(("indirect", sub["idx_exprs"], idx_view, bpe))
-            else:
-                raise ValueError(f"Unknown indirect subscript kind: {kind}")
-
-        points = vss.enumerate(iat.shape)
-
-        coords = []
-        for pt in points:
-            coord = []
-            for res in resolvers:
-                tag = res[0]
-                if tag == "direct":
-                    coord.append(pt[res[1]])
-                elif tag == "direct_expr":
-                    coord.append(eval_subscript_expr(res[1], pt))
-                else:  # indirect
-                    _, idx_exprs, idx_view, bpe = res
-                    idx_coords = tuple(eval_subscript_expr(e, pt) for e in idx_exprs)
-                    offset = sum(c * s for c, s in zip(idx_coords, idx_view.strides))
-                    addr = idx_view.byte_address + offset * bpe
-                    raw_idx = int(_MemAccessor(context, idx_view.memory_space, addr, idx_view.lx_core_id).read(1, idx_view.dtype)[0])
-                    # NumPy fancy-index assignment silently wraps negative
-                    # indices; reject them here. Use raise so the check
-                    # survives python -O.
-                    if raw_idx < 0:
-                        raise IndexError(
-                            f"indirect index {raw_idx} from {idx_view} is negative"
-                        )
-                    coord.append(raw_idx)
-            coords.append(tuple(coord))
+        # Resolve every idx-tensor read up front (mirror of indirect_load).
+        # Stick count is discarded here — ``_data_size`` recomputes it from
+        # the IAT for store ops because there is no result Tile to carry
+        # ``index_unique_sticks``.
+        idx_values, _ = _resolve_idx_reads(context, iat)
+        coords = _build_indirect_coords(iat, idx_values)
 
         MemoryOps.store(context, tile, iat.parent_ref.to_tile_ref(), coords=coords)

--- a/ktir_cpu/ops/memory_ops.py
+++ b/ktir_cpu/ops/memory_ops.py
@@ -115,12 +115,20 @@ class _MemAccessor:
 
         Reads are addressed by elements of ``byte_addresses`` directly;
         the accessor's ``byte_addr`` (used by :meth:`read`) is unused on
-        this path. Full migration to a tuple-returning ``read()`` is a
-        follow-up.
+        this path.
 
         Raises ``ValueError`` on empty ``byte_addresses`` — empty is
         ambiguous in a read context (zero-traffic vs caller bug); use
         :meth:`count_sticks` directly for the pure query.
+
+        Caller invariant: all ``byte_addresses`` must lie within a single
+        HBM allocation. Cross-allocation calls are silently wrong —
+        physically-adjacent addresses from two allocations merge into one
+        run, and ``HBMSimulator._read_flat`` reads only the allocation
+        containing the run's start address, zero-filling the rest instead
+        of reading from the second allocation. No error is raised.
+        Hard-guarding this requires the simulator to expose allocation
+        extent; tracked as a follow-up.
         """
         if not byte_addresses:
             raise ValueError("read_scattered called with empty address list")
@@ -129,6 +137,7 @@ class _MemAccessor:
         bpe = _bytes_per_elem(dtype)
 
         sorted_unique = sorted(set(byte_addresses))
+        # sorted_unique non-empty: byte_addresses guarded above.
         runs: List[List[int]] = [[sorted_unique[0]]]
         for a in sorted_unique[1:]:
             if a - runs[-1][-1] == bpe:
@@ -179,11 +188,8 @@ def _resolve_idx_reads(
       special-case it, and the LX-only case is a defined "zero HBM
       traffic" answer, so the function returns the integer directly.
 
-    Performance note: per-view loop-invariants (``bpe``, ``strides``,
-    ``byte_address``) are hoisted out of the pt loop. At
-    paged-attention scale (millions of points) the inner loop would
-    otherwise pay function-call + bpe-lookup overhead on each
-    enumerated point.
+    Per-view loop-invariants (``bpe``, ``strides``, ``byte_address``)
+    are hoisted out of the pt loop for million-point scale.
 
     This is the canonical idx-side resolver: ``indirect_load`` and
     ``indirect_store`` both call it so their stick accounting stays in
@@ -218,6 +224,11 @@ def _resolve_idx_reads(
     per_view_values: Dict[int, np.ndarray] = {}
     total_sticks = 0
     for iv_idx, addrs in per_view_addrs.items():
+        # Zero-extent enumeration: no points, no addresses, no read.
+        # _build_indirect_coords iterates the same enumeration, so it
+        # also produces zero coords and never consumes from this view.
+        if not addrs:
+            continue
         idx_view = iat.index_views[iv_idx]
         accessor = _MemAccessor(
             context, idx_view.memory_space, idx_view.byte_address,

--- a/ktir_cpu/ops/memory_ops.py
+++ b/ktir_cpu/ops/memory_ops.py
@@ -97,12 +97,21 @@ class _MemAccessor:
     def read_scattered(
         self, byte_addresses: List[int], dtype: str,
     ) -> Tuple[np.ndarray, Optional[int]]:
-        """Per-element scatter read; returns ``(values, unique_sticks)``.
+        """Run-batched scatter read; returns ``(values, unique_sticks)``.
 
-        Issues one ``self._sim.read(addr, 1, dtype)`` per unique address
-        (set-deduped), then assembles ``values`` in the caller's order.
+        Sorts unique addresses (set-deduped) and merges adjacent ones
+        (``diff == bpe``) into contiguous runs. Each run becomes a single
+        ``self._sim.read(start, len(run), dtype)`` call — one DMA
+        descriptor's worth, matching real hardware behavior. Values are
+        then assembled in the caller's order.
+
         ``unique_sticks`` comes from :meth:`count_sticks` over
         ``byte_addresses`` (HBM: ``int``; LX: ``None``).
+
+        Number of ``sim.read`` calls = run count, bounded by
+        ``unique_sticks`` (HBM) or by ``len(set(byte_addresses))`` (LX).
+        Best case (dense access) collapses to ``1`` call; worst case
+        (fully scattered) issues one call per unique address.
 
         Reads are addressed by elements of ``byte_addresses`` directly;
         the accessor's ``byte_addr`` (used by :meth:`read`) is unused on
@@ -117,13 +126,28 @@ class _MemAccessor:
             raise ValueError("read_scattered called with empty address list")
         unique_sticks = type(self).count_sticks(self._memory_space, byte_addresses)
         np_dtype = _to_np_dtype(dtype)
-        cache: Dict[int, Any] = {}
-        for a in set(byte_addresses):
-            if self.stick_bytes is not None:
-                stick, intra = divmod(a, self.stick_bytes)
-                cache[a] = self._sim.read(stick, 1, dtype, intra_byte=intra)[0]
+        bpe = _bytes_per_elem(dtype)
+
+        sorted_unique = sorted(set(byte_addresses))
+        runs: List[List[int]] = [[sorted_unique[0]]]
+        for a in sorted_unique[1:]:
+            if a - runs[-1][-1] == bpe:
+                runs[-1].append(a)
             else:
-                cache[a] = self._sim.read(a, 1, dtype)[0]
+                runs.append([a])
+
+        cache: Dict[int, Any] = {}
+        for run in runs:
+            start = run[0]
+            n = len(run)
+            if self.stick_bytes is not None:
+                stick, intra = divmod(start, self.stick_bytes)
+                block = self._sim.read(stick, n, dtype, intra_byte=intra)
+            else:
+                block = self._sim.read(start, n, dtype)
+            for i, addr in enumerate(run):
+                cache[addr] = block[i]
+
         values = np.fromiter(
             (cache[a] for a in byte_addresses), dtype=np_dtype,
             count=len(byte_addresses),
@@ -156,10 +180,10 @@ def _resolve_idx_reads(
       traffic" answer, so the function returns the integer directly.
 
     Performance note: per-view loop-invariants (``bpe``, ``strides``,
-    ``byte_address``) are hoisted out of the pt loop. With the
-    per-element ``read_scattered``, paged-attention-scale IATs (millions
-    of points) would otherwise pay function-call + bpe-lookup overhead
-    on each enumerated point.
+    ``byte_address``) are hoisted out of the pt loop. At
+    paged-attention scale (millions of points) the inner loop would
+    otherwise pay function-call + bpe-lookup overhead on each
+    enumerated point.
 
     This is the canonical idx-side resolver: ``indirect_load`` and
     ``indirect_store`` both call it so their stick accounting stays in
@@ -253,46 +277,6 @@ def _build_indirect_coords(
                 raise ValueError(f"Unknown indirect subscript kind: {kind}")
         coords.append(tuple(coord))
     return coords
-
-
-def _idx_unique_sticks_no_reads(iat: "IndirectAccessTile") -> int:
-    """Total HBM sticks an IAT's idx-side reads would touch — without reading.
-
-    Mirrors the stick-counting half of :func:`_resolve_idx_reads` without
-    issuing any simulator reads. Used by latency evaluation paths that
-    lack a result Tile to read ``index_unique_sticks`` from (e.g.
-    ``ktdp.store`` with an indirect access tile).
-
-    Returns ``0`` when every idx view lives in LX (LX has no stick
-    concept). Stick counting itself is delegated to
-    :meth:`_MemAccessor.count_sticks` so this function holds zero
-    knowledge of ``STICK_BYTES``.
-
-    Per-view loop-invariants (``bpe``, ``strides``, ``byte_address``)
-    are hoisted out of the pt loop to mirror ``_resolve_idx_reads``'s
-    paged-attention-friendly iteration shape.
-    """
-    points = iat.variables_space_set.enumerate(iat.shape)
-    total = 0
-    for sub in iat.dim_subscripts:
-        if sub.get("kind") != "indirect":
-            continue
-        iv = iat.index_views[sub["index_view_idx"]]
-        bpe = _bytes_per_elem(iv.dtype)
-        strides = list(iv.strides)
-        base = iv.byte_address
-        idx_exprs = sub["idx_exprs"]
-        addrs = [
-            base + bpe * sum(
-                eval_subscript_expr(e, pt) * s
-                for e, s in zip(idx_exprs, strides)
-            )
-            for pt in points
-        ]
-        sticks = _MemAccessor.count_sticks(iv.memory_space, addrs)
-        if sticks is not None:
-            total += sticks
-    return total
 
 
 class MemoryOps:
@@ -511,7 +495,7 @@ class MemoryOps:
         tile: Tile,
         tile_ref: TileRef,
         coords: Optional[List[Tuple[int, ...]]] = None,
-    ):
+    ) -> int:
         """Store tile data to HBM or LX.
 
         - HBM target → DMA write from LX to HBM.
@@ -535,22 +519,42 @@ class MemoryOps:
             tile: Tile value (tensor data) to store
             tile_ref: Tile reference (memref) describing destination
             coords: Optional list of local coordinate tuples to scatter into.
+
+        Returns:
+            ``unique_sticks`` (int) — the number of distinct 128-byte HBM
+            sticks the write touches. ``0`` for LX destinations (no stick
+            concept; LX HBM traffic is zero by definition). The dialect
+            handler returns this value so :meth:`LatencyTracker._data_size`
+            charges HBM traffic at stick granularity
+            (``unique_sticks * STICK_BYTES``) instead of the source tile's
+            logical ``nbytes``, which would undercount scatter writes.
         """
         mgr = _MemAccessor(context, tile_ref.memref.memory_space, tile_ref.base_ptr, tile_ref.memref.lx_core_id)
+        stick_bytes = mgr.stick_bytes
 
         # Fast path: contiguous tile, no coord filtering — single dict-key write.
         if coords is None and MemoryOps._is_contiguous(tile_ref.shape, tile_ref.strides):
             mgr.write(tile.data.flatten())
-            return
+            if not stick_bytes:
+                return 0
+            n = int(np.prod(tile_ref.shape))
+            bpe = _bytes_per_elem(tile_ref.dtype)
+            end = tile_ref.base_ptr + n * bpe
+            return (
+                (end + stick_bytes - 1) // stick_bytes
+                - tile_ref.base_ptr // stick_bytes
+            )
 
         # Strided or coord-set path: read-modify-write via scatter offsets.
-        offsets, _ = MemoryOps._flat_memory_offsets(
-            tile_ref.base_ptr, tile_ref.shape, tile_ref.strides, tile_ref.dtype, coords
+        offsets, unique_sticks = MemoryOps._flat_memory_offsets(
+            tile_ref.base_ptr, tile_ref.shape, tile_ref.strides, tile_ref.dtype,
+            coords, stick_bytes=stick_bytes,
         )
         span = max(offsets) + 1 if offsets else 1
         flat = mgr.read(span, tile_ref.dtype)
         flat[offsets] = tile.data.flatten()
         mgr.write(flat)
+        return unique_sticks if unique_sticks is not None else 0
 
     @staticmethod
     def indirect_load(
@@ -799,7 +803,7 @@ class MemoryOps:
         context: CoreContext,
         tile: Tile,
         dist_tile_ref: DistributedTileRef,
-    ) -> None:
+    ) -> int:
         """Scatter a tile to surviving partitions, symmetric to :meth:`distributed_load`.
 
         Fast path (BoxSet C_i): slice the source tile rectangularly at
@@ -809,10 +813,18 @@ class MemoryOps:
 
         Slow path (List[Tuple] C_i): per-coord gather/write via one
         read-modify-write.
+
+        Returns:
+            Sum of ``unique_sticks`` across all surviving HBM partitions
+            (``0`` when every partition lives in LX). Mirrors
+            :meth:`distributed_load`'s ``total_unique_sticks`` aggregation
+            so :meth:`LatencyTracker._data_size` charges HBM at stick
+            granularity instead of the source tile's ``nbytes``.
         """
         x = dist_tile_ref.global_base or (0,) * len(dist_tile_ref.shape)
         ndim = len(dist_tile_ref.shape)
 
+        total_unique_sticks = 0
         for survivor in dist_tile_ref.partitions:
             cs = survivor.coordinate_set
             if isinstance(cs, BoxSet):
@@ -822,7 +834,7 @@ class MemoryOps:
                 )
                 src = np.ascontiguousarray(tile.data[slc])
                 sub_tile = Tile(src, survivor.dtype, src.shape)
-                MemoryOps.store(context, sub_tile, sub)
+                total_unique_sticks += MemoryOps.store(context, sub_tile, sub)
                 continue
 
             C_i = cs or []
@@ -834,22 +846,26 @@ class MemoryOps:
                 tuple(c[d] - x[d] for d in range(ndim)) for c in C_i
             ]
             mgr = _MemAccessor(context, survivor.memref.memory_space, survivor.base_ptr, survivor.memref.lx_core_id)
-            offsets, _ = MemoryOps._flat_memory_offsets(
+            offsets, unique_sticks = MemoryOps._flat_memory_offsets(
                 survivor.base_ptr, survivor.shape, survivor.strides, survivor.dtype,
-                local_coords,
+                local_coords, stick_bytes=mgr.stick_bytes,
             )
             span = max(offsets) + 1 if offsets else 1
             flat = mgr.read(span, survivor.dtype)
             for ac, off in zip(access_coords, offsets):
                 flat[off] = tile.data[ac]
             mgr.write(flat)
+            if unique_sticks is not None:
+                total_unique_sticks += unique_sticks
+
+        return total_unique_sticks
 
     @staticmethod
     def indirect_store(
         context: CoreContext,
         tile: Tile,
         iat: "IndirectAccessTile",
-    ) -> None:
+    ) -> int:
         """Store data using an indirect access tile (scatter pattern).
 
         Mirror of :meth:`indirect_load`. Enumerates the variable space,
@@ -860,6 +876,16 @@ class MemoryOps:
         Coordinate collisions (multiple source elements mapping to the same
         destination coordinate) are *implementation-defined*; the current
         behavior is last-writer-wins via NumPy fancy-index assignment.
+
+        Returns:
+            Total ``unique_sticks`` touched on HBM — sum of the parent
+            tile's destination sticks (from :meth:`store`) and the
+            idx-side sticks (from :func:`_resolve_idx_reads`). ``0`` when
+            both the parent and every idx view live in LX (no HBM
+            traffic). Returned via the dialect handler as the op result
+            so :meth:`LatencyTracker._data_size` can charge stick-granular
+            HBM cost — guard symmetry with :meth:`indirect_load`, which
+            stamps the same totals on the result Tile.
         """
         # MLIR type system should already enforce shape match; raise here so a
         # mismatch surfaces clearly instead of as an opaque NumPy shape error.
@@ -876,11 +902,12 @@ class MemoryOps:
                 "variables_space_order is not yet implemented"
             )
 
-        # Resolve every idx-tensor read up front (mirror of indirect_load).
-        # Stick count is discarded here — ``_data_size`` recomputes it from
-        # the IAT for store ops because there is no result Tile to carry
-        # ``index_unique_sticks``.
-        idx_values, _ = _resolve_idx_reads(context, iat)
+        # Resolve idx reads (returns idx_unique_sticks: int, 0 for all-LX
+        # views) and delegate the data write to MemoryOps.store (returns
+        # int: HBM stick count, 0 for LX).
+        idx_values, idx_unique_sticks = _resolve_idx_reads(context, iat)
         coords = _build_indirect_coords(iat, idx_values)
-
-        MemoryOps.store(context, tile, iat.parent_ref.to_tile_ref(), coords=coords)
+        data_sticks = MemoryOps.store(
+            context, tile, iat.parent_ref.to_tile_ref(), coords=coords,
+        )
+        return data_sticks + idx_unique_sticks

--- a/tests/test_latency.py
+++ b/tests/test_latency.py
@@ -590,7 +590,12 @@ class TestLatencyEdgeCases:
         assert n_elems == 0
 
     def test_lx_index_views_excluded_from_hbm_bytes(self):
-        """_data_size() ignores LX index views; _memory_space() falls back to parent."""
+        """_data_size() ignores LX index views; _memory_space() falls back to parent.
+
+        The result Tile is constructed with ``index_unique_sticks=0`` to
+        honor the IAT-load contract — in real workflow ``indirect_load``
+        produces ``0`` for an all-LX IAT (LX has no stick concept).
+        """
         from ktir_cpu.latency import LatencyTracker
         from ktir_cpu.ir_types import IndirectAccessTile, MemRef, Tile
         from ktir_cpu.parser_ast import parse_affine_set
@@ -605,7 +610,10 @@ class TestLatencyEdgeCases:
             index_views=[lx_idx, lx_idx],
             variables_space_set=vss, variables_space_order=None,
         )
-        result = Tile(np.zeros((4, 4), dtype=np.float16), "f16", (4, 4))
+        result = Tile(
+            np.zeros((4, 4), dtype=np.float16), "f16", (4, 4),
+            index_unique_sticks=0,
+        )
 
         assert LatencyTracker._data_size(result, [iat]) == result.data.nbytes
         assert LatencyTracker._memory_space([iat]) == "HBM"
@@ -763,3 +771,545 @@ class TestIndirectAccessLatency:
         original = Tile(np.zeros(64, dtype=np.float16), "f16", (64,), unique_sticks=7)
 
         assert original.copy().unique_sticks == 7
+
+    def test_copy_propagates_index_unique_sticks(self):
+        """Tile.copy() preserves index_unique_sticks alongside unique_sticks.
+
+        Both fields describe HBM traffic of the load that produced the tile;
+        a deep copy of the tile data does not change either.
+        """
+        from ktir_cpu.ir_types import Tile
+
+        original = Tile(
+            np.zeros(64, dtype=np.float16), "f16", (64,),
+            unique_sticks=7, index_unique_sticks=11,
+        )
+        copied = original.copy()
+        assert copied.unique_sticks == 7
+        assert copied.index_unique_sticks == 11
+
+    def test_data_size_charges_index_unique_sticks(self):
+        """_data_size adds ``index_unique_sticks * STICK_BYTES`` for indirect_load result.
+
+        For a gather result with both fields set:
+          data side  = unique_sticks * 128
+          idx side   = index_unique_sticks * 128
+        ``_data_size`` returns the sum.
+        """
+        from ktir_cpu.ir_types import Tile
+        from ktir_cpu.latency import LatencyTracker
+
+        # 1 stick of data + 3 sticks of idx reads = (1 + 3) * 128 = 512.
+        result = Tile(
+            np.zeros(64, dtype=np.float16), "f16", (64,),
+            unique_sticks=1, index_unique_sticks=3,
+        )
+
+        assert LatencyTracker._data_size(result, []) == (1 + 3) * 128
+
+    @pytest.mark.parametrize("idx_sticks", [
+        pytest.param(5, id="positive_idx_sticks"),
+        pytest.param(0, id="zero_idx_sticks_lx_only_safe"),
+    ])
+    def test_data_size_iat_load_skips_operand_branch_when_result_field_set(
+        self, idx_sticks,
+    ):
+        """When ``result.index_unique_sticks`` is set (any int, including 0),
+        the IAT operand branch in :meth:`LatencyTracker._data_size` is
+        skipped — load case routes through the result field, sidestepping
+        the side-channel ``_idx_unique_sticks_no_reads(iat)`` charge.
+
+        Two regression scenarios are covered:
+
+        * positive (``idx_sticks=5``): an HBM IAT whose
+          ``_idx_unique_sticks_no_reads`` would itself give a positive
+          count. If the operand branch ever stops being skipped on the
+          load path, the assertion catches the double-charge.
+        * zero (``idx_sticks=0``): an LX-only IAT load legitimately
+          stamps ``0`` on the result. The gated raise must distinguish
+          ``0`` from ``None`` and let this through.
+        """
+        from ktir_cpu.ir_types import IndirectAccessTile, MemRef, Tile
+        from ktir_cpu.latency import LatencyTracker
+        from ktir_cpu.parser_ast import parse_affine_set
+
+        # HBM idx_view: _idx_unique_sticks_no_reads(iat) would give a
+        # positive count if the operand branch fired. The result field
+        # forces it skipped.
+        idx_view = MemRef(
+            base_ptr=0, shape=(4,), strides=[1],
+            memory_space="HBM", dtype="i32",
+        )
+        iat = IndirectAccessTile(
+            parent_ref=idx_view, shape=(4,),
+            dim_subscripts=[
+                {"kind": "indirect", "index_view_idx": 0,
+                 "idx_exprs": [("dim", 0)]},
+            ],
+            index_views=[idx_view],
+            variables_space_set=parse_affine_set(
+                "(d0) : (d0 >= 0, -d0 + 3 >= 0)"
+            ),
+            variables_space_order=None,
+        )
+        result = Tile(
+            np.zeros(4, dtype=np.float16), "f16", (4,),
+            unique_sticks=2, index_unique_sticks=idx_sticks,
+        )
+
+        # Expected: (data sticks + idx sticks from result field) * 128.
+        # An operand-branch double-charge would add
+        # _idx_unique_sticks_no_reads(iat) * 128 on top, breaking equality.
+        assert LatencyTracker._data_size(result, [iat]) == (2 + idx_sticks) * 128
+
+    def test_read_scattered_empty_raises(self):
+        """_MemAccessor.read_scattered rejects empty address lists.
+
+        Empty input is ambiguous — could mean "zero sticks" or "caller bug" —
+        so raise rather than silently return ``([], 0)``.
+        """
+        from ktir_cpu.ops.memory_ops import _MemAccessor
+        from unittest.mock import MagicMock
+
+        ctx = MagicMock()
+        ctx.hbm = MagicMock()
+        accessor = _MemAccessor(ctx, "HBM", byte_addr=0x10000)
+
+        with pytest.raises(ValueError, match="empty address list"):
+            accessor.read_scattered([], "i32")
+
+    def test_idx_unique_sticks_no_reads_dedups_repeated_coords(self):
+        """_idx_unique_sticks_no_reads dedups across vss-enumerated points.
+
+        Models a paged-attention-shape access pattern in miniature: a
+        2-D variable space ``(d0, d1)`` where ``idx_exprs = (d0,)``
+        projects out ``d1`` entirely.  Each idx coord (d0=0, d0=1) is
+        looked up |range(d1)| = 4 times — but they live on the same
+        stick (i32 idx, base_ptr=0, addresses 0 and 4 both fall in
+        stick 0 of a 128-byte stick).
+
+        Expected: 1 unique stick (despite 8 enumerated points).
+        """
+        from ktir_cpu.ir_types import IndirectAccessTile, MemRef
+        from ktir_cpu.ops.memory_ops import _idx_unique_sticks_no_reads
+        from ktir_cpu.parser_ast import parse_affine_set
+
+        idx_view = MemRef(
+            base_ptr=0, shape=(64,), strides=[1],
+            memory_space="HBM", dtype="i32",  # bpe=4
+        )
+        iat = IndirectAccessTile(
+            parent_ref=idx_view, shape=(2, 4),
+            dim_subscripts=[
+                {"kind": "indirect", "index_view_idx": 0,
+                 "idx_exprs": [("dim", 0)]},
+            ],
+            index_views=[idx_view],
+            variables_space_set=parse_affine_set(
+                "(d0, d1) : (d0 >= 0, -d0 + 1 >= 0, d1 >= 0, -d1 + 3 >= 0)"
+            ),
+            variables_space_order=None,
+        )
+
+        assert _idx_unique_sticks_no_reads(iat) == 1
+
+    def test_idx_unique_sticks_no_reads_n_distinct_sticks(self):
+        """_idx_unique_sticks_no_reads counts N sticks when each idx coord
+        owns its own stick.
+
+        ``idx_view`` is i32 with one element per stick (stride forces each
+        coord onto a distinct stick).  Enumerating 4 distinct d0 values
+        therefore gives 4 unique sticks.
+        """
+        from ktir_cpu.ir_types import IndirectAccessTile, MemRef
+        from ktir_cpu.ops.memory_ops import _idx_unique_sticks_no_reads
+        from ktir_cpu.parser_ast import parse_affine_set
+
+        # i32 with stride 32 means each idx element is 32 * 4 = 128 bytes
+        # apart — one stick per element.
+        idx_view = MemRef(
+            base_ptr=0, shape=(128,), strides=[32],
+            memory_space="HBM", dtype="i32",
+        )
+        iat = IndirectAccessTile(
+            parent_ref=idx_view, shape=(4,),
+            dim_subscripts=[
+                {"kind": "indirect", "index_view_idx": 0,
+                 "idx_exprs": [("dim", 0)]},
+            ],
+            index_views=[idx_view],
+            variables_space_set=parse_affine_set(
+                "(d0) : (d0 >= 0, -d0 + 3 >= 0)"
+            ),
+            variables_space_order=None,
+        )
+
+        assert _idx_unique_sticks_no_reads(iat) == 4
+
+    def test_idx_unique_sticks_no_reads_returns_zero_for_lx_only_iat(self):
+        """LX has no stick concept — return 0 (defined "no HBM traffic"), not None.
+
+        Reserving ``None`` for "not computed" lets the gated raise in
+        ``_data_size`` catch handlers that forget to populate the field.
+        An LX-only IAT load is a fully legitimate workflow that must
+        report zero HBM idx-side traffic without tripping the guard.
+        """
+        from ktir_cpu.ir_types import IndirectAccessTile, MemRef
+        from ktir_cpu.ops.memory_ops import _idx_unique_sticks_no_reads
+        from ktir_cpu.parser_ast import parse_affine_set
+
+        idx_view = MemRef(
+            base_ptr=0, shape=(64,), strides=[1],
+            memory_space="LX", dtype="i32",
+        )
+        iat = IndirectAccessTile(
+            parent_ref=idx_view, shape=(4,),
+            dim_subscripts=[
+                {"kind": "indirect", "index_view_idx": 0,
+                 "idx_exprs": [("dim", 0)]},
+            ],
+            index_views=[idx_view],
+            variables_space_set=parse_affine_set(
+                "(d0) : (d0 >= 0, -d0 + 3 >= 0)"
+            ),
+            variables_space_order=None,
+        )
+
+        assert _idx_unique_sticks_no_reads(iat) == 0
+
+    # ---------------------------------------------------------------------
+    # _MemAccessor.count_sticks — single source of truth for stick counting.
+    # ---------------------------------------------------------------------
+
+    @pytest.mark.parametrize("addrs,expected", [
+        # All in stick 0 (bytes 0..127): 1 stick total.
+        pytest.param([0, 4, 8, 12], 1, id="four_addrs_one_stick"),
+        # Repeats fold into the same stick: dedup is by stick, not address.
+        pytest.param([0, 0, 0, 0], 1, id="repeated_addrs_same_stick"),
+        # 0 → stick 0, 128 → stick 1, 256 → stick 2.
+        pytest.param([0, 128, 256], 3, id="three_distinct_sticks"),
+        # 0 + 4 share stick 0; 128 lives on stick 1.
+        pytest.param([0, 4, 128], 2, id="subset_two_sticks"),
+        # Empty input: defined "no traffic" (kept distinct from None).
+        pytest.param([], 0, id="empty_returns_zero"),
+    ])
+    def test_count_sticks_hbm(self, addrs, expected):
+        """_MemAccessor.count_sticks counts distinct HBM sticks via set dedup.
+
+        Stick boundaries are 128 bytes (HBMSimulator.STICK_BYTES):
+        addresses 0..127 share stick 0, 128..255 share stick 1, etc.
+        Counting routes through this classmethod so callers stay free
+        of ``addr // STICK_BYTES`` arithmetic.
+        """
+        from ktir_cpu.ops.memory_ops import _MemAccessor
+
+        assert _MemAccessor.count_sticks("HBM", addrs) == expected
+
+    def test_count_sticks_lx_returns_none(self):
+        """LX has no stick concept — count_sticks returns None for any input.
+
+        ``None`` is the LX answer (no stick boundaries exist there);
+        ``0`` is HBM's answer for an empty address list. The two are
+        kept distinct so callers can route on memory space.
+        """
+        from ktir_cpu.ops.memory_ops import _MemAccessor
+
+        assert _MemAccessor.count_sticks("LX", [0, 128, 256]) is None
+        assert _MemAccessor.count_sticks("LX", []) is None
+
+    # ---------------------------------------------------------------------
+    # _MemAccessor.read_scattered — per-element reads with stick counting.
+    # ---------------------------------------------------------------------
+
+    def _seeded_hbm_accessor(self):
+        """Build an HBM accessor over a freshly-allocated, pre-seeded region.
+
+        Layout: stick 0 (bytes 0..127) holds i32 values [10, 20, 30, 40]
+        at byte offsets 0, 4, 8, 12. Stick 1 (bytes 128..255) holds
+        i32 value 99 at byte offset 128. All other addresses are
+        unwritten (would read zero).
+        """
+        from ktir_cpu.ops.memory_ops import _MemAccessor
+        from ktir_cpu.memory import HBMSimulator
+        from unittest.mock import MagicMock
+
+        hbm = HBMSimulator()
+        hbm.write(0, np.array([10, 20, 30, 40], dtype=np.int32))
+        hbm.write(1, np.array([99], dtype=np.int32))
+
+        ctx = MagicMock()
+        ctx.hbm = hbm
+        return _MemAccessor(ctx, "HBM", byte_addr=0)
+
+    @pytest.mark.parametrize("addrs,expected_values,expected_sticks", [
+        # Per-element read in input order, all sharing stick 0.
+        pytest.param([0, 4, 8, 12], [10, 20, 30, 40], 1, id="dense_within_stick"),
+        # Repeated address reads the same value each time (cache hit
+        # internally); stick count is set-deduped to 1.
+        pytest.param([0, 0, 0], [10, 10, 10], 1, id="repeated_same_addr"),
+        # Subset preserves order and skips unaccessed addresses.
+        pytest.param([12, 0], [40, 10], 1, id="subset_preserves_order"),
+        # Two distinct sticks: one address per stick, span 128 bytes apart.
+        pytest.param([0, 128], [10, 99], 2, id="two_sticks"),
+    ])
+    def test_read_scattered_hbm_per_element(
+        self, addrs, expected_values, expected_sticks,
+    ):
+        """read_scattered reads one element per address, returns (values, sticks).
+
+        Verifies the per-element semantics fabian's review required:
+        stick count is set-deduped on the address side regardless of how
+        many physical reads are issued; values are returned in caller
+        order. Per-stick formula: ``len({addr // 128 for addr in addrs})``.
+        """
+        accessor = self._seeded_hbm_accessor()
+
+        values, sticks = accessor.read_scattered(addrs, "i32")
+        assert list(values) == expected_values
+        assert sticks == expected_sticks
+
+    def test_read_scattered_lx_returns_none_sticks(self):
+        """read_scattered on LX returns ``None`` for the stick count.
+
+        Mirror of :meth:`_MemAccessor.count_sticks` semantics — LX has
+        no stick concept, so the second tuple element is ``None`` and
+        callers must skip stick-based latency accounting.
+        """
+        from ktir_cpu.ops.memory_ops import _MemAccessor
+        from ktir_cpu.memory import LXScratchpad
+        from unittest.mock import MagicMock
+
+        lx = LXScratchpad()
+        lx.write(0, np.array([10, 20, 30, 40], dtype=np.int32))
+
+        ctx = MagicMock()
+        ctx.get_lx = MagicMock(return_value=lx)
+        accessor = _MemAccessor(ctx, "LX", byte_addr=0, lx_core_id=0)
+
+        values, sticks = accessor.read_scattered([0, 4, 8, 12], "i32")
+        assert list(values) == [10, 20, 30, 40]
+        assert sticks is None
+
+    # ---------------------------------------------------------------------
+    # _data_size — gated raise enforces the IAT-load contract.
+    # ---------------------------------------------------------------------
+
+    def test_data_size_raises_when_iat_load_result_missing_index_unique_sticks(self):
+        """_data_size raises when an IAT-load result Tile arrives with index_unique_sticks=None.
+
+        The contract: a handler that produces a Tile from an IAT operand
+        must populate ``index_unique_sticks`` (``0`` for an all-LX IAT,
+        positive for HBM). A surviving ``None`` indicates the handler
+        skipped ``_resolve_idx_reads``, which would silently undercount.
+        """
+        from ktir_cpu.ir_types import IndirectAccessTile, MemRef, Tile
+        from ktir_cpu.latency import LatencyTracker
+        from ktir_cpu.parser_ast import parse_affine_set
+
+        idx_view = MemRef(
+            base_ptr=0, shape=(4,), strides=[1],
+            memory_space="HBM", dtype="i32",
+        )
+        iat = IndirectAccessTile(
+            parent_ref=idx_view, shape=(4,),
+            dim_subscripts=[
+                {"kind": "indirect", "index_view_idx": 0,
+                 "idx_exprs": [("dim", 0)]},
+            ],
+            index_views=[idx_view],
+            variables_space_set=parse_affine_set(
+                "(d0) : (d0 >= 0, -d0 + 3 >= 0)"
+            ),
+            variables_space_order=None,
+        )
+        # Result Tile with index_unique_sticks left at default None —
+        # mimics a buggy handler that skipped _resolve_idx_reads.
+        result = Tile(
+            np.zeros(4, dtype=np.float16), "f16", (4,), unique_sticks=1,
+        )
+
+        with pytest.raises(
+            RuntimeError, match="must populate index_unique_sticks"
+        ):
+            LatencyTracker._data_size(result, [iat])
+
+    # ---------------------------------------------------------------------
+    # Guard symmetry — indirect_store charges idx sticks via _data_size's
+    # IAT-operand fallback, mirroring the indirect_load load-side charge.
+    # ---------------------------------------------------------------------
+
+    def test_data_size_indirect_store_charges_idx_sticks(self):
+        """Store path: _data_size recomputes idx sticks from the IAT (no result Tile).
+
+        ``ktdp.store`` with an indirect access tile has ``result=None``,
+        so the IAT-operand branch in :meth:`LatencyTracker._data_size`
+        falls through to :func:`_idx_unique_sticks_no_reads` rather
+        than reading ``result.index_unique_sticks`` (which doesn't
+        exist). Mirrors the load-side charge for guard symmetry.
+
+        The IAT here enumerates 4 distinct d0 values; idx_view stride
+        forces each onto its own stick → 4 unique sticks → 4 * 128 bytes.
+        """
+        from ktir_cpu.ir_types import IndirectAccessTile, MemRef, Tile
+        from ktir_cpu.latency import LatencyTracker
+        from ktir_cpu.parser_ast import parse_affine_set
+
+        # i32 stride 32 → each idx element is 32 * 4 = 128 bytes apart,
+        # one stick per element.
+        idx_view = MemRef(
+            base_ptr=0, shape=(128,), strides=[32],
+            memory_space="HBM", dtype="i32",
+        )
+        iat = IndirectAccessTile(
+            parent_ref=idx_view, shape=(4,),
+            dim_subscripts=[
+                {"kind": "indirect", "index_view_idx": 0,
+                 "idx_exprs": [("dim", 0)]},
+            ],
+            index_views=[idx_view],
+            variables_space_set=parse_affine_set(
+                "(d0) : (d0 >= 0, -d0 + 3 >= 0)"
+            ),
+            variables_space_order=None,
+        )
+        # Store source tile lands as the second branch's Tile operand;
+        # we only care that the IAT operand branch contributes its idx
+        # sticks. The store source contributes its data.nbytes.
+        src = Tile(np.zeros(4, dtype=np.float16), "f16", (4,))
+
+        # result=None (store), operands=[iat, src]:
+        #   IAT branch (store path) → 4 sticks * 128 = 512
+        #   Tile branch (src)       → src.data.nbytes = 8
+        assert LatencyTracker._data_size(None, [iat, src]) == 4 * 128 + 8
+
+    # ---------------------------------------------------------------------
+    # End-to-end: MemoryOps.indirect_load / .indirect_store actually stash
+    # the count on the returned Tile / produce the matching count via the
+    # IAT side-channel. These pin the wiring that connects the helpers to
+    # the public ops — a plain unit test on _data_size cannot catch a
+    # regression where indirect_load forgets to set the field.
+    # ---------------------------------------------------------------------
+
+    @staticmethod
+    def _build_simple_gather_iat(hbm):
+        """Allocate X / IDX1 / IDX2 in HBM and return an IAT for the gather.
+
+        Layout matches RFC §5 Example 1 in miniature (8×8 instead of
+        64×64 to keep the formula human-readable; the same per-stick
+        math applies):
+
+        * X:    8×8 f16 (128 bytes = 1 stick)
+        * IDX1: 8×8 i32 (256 bytes = 2 sticks)
+        * IDX2: 8×8 i32 (256 bytes = 2 sticks)
+
+        Both index tensors are seeded to all-zeros, so every gather
+        collapses to ``X[0, 0]`` — but the IAT enumeration still reads
+        every index entry (8*8 = 64 reads per view), and those 64
+        addresses span the full 256 bytes of each view → 2 sticks each.
+        """
+        from ktir_cpu.ir_types import IndirectAccessTile, MemRef
+        from ktir_cpu.parser_ast import parse_affine_set
+
+        x_stick = hbm.allocate(8 * 8 * 2)         # 128 bytes (1 stick)
+        idx1_stick = hbm.allocate(8 * 8 * 4)      # 256 bytes (2 sticks)
+        idx2_stick = hbm.allocate(8 * 8 * 4)      # 256 bytes (2 sticks)
+
+        hbm.write(x_stick, np.zeros(64, dtype=np.float16))
+        hbm.write(idx1_stick, np.zeros(64, dtype=np.int32))
+        hbm.write(idx2_stick, np.zeros(64, dtype=np.int32))
+
+        parent = MemRef(base_ptr=x_stick, shape=(8, 8), strides=[8, 1],
+                        memory_space="HBM", dtype="f16")
+        idx1 = MemRef(base_ptr=idx1_stick, shape=(8, 8), strides=[8, 1],
+                      memory_space="HBM", dtype="i32")
+        idx2 = MemRef(base_ptr=idx2_stick, shape=(8, 8), strides=[8, 1],
+                      memory_space="HBM", dtype="i32")
+
+        iat = IndirectAccessTile(
+            parent_ref=parent, shape=(8, 8),
+            dim_subscripts=[
+                {"kind": "indirect", "index_view_idx": 0,
+                 "idx_exprs": [("dim", 0), ("dim", 1)]},
+                {"kind": "indirect", "index_view_idx": 1,
+                 "idx_exprs": [("dim", 0), ("dim", 1)]},
+            ],
+            index_views=[idx1, idx2],
+            variables_space_set=parse_affine_set(
+                "(d0, d1) : (d0 >= 0, -d0 + 7 >= 0, "
+                "d1 >= 0, -d1 + 7 >= 0)"
+            ),
+            variables_space_order=None,
+        )
+        return iat
+
+    def test_indirect_load_index_sticks_simple_gather(self):
+        """End-to-end: MemoryOps.indirect_load stamps index_unique_sticks on the result Tile.
+
+        RFC §5 Example 1 pattern (2-D gather Y[m, k] = X[IDX1[m, k], IDX2[m, k]]).
+        Per-stick formula::
+
+            addrs per view = 8 * 8 = 64 (one per enumerated (m, k) pt)
+            byte span      = 64 * 4 = 256 bytes (i32, contiguous)
+            sticks per view= 256 / 128 = 2
+            total          = 2 + 2 = 4
+
+        If a future refactor drops ``result.index_unique_sticks =
+        idx_unique_sticks`` from :meth:`MemoryOps.indirect_load`, this
+        assertion catches it; helper-level tests would not.
+        """
+        from ktir_cpu.grid import CoreContext
+        from ktir_cpu.memory import HBMSimulator, LXScratchpad
+        from ktir_cpu.ops.memory_ops import MemoryOps
+
+        hbm = HBMSimulator()
+        lx = LXScratchpad(size_mb=2, core_id=0)
+        ctx = CoreContext(core_id=0, grid_pos=(0, 0, 0), lx=lx, hbm=hbm)
+
+        iat = self._build_simple_gather_iat(hbm)
+
+        result = MemoryOps.indirect_load(ctx, iat)
+
+        assert result.index_unique_sticks == 4, (
+            f"expected 4 idx sticks (2 per view × 2 views = 4), "
+            f"got {result.index_unique_sticks}"
+        )
+
+    def test_indirect_store_index_sticks_mirrors_load(self):
+        """Guard symmetry: indirect_store's idx-side stick count matches indirect_load.
+
+        Both ops share ``_resolve_idx_reads`` for the runtime read and
+        delegate stick counting to ``_MemAccessor.count_sticks``. The
+        latency model recomputes the store-side count via
+        ``_idx_unique_sticks_no_reads(iat)`` (since stores have no
+        result Tile). Pinning the load value and the no-read value
+        equal locks the symmetry — if either path drifts, this trips.
+        """
+        from ktir_cpu.grid import CoreContext
+        from ktir_cpu.ir_types import Tile
+        from ktir_cpu.memory import HBMSimulator, LXScratchpad
+        from ktir_cpu.ops.memory_ops import MemoryOps, _idx_unique_sticks_no_reads
+
+        hbm = HBMSimulator()
+        lx = LXScratchpad(size_mb=2, core_id=0)
+        ctx = CoreContext(core_id=0, grid_pos=(0, 0, 0), lx=lx, hbm=hbm)
+
+        iat = self._build_simple_gather_iat(hbm)
+
+        load_result = MemoryOps.indirect_load(ctx, iat)
+        load_sticks = load_result.index_unique_sticks
+
+        # Store side: _data_size goes through _idx_unique_sticks_no_reads,
+        # which is the no-IO mirror of _resolve_idx_reads' stick count.
+        store_sticks = _idx_unique_sticks_no_reads(iat)
+
+        assert load_sticks == store_sticks == 4, (
+            f"load idx sticks={load_sticks}, store idx sticks={store_sticks}, "
+            f"expected both to be 4"
+        )
+
+        # Smoke-test the actual store call (does it execute, does it
+        # leave HBM in a consistent state). Source is i32 zeros sized
+        # to match the IAT shape; we already seeded X to zeros so the
+        # store is effectively a no-op write.
+        src_tile = Tile(np.zeros((8, 8), dtype=np.float16), "f16", (8, 8))
+        MemoryOps.indirect_store(ctx, src_tile, iat)

--- a/tests/test_latency.py
+++ b/tests/test_latency.py
@@ -577,8 +577,11 @@ class TestLatencyEdgeCases:
         cfg = HardwareConfig()
         tracker = LatencyTracker(cfg)
 
-        # A zero-element tile (e.g. empty slice)
-        zero_tile = Tile(np.array([], dtype=np.float16), "f16", (0,))
+        # A zero-element tile (e.g. empty slice). unique_sticks=0 honors
+        # the HBM-load contract: a zero-element load spans zero sticks.
+        zero_tile = Tile(
+            np.array([], dtype=np.float16), "f16", (0,), unique_sticks=0,
+        )
         assert zero_tile.size_bytes() == 0
 
         # _data_size should return 0 for a zero-element result
@@ -610,12 +613,18 @@ class TestLatencyEdgeCases:
             index_views=[lx_idx, lx_idx],
             variables_space_set=vss, variables_space_order=None,
         )
+        # 4x4 f16 = 32 bytes — fits within one 128-byte stick.
+        # index_unique_sticks=0 honors the IAT-load contract for an
+        # all-LX IAT (LX has no stick concept).
         result = Tile(
             np.zeros((4, 4), dtype=np.float16), "f16", (4, 4),
+            unique_sticks=1,
             index_unique_sticks=0,
         )
 
-        assert LatencyTracker._data_size(result, [iat]) == result.data.nbytes
+        # Data side: 1 stick * 128 bytes. Idx side: 0 (all-LX index views
+        # contribute nothing). Total stays stick-granular, not data.nbytes.
+        assert LatencyTracker._data_size(result, [iat]) == 1 * 128
         assert LatencyTracker._memory_space([iat]) == "HBM"
 
     def test_empty_counters_bottleneck(self):
@@ -958,8 +967,7 @@ class TestIndirectAccessLatency:
     ):
         """read_scattered reads one element per address, returns (values, sticks).
 
-        Verifies the per-element semantics fabian's review required:
-        stick count is set-deduped on the address side regardless of how
+        Stick count is set-deduped on the address side regardless of how
         many physical reads are issued; values are returned in caller
         order. Per-stick formula: ``len({addr // 128 for addr in addrs})``.
         """
@@ -1172,23 +1180,82 @@ class TestIndirectAccessLatency:
         ):
             LatencyTracker._data_size(result, [iat])
 
+    def test_resolve_idx_reads_zero_extent_skips_view(self, monkeypatch):
+        """Zero-extent IAT enumeration: ``_resolve_idx_reads`` returns
+        ``({}, 0)`` rather than calling ``read_scattered([])``.
+
+        A zero-extent dim is a legitimate degenerate case (the
+        enumeration yields no points, hence no addresses to resolve).
+        The view is skipped; ``_build_indirect_coords`` iterates the
+        same enumeration and likewise produces no coords, so the
+        missing key is never consumed.
+        """
+        from ktir_cpu.ir_types import IndirectAccessTile, MemRef
+        from ktir_cpu.ops.memory_ops import _resolve_idx_reads
+        from ktir_cpu.parser_ast import parse_affine_set_raw
+
+        idx_view = MemRef(
+            base_ptr=0, shape=(4,), strides=[1],
+            memory_space="HBM", dtype="i32",
+        )
+        iat = IndirectAccessTile(
+            parent_ref=idx_view, shape=(4,),
+            dim_subscripts=[
+                {"kind": "indirect", "index_view_idx": 0,
+                 "idx_exprs": [("dim", 0)]},
+            ],
+            index_views=[idx_view],
+            # Raw AffineSet (not a BoxSet) so enumerate goes through the
+            # module-level enumerate_affine_set we stub below.
+            variables_space_set=parse_affine_set_raw(
+                "(d0) : (d0 >= 0, -d0 + 3 >= 0)"
+            ),
+            variables_space_order=None,
+        )
+        # Stub the enumerator to an empty list — the legitimate
+        # zero-extent case. context is never accessed: ``continue`` fires
+        # before any ``_MemAccessor`` is constructed.
+        import ktir_cpu.parser_ast as parser_ast
+        monkeypatch.setattr(
+            parser_ast, "enumerate_affine_set", lambda *a, **kw: []
+        )
+        per_view_values, total_sticks = _resolve_idx_reads(None, iat)
+        assert per_view_values == {}
+        assert total_sticks == 0
+
+    def test_data_size_raises_when_tile_result_missing_unique_sticks(self):
+        """Tile result with ``unique_sticks=None`` raises.
+
+        ``_data_size`` is reached only on the HBM path (LX short-circuits
+        before it). On HBM, load handlers must populate ``unique_sticks``;
+        a None here is a handler bug.
+        """
+        from ktir_cpu.ir_types import Tile
+        from ktir_cpu.latency import LatencyTracker
+
+        result = Tile(
+            np.zeros(4, dtype=np.float16), "f16", (4,), unique_sticks=None,
+        )
+
+        with pytest.raises(
+            RuntimeError, match="must populate unique_sticks"
+        ):
+            LatencyTracker._data_size(result, [])
+
     # ---------------------------------------------------------------------
     # Store sideband — _data_size charges HBM bytes from the int sideband
     # returned by MemoryOps.{store, indirect_store, distributed_store}.
-    # The handler propagates that int as the op result; loads still
-    # carry stick counts on the result Tile (guard symmetry).
+    # The handler propagates that int as the op result; loads carry
+    # stick counts on the result Tile (guard symmetry).
     # ---------------------------------------------------------------------
 
     def test_data_size_int_sideband_charges_stick_bytes(self):
-        """Store path: int result is the unique-stick total; _data_size
-        returns ``result * STICK_BYTES`` regardless of operands.
+        """``_data_size`` returns ``result * STICK_BYTES`` for an int result.
 
-        The sideband int (returned by ``MemoryOps.indirect_store`` for
-        IATs, or ``MemoryOps.store`` for direct stores) already
-        aggregates both data sticks (destination) and idx sticks (IAT).
-        Operands are therefore ignored by the int branch — this asserts
-        the absence of the pre-fix double-charge that fell through to
-        ``v.data.nbytes`` for the source Tile.
+        The sideband int (from ``MemoryOps.indirect_store`` for IATs, or
+        ``MemoryOps.store`` for direct stores) already aggregates data
+        sticks (destination) and idx sticks (IAT). Operands are
+        therefore ignored on the int branch.
         """
         from ktir_cpu.ir_types import IndirectAccessTile, MemRef, Tile
         from ktir_cpu.latency import LatencyTracker
@@ -1217,31 +1284,27 @@ class TestIndirectAccessLatency:
         assert LatencyTracker._data_size(4, [iat, src]) == 4 * 128
 
     def test_data_size_int_sideband_direct_store_64x64_scatter(self):
-        """C3 regression: stick-granular accounting beats source.nbytes for scatters.
+        """Direct store cost is stick-granular, not source-tile bytes.
 
-        Before the sideband fix, ``_data_size`` charged direct stores at
-        ``v.data.nbytes`` — the source tile's logical size, blind to
-        scatter pattern. For a 64×64 f16 tile (8192 bytes) scattered to
-        100 distinct sticks, the real HBM traffic is ``100 * 128 = 12800``
-        bytes (HBM is stick-addressed; partial stick writes still cost
-        the full 128 bytes). The pre-fix path undercounted by 4608 bytes.
-
-        With the sideband, the int (``unique_sticks=100``) carries the
-        correct stick count; ``_data_size`` returns ``100 * 128``.
+        For a 64×64 f16 tile (8192 logical bytes) scattered to 100
+        distinct sticks, HBM traffic is ``100 * 128 = 12800`` bytes —
+        HBM is stick-addressed, so a partial-stick write still costs
+        the full 128 bytes. The sideband int (``unique_sticks=100``)
+        carries the stick count; ``_data_size`` returns ``100 * 128``,
+        which differs from ``64 * 64 * 2`` by 4608 bytes.
         """
         from ktir_cpu.latency import LatencyTracker
 
         assert LatencyTracker._data_size(100, []) == 100 * 128
-        assert 100 * 128 != 64 * 64 * 2  # the bug magnitude is non-trivial
+        # Stick-granular cost differs from logical-bytes by a non-trivial margin.
+        assert 100 * 128 != 64 * 64 * 2
 
     def test_data_size_rejects_tile_operand_with_none_result(self):
-        """Tile operand + None result trips the guard — was the pre-fix bug.
+        """Tile operand with None result raises.
 
-        Pre-sideband, ``_data_size`` fell back to ``v.data.nbytes`` for
-        the source Tile of a store, undercounting any non-stick-aligned
-        scatter. The new contract: store handlers must propagate
-        ``MemoryOps.store``'s int return. A None result with a Tile
-        operand now raises rather than silently using nbytes.
+        Store handlers must propagate ``MemoryOps.store``'s int return
+        as the op result; a None result with a Tile operand violates
+        the contract and raises.
         """
         from ktir_cpu.ir_types import Tile
         from ktir_cpu.latency import LatencyTracker
@@ -1252,13 +1315,11 @@ class TestIndirectAccessLatency:
             LatencyTracker._data_size(None, [src])
 
     def test_data_size_rejects_iat_operand_with_none_result(self):
-        """IAT operand + None result trips the guard — store sideband must fire.
+        """IAT operand with None result raises.
 
-        Pre-sideband, the IAT-operand branch fell back to
-        ``_idx_unique_sticks_no_reads(v) * STICK_BYTES``. The new
-        contract: indirect-store handlers must propagate
-        ``MemoryOps.indirect_store``'s int return. A None result with
-        an IAT operand now raises.
+        Indirect-store handlers must propagate
+        ``MemoryOps.indirect_store``'s int return as the op result; a
+        None result with an IAT operand violates the contract and raises.
         """
         from ktir_cpu.ir_types import IndirectAccessTile, MemRef
         from ktir_cpu.latency import LatencyTracker

--- a/tests/test_latency.py
+++ b/tests/test_latency.py
@@ -878,105 +878,6 @@ class TestIndirectAccessLatency:
         with pytest.raises(ValueError, match="empty address list"):
             accessor.read_scattered([], "i32")
 
-    def test_idx_unique_sticks_no_reads_dedups_repeated_coords(self):
-        """_idx_unique_sticks_no_reads dedups across vss-enumerated points.
-
-        Models a paged-attention-shape access pattern in miniature: a
-        2-D variable space ``(d0, d1)`` where ``idx_exprs = (d0,)``
-        projects out ``d1`` entirely.  Each idx coord (d0=0, d0=1) is
-        looked up |range(d1)| = 4 times — but they live on the same
-        stick (i32 idx, base_ptr=0, addresses 0 and 4 both fall in
-        stick 0 of a 128-byte stick).
-
-        Expected: 1 unique stick (despite 8 enumerated points).
-        """
-        from ktir_cpu.ir_types import IndirectAccessTile, MemRef
-        from ktir_cpu.ops.memory_ops import _idx_unique_sticks_no_reads
-        from ktir_cpu.parser_ast import parse_affine_set
-
-        idx_view = MemRef(
-            base_ptr=0, shape=(64,), strides=[1],
-            memory_space="HBM", dtype="i32",  # bpe=4
-        )
-        iat = IndirectAccessTile(
-            parent_ref=idx_view, shape=(2, 4),
-            dim_subscripts=[
-                {"kind": "indirect", "index_view_idx": 0,
-                 "idx_exprs": [("dim", 0)]},
-            ],
-            index_views=[idx_view],
-            variables_space_set=parse_affine_set(
-                "(d0, d1) : (d0 >= 0, -d0 + 1 >= 0, d1 >= 0, -d1 + 3 >= 0)"
-            ),
-            variables_space_order=None,
-        )
-
-        assert _idx_unique_sticks_no_reads(iat) == 1
-
-    def test_idx_unique_sticks_no_reads_n_distinct_sticks(self):
-        """_idx_unique_sticks_no_reads counts N sticks when each idx coord
-        owns its own stick.
-
-        ``idx_view`` is i32 with one element per stick (stride forces each
-        coord onto a distinct stick).  Enumerating 4 distinct d0 values
-        therefore gives 4 unique sticks.
-        """
-        from ktir_cpu.ir_types import IndirectAccessTile, MemRef
-        from ktir_cpu.ops.memory_ops import _idx_unique_sticks_no_reads
-        from ktir_cpu.parser_ast import parse_affine_set
-
-        # i32 with stride 32 means each idx element is 32 * 4 = 128 bytes
-        # apart — one stick per element.
-        idx_view = MemRef(
-            base_ptr=0, shape=(128,), strides=[32],
-            memory_space="HBM", dtype="i32",
-        )
-        iat = IndirectAccessTile(
-            parent_ref=idx_view, shape=(4,),
-            dim_subscripts=[
-                {"kind": "indirect", "index_view_idx": 0,
-                 "idx_exprs": [("dim", 0)]},
-            ],
-            index_views=[idx_view],
-            variables_space_set=parse_affine_set(
-                "(d0) : (d0 >= 0, -d0 + 3 >= 0)"
-            ),
-            variables_space_order=None,
-        )
-
-        assert _idx_unique_sticks_no_reads(iat) == 4
-
-    def test_idx_unique_sticks_no_reads_returns_zero_for_lx_only_iat(self):
-        """LX has no stick concept — return 0 (defined "no HBM traffic"), not None.
-
-        Reserving ``None`` for "not computed" lets the gated raise in
-        ``_data_size`` catch handlers that forget to populate the field.
-        An LX-only IAT load is a fully legitimate workflow that must
-        report zero HBM idx-side traffic without tripping the guard.
-        """
-        from ktir_cpu.ir_types import IndirectAccessTile, MemRef
-        from ktir_cpu.ops.memory_ops import _idx_unique_sticks_no_reads
-        from ktir_cpu.parser_ast import parse_affine_set
-
-        idx_view = MemRef(
-            base_ptr=0, shape=(64,), strides=[1],
-            memory_space="LX", dtype="i32",
-        )
-        iat = IndirectAccessTile(
-            parent_ref=idx_view, shape=(4,),
-            dim_subscripts=[
-                {"kind": "indirect", "index_view_idx": 0,
-                 "idx_exprs": [("dim", 0)]},
-            ],
-            index_views=[idx_view],
-            variables_space_set=parse_affine_set(
-                "(d0) : (d0 >= 0, -d0 + 3 >= 0)"
-            ),
-            variables_space_order=None,
-        )
-
-        assert _idx_unique_sticks_no_reads(iat) == 0
-
     # ---------------------------------------------------------------------
     # _MemAccessor.count_sticks — single source of truth for stick counting.
     # ---------------------------------------------------------------------
@@ -1091,6 +992,144 @@ class TestIndirectAccessLatency:
         assert sticks is None
 
     # ---------------------------------------------------------------------
+    # _MemAccessor.read_scattered — contiguous-run batching.
+    #
+    # Runs are formed by sorting the unique addresses and merging any pair
+    # whose diff equals ``bpe`` (one element apart in the access dtype).
+    # Each run becomes one ``sim.read(start, n=run_len, dtype, intra_byte)``
+    # call, which models a single DMA descriptor. Number of calls = run
+    # count, which equals 1 for fully dense access and ``unique_sticks``
+    # in the worst case (every address isolated by a gap).
+    # ---------------------------------------------------------------------
+
+    @pytest.mark.parametrize(
+        "addrs,expected_call_args",
+        [
+            # Dense within a stick: all four 4-byte gaps, one run of 4.
+            pytest.param(
+                [0, 4, 8, 12],
+                [(0, 4, "i32", 0)],
+                id="dense_within_stick_one_run",
+            ),
+            # Mid-stick start: intra_byte propagated; one run of 3.
+            pytest.param(
+                [4, 8, 12],
+                [(0, 3, "i32", 4)],
+                id="mid_stick_run_intra_byte_propagated",
+            ),
+            # Two pairs of dense addresses, separated by a stick boundary:
+            # ``[0, 4, 128, 132]`` → two runs of 2 (one per stick).
+            pytest.param(
+                [0, 4, 128, 132],
+                [(0, 2, "i32", 0), (1, 2, "i32", 0)],
+                id="scattered_two_runs_of_two",
+            ),
+            # Two isolated points (gap > bpe between them): two runs of 1.
+            pytest.param(
+                [0, 128],
+                [(0, 1, "i32", 0), (1, 1, "i32", 0)],
+                id="two_isolated_points_two_runs",
+            ),
+            # Repeated address: 1 unique → 1 run; values broadcast in caller order.
+            pytest.param(
+                [0, 0, 0],
+                [(0, 1, "i32", 0)],
+                id="repeated_addr_one_run",
+            ),
+            # Non-monotonic input: caller order ``[12, 0]`` resolves via runs
+            # sorted by address, but values reassemble in input order.
+            pytest.param(
+                [12, 0],
+                [(0, 1, "i32", 0), (0, 1, "i32", 12)],
+                id="non_monotonic_input_runs_sorted_values_in_input_order",
+            ),
+            # Run that crosses a stick boundary: addresses ``[124, 128]``
+            # differ by ``bpe`` so they merge; ``intra_byte=124``, ``n=2``
+            # crosses sticks. ``HBMSimulator._read_flat`` handles this
+            # as long as the underlying allocation spans both sticks.
+            pytest.param(
+                [124, 128],
+                [(0, 2, "i32", 124)],
+                id="run_crosses_stick_boundary_one_call",
+            ),
+        ],
+    )
+    def test_read_scattered_run_batching_call_count_and_args(
+        self, addrs, expected_call_args,
+    ):
+        """read_scattered groups adjacent (diff == bpe) addresses into runs.
+
+        Each run is a single ``sim.read(start, n=run_len, dtype, intra_byte)``
+        call — the simulator-side equivalent of one DMA descriptor.
+        Stubs ``ctx.hbm.read`` with a synthetic byte-addressable layout
+        (``value = (byte_address // 4) + 10``) so the run-merging algorithm
+        can be exercised over arbitrary stick spans without setting up a
+        real HBM region. Verifies (a) actual calls match the expected
+        run decomposition (sorted-address order), (b) returned values
+        reassemble in caller's input order, (c) ``unique_sticks``
+        matches set-dedup over ``addr // 128``.
+        """
+        from ktir_cpu.ops.memory_ops import _MemAccessor
+        from unittest.mock import MagicMock
+
+        def fake_read(stick, n, dtype, *, intra_byte=0):
+            base_byte = stick * 128 + intra_byte
+            return np.array(
+                [(base_byte // 4) + 10 + i for i in range(n)],
+                dtype=np.int32,
+            )
+
+        ctx = MagicMock()
+        ctx.hbm.read = MagicMock(side_effect=fake_read)
+        accessor = _MemAccessor(ctx, "HBM", byte_addr=0)
+
+        values, sticks = accessor.read_scattered(addrs, "i32")
+        # Synthetic layout mirrors the stub: caller sees the byte-address
+        # formula directly, so expected values derive from input addrs.
+        assert list(values) == [(a // 4) + 10 for a in addrs]
+        # Stick count: set-deduped over unique stick indices.
+        assert sticks == len({a // 128 for a in addrs})
+        # Run-batching assertion: one sim.read per run, in sorted-address order.
+        actual_calls = [
+            (c.args[0], c.args[1], c.args[2], c.kwargs.get("intra_byte", 0))
+            for c in ctx.hbm.read.call_args_list
+        ]
+        assert actual_calls == expected_call_args
+
+    def test_read_scattered_run_batching_lx_path(self):
+        """LX run-batching: ``sim.read(byte_addr, n, dtype)``, no intra_byte.
+
+        LX has no stick concept (``stick_bytes = None``), so ``run_start``
+        is passed as the byte address directly. Runs still merge by
+        ``diff == bpe``; the test asserts both the call shape and that
+        ``unique_sticks`` is ``None`` (LX semantics from
+        :meth:`_MemAccessor.count_sticks`).
+        """
+        from ktir_cpu.ops.memory_ops import _MemAccessor
+        from unittest.mock import MagicMock
+
+        def fake_read(byte_addr, n, dtype):
+            base = byte_addr // 4
+            return np.array(
+                [10 * (base + i) for i in range(n)], dtype=np.int32,
+            )
+
+        lx = MagicMock()
+        lx.read = MagicMock(side_effect=fake_read)
+        ctx = MagicMock()
+        ctx.get_lx = MagicMock(return_value=lx)
+        accessor = _MemAccessor(ctx, "LX", byte_addr=0, lx_core_id=0)
+
+        # Two runs: [0, 4, 8] (one run of 3) and [16] (one run of 1).
+        values, sticks = accessor.read_scattered([0, 4, 8, 16], "i32")
+        assert list(values) == [0, 10, 20, 40]
+        assert sticks is None
+        assert lx.read.call_args_list == [
+            ((0, 3, "i32"),),
+            ((16, 1, "i32"),),
+        ]
+
+    # ---------------------------------------------------------------------
     # _data_size — gated raise enforces the IAT-load contract.
     # ---------------------------------------------------------------------
 
@@ -1134,28 +1173,27 @@ class TestIndirectAccessLatency:
             LatencyTracker._data_size(result, [iat])
 
     # ---------------------------------------------------------------------
-    # Guard symmetry — indirect_store charges idx sticks via _data_size's
-    # IAT-operand fallback, mirroring the indirect_load load-side charge.
+    # Store sideband — _data_size charges HBM bytes from the int sideband
+    # returned by MemoryOps.{store, indirect_store, distributed_store}.
+    # The handler propagates that int as the op result; loads still
+    # carry stick counts on the result Tile (guard symmetry).
     # ---------------------------------------------------------------------
 
-    def test_data_size_indirect_store_charges_idx_sticks(self):
-        """Store path: _data_size recomputes idx sticks from the IAT (no result Tile).
+    def test_data_size_int_sideband_charges_stick_bytes(self):
+        """Store path: int result is the unique-stick total; _data_size
+        returns ``result * STICK_BYTES`` regardless of operands.
 
-        ``ktdp.store`` with an indirect access tile has ``result=None``,
-        so the IAT-operand branch in :meth:`LatencyTracker._data_size`
-        falls through to :func:`_idx_unique_sticks_no_reads` rather
-        than reading ``result.index_unique_sticks`` (which doesn't
-        exist). Mirrors the load-side charge for guard symmetry.
-
-        The IAT here enumerates 4 distinct d0 values; idx_view stride
-        forces each onto its own stick → 4 unique sticks → 4 * 128 bytes.
+        The sideband int (returned by ``MemoryOps.indirect_store`` for
+        IATs, or ``MemoryOps.store`` for direct stores) already
+        aggregates both data sticks (destination) and idx sticks (IAT).
+        Operands are therefore ignored by the int branch — this asserts
+        the absence of the pre-fix double-charge that fell through to
+        ``v.data.nbytes`` for the source Tile.
         """
         from ktir_cpu.ir_types import IndirectAccessTile, MemRef, Tile
         from ktir_cpu.latency import LatencyTracker
         from ktir_cpu.parser_ast import parse_affine_set
 
-        # i32 stride 32 → each idx element is 32 * 4 = 128 bytes apart,
-        # one stick per element.
         idx_view = MemRef(
             base_ptr=0, shape=(128,), strides=[32],
             memory_space="HBM", dtype="i32",
@@ -1172,15 +1210,191 @@ class TestIndirectAccessLatency:
             ),
             variables_space_order=None,
         )
-        # Store source tile lands as the second branch's Tile operand;
-        # we only care that the IAT operand branch contributes its idx
-        # sticks. The store source contributes its data.nbytes.
         src = Tile(np.zeros(4, dtype=np.float16), "f16", (4,))
 
-        # result=None (store), operands=[iat, src]:
-        #   IAT branch (store path) → 4 sticks * 128 = 512
-        #   Tile branch (src)       → src.data.nbytes = 8
-        assert LatencyTracker._data_size(None, [iat, src]) == 4 * 128 + 8
+        # result=4 (sideband: total unique sticks for this store);
+        # operands=[iat, src] are ignored on the int branch.
+        assert LatencyTracker._data_size(4, [iat, src]) == 4 * 128
+
+    def test_data_size_int_sideband_direct_store_64x64_scatter(self):
+        """C3 regression: stick-granular accounting beats source.nbytes for scatters.
+
+        Before the sideband fix, ``_data_size`` charged direct stores at
+        ``v.data.nbytes`` — the source tile's logical size, blind to
+        scatter pattern. For a 64×64 f16 tile (8192 bytes) scattered to
+        100 distinct sticks, the real HBM traffic is ``100 * 128 = 12800``
+        bytes (HBM is stick-addressed; partial stick writes still cost
+        the full 128 bytes). The pre-fix path undercounted by 4608 bytes.
+
+        With the sideband, the int (``unique_sticks=100``) carries the
+        correct stick count; ``_data_size`` returns ``100 * 128``.
+        """
+        from ktir_cpu.latency import LatencyTracker
+
+        assert LatencyTracker._data_size(100, []) == 100 * 128
+        assert 100 * 128 != 64 * 64 * 2  # the bug magnitude is non-trivial
+
+    def test_data_size_rejects_tile_operand_with_none_result(self):
+        """Tile operand + None result trips the guard — was the pre-fix bug.
+
+        Pre-sideband, ``_data_size`` fell back to ``v.data.nbytes`` for
+        the source Tile of a store, undercounting any non-stick-aligned
+        scatter. The new contract: store handlers must propagate
+        ``MemoryOps.store``'s int return. A None result with a Tile
+        operand now raises rather than silently using nbytes.
+        """
+        from ktir_cpu.ir_types import Tile
+        from ktir_cpu.latency import LatencyTracker
+
+        src = Tile(np.zeros(4, dtype=np.float16), "f16", (4,))
+
+        with pytest.raises(RuntimeError, match="propagate MemoryOps.store"):
+            LatencyTracker._data_size(None, [src])
+
+    def test_data_size_rejects_iat_operand_with_none_result(self):
+        """IAT operand + None result trips the guard — store sideband must fire.
+
+        Pre-sideband, the IAT-operand branch fell back to
+        ``_idx_unique_sticks_no_reads(v) * STICK_BYTES``. The new
+        contract: indirect-store handlers must propagate
+        ``MemoryOps.indirect_store``'s int return. A None result with
+        an IAT operand now raises.
+        """
+        from ktir_cpu.ir_types import IndirectAccessTile, MemRef
+        from ktir_cpu.latency import LatencyTracker
+        from ktir_cpu.parser_ast import parse_affine_set
+
+        idx_view = MemRef(
+            base_ptr=0, shape=(4,), strides=[1],
+            memory_space="HBM", dtype="i32",
+        )
+        iat = IndirectAccessTile(
+            parent_ref=idx_view, shape=(4,),
+            dim_subscripts=[
+                {"kind": "indirect", "index_view_idx": 0,
+                 "idx_exprs": [("dim", 0)]},
+            ],
+            index_views=[idx_view],
+            variables_space_set=parse_affine_set(
+                "(d0) : (d0 >= 0, -d0 + 3 >= 0)"
+            ),
+            variables_space_order=None,
+        )
+
+        with pytest.raises(RuntimeError, match="without int sideband"):
+            LatencyTracker._data_size(None, [iat])
+
+    # ---------------------------------------------------------------------
+    # LX stores: the sideband int is 0 (no HBM stick concept), and
+    # _data_size charges 0 bytes. These guard against the rejects-tests
+    # above accidentally over-firing on legitimate LX paths — store
+    # handlers must always return an int, never None.
+    # ---------------------------------------------------------------------
+
+    def test_store_returns_zero_for_lx_destination(self):
+        """``MemoryOps.store`` to an LX tile returns ``0``, not ``None``.
+
+        LX has no stick concept, so HBM stick traffic is 0 by definition.
+        The handler propagates that 0 as the op result; ``_data_size``'s
+        int branch fires with ``0 * STICK_BYTES = 0``. Returning ``None``
+        instead would trip ``test_data_size_rejects_tile_operand_with_none_result``
+        on every LX store path.
+        """
+        from ktir_cpu.grid import CoreContext
+        from ktir_cpu.ir_types import MemRef, Tile
+        from ktir_cpu.memory import HBMSimulator, LXScratchpad
+        from ktir_cpu.ops.memory_ops import MemoryOps
+
+        ctx = CoreContext(core_id=0, grid_pos=(0, 0, 0),
+                          lx=LXScratchpad(core_id=0), hbm=HBMSimulator())
+        tile_ref = MemRef(
+            base_ptr=0, shape=(4,), strides=[1],
+            memory_space="LX", dtype="f16",
+        ).to_tile_ref()
+        src = Tile(np.arange(4, dtype=np.float16), "f16", (4,))
+
+        result = MemoryOps.store(ctx, src, tile_ref)
+        assert result == 0
+        assert isinstance(result, int)  # not None
+
+    def test_indirect_store_returns_zero_for_all_lx(self):
+        """``MemoryOps.indirect_store`` returns ``0`` when parent + every
+        idx view live in LX (no HBM traffic on either side).
+        """
+        from ktir_cpu.grid import CoreContext
+        from ktir_cpu.ir_types import IndirectAccessTile, MemRef, Tile
+        from ktir_cpu.memory import HBMSimulator, LXScratchpad
+        from ktir_cpu.ops.memory_ops import MemoryOps
+        from ktir_cpu.parser_ast import parse_affine_set
+
+        lx = LXScratchpad(core_id=0)
+        ctx = CoreContext(core_id=0, grid_pos=(0, 0, 0), lx=lx, hbm=HBMSimulator())
+
+        parent_ptr = 0
+        idx_ptr = 64  # past parent's 8 f16 = 16 bytes; safe non-overlap
+        lx.write(parent_ptr, np.zeros(8, dtype=np.float16))  # seed for read-modify-write
+        lx.write(idx_ptr, np.arange(4, dtype=np.int32))
+
+        parent_ref = MemRef(
+            base_ptr=parent_ptr, shape=(8,), strides=[1],
+            memory_space="LX", dtype="f16",
+        )
+        idx_view = MemRef(
+            base_ptr=idx_ptr, shape=(4,), strides=[1],
+            memory_space="LX", dtype="i32",
+        )
+        iat = IndirectAccessTile(
+            parent_ref=parent_ref, shape=(4,),
+            dim_subscripts=[
+                {"kind": "indirect", "index_view_idx": 0,
+                 "idx_exprs": [("dim", 0)]},
+            ],
+            index_views=[idx_view],
+            variables_space_set=parse_affine_set(
+                "(d0) : (d0 >= 0, -d0 + 3 >= 0)"
+            ),
+            variables_space_order=None,
+        )
+        src = Tile(np.arange(4, dtype=np.float16), "f16", (4,))
+
+        result = MemoryOps.indirect_store(ctx, src, iat)
+        assert result == 0
+        assert isinstance(result, int)
+
+    def test_distributed_store_returns_zero_for_all_lx(self):
+        """``MemoryOps.distributed_store`` returns ``0`` when every
+        surviving partition lives in LX. Mirrors the all-HBM aggregation
+        path but with the LX sentinel (0 sticks per survivor).
+        """
+        from ktir_cpu.affine import BoxSet
+        from ktir_cpu.grid import CoreContext
+        from ktir_cpu.ir_types import (
+            DistributedTileRef, MemRef, Tile, TileRef,
+        )
+        from ktir_cpu.memory import HBMSimulator, LXScratchpad
+        from ktir_cpu.ops.memory_ops import MemoryOps
+
+        ctx = CoreContext(core_id=0, grid_pos=(0, 0, 0),
+                          lx=LXScratchpad(core_id=0), hbm=HBMSimulator())
+
+        ptr = 0
+        memref = MemRef(
+            base_ptr=ptr, shape=(8,), strides=[1],
+            memory_space="LX", dtype="f16",
+        )
+        survivor = TileRef(
+            base_ptr=ptr, shape=(8,), strides=[1], memref=memref, dtype="f16",
+            coordinate_set=BoxSet(lo=(0,), hi=(8,)),
+            partition_origin=(0,),
+        )
+        dist_ref = DistributedTileRef(
+            partitions=[survivor], shape=(8,), dtype="f16", global_base=(0,),
+        )
+        src = Tile(np.arange(8, dtype=np.float16), "f16", (8,))
+
+        result = MemoryOps.distributed_store(ctx, src, dist_ref)
+        assert result == 0
+        assert isinstance(result, int)
 
     # ---------------------------------------------------------------------
     # End-to-end: MemoryOps.indirect_load / .indirect_store actually stash
@@ -1275,19 +1489,19 @@ class TestIndirectAccessLatency:
         )
 
     def test_indirect_store_index_sticks_mirrors_load(self):
-        """Guard symmetry: indirect_store's idx-side stick count matches indirect_load.
+        """Guard symmetry: indirect_store's idx-side count matches indirect_load.
 
-        Both ops share ``_resolve_idx_reads`` for the runtime read and
-        delegate stick counting to ``_MemAccessor.count_sticks``. The
-        latency model recomputes the store-side count via
-        ``_idx_unique_sticks_no_reads(iat)`` (since stores have no
-        result Tile). Pinning the load value and the no-read value
-        equal locks the symmetry — if either path drifts, this trips.
+        Both ops share ``_resolve_idx_reads`` for the runtime read.
+        ``indirect_load`` stamps idx sticks on ``Tile.index_unique_sticks``;
+        ``indirect_store`` returns the same count (plus data sticks) via
+        the int sideband. Pinning load's idx total against the store's
+        return minus its data sticks locks the symmetry — drift on
+        either path trips this test.
         """
         from ktir_cpu.grid import CoreContext
         from ktir_cpu.ir_types import Tile
         from ktir_cpu.memory import HBMSimulator, LXScratchpad
-        from ktir_cpu.ops.memory_ops import MemoryOps, _idx_unique_sticks_no_reads
+        from ktir_cpu.ops.memory_ops import MemoryOps
 
         hbm = HBMSimulator()
         lx = LXScratchpad(size_mb=2, core_id=0)
@@ -1296,20 +1510,17 @@ class TestIndirectAccessLatency:
         iat = self._build_simple_gather_iat(hbm)
 
         load_result = MemoryOps.indirect_load(ctx, iat)
-        load_sticks = load_result.index_unique_sticks
+        load_idx_sticks = load_result.index_unique_sticks
+        load_data_sticks = load_result.unique_sticks
 
-        # Store side: _data_size goes through _idx_unique_sticks_no_reads,
-        # which is the no-IO mirror of _resolve_idx_reads' stick count.
-        store_sticks = _idx_unique_sticks_no_reads(iat)
-
-        assert load_sticks == store_sticks == 4, (
-            f"load idx sticks={load_sticks}, store idx sticks={store_sticks}, "
-            f"expected both to be 4"
-        )
-
-        # Smoke-test the actual store call (does it execute, does it
-        # leave HBM in a consistent state). Source is i32 zeros sized
-        # to match the IAT shape; we already seeded X to zeros so the
-        # store is effectively a no-op write.
+        # Store side: returned int = data_sticks + idx_sticks. Subtract
+        # data_sticks (1 stick: 8×8 f16 = 128 bytes = 1 stick) to recover
+        # the idx-side count and assert symmetry against the load.
         src_tile = Tile(np.zeros((8, 8), dtype=np.float16), "f16", (8, 8))
-        MemoryOps.indirect_store(ctx, src_tile, iat)
+        store_total_sticks = MemoryOps.indirect_store(ctx, src_tile, iat)
+        store_idx_sticks = store_total_sticks - load_data_sticks
+
+        assert load_idx_sticks == store_idx_sticks == 4, (
+            f"load idx sticks={load_idx_sticks}, "
+            f"store idx sticks={store_idx_sticks}, expected both to be 4"
+        )

--- a/tests/test_latency_modeling.py
+++ b/tests/test_latency_modeling.py
@@ -396,17 +396,17 @@ class TestModelingAssumptions:
         expected_compute = (tile / base_cfg.simd_elements_per_cycle)
         assert report.counters[0].compute_cycles == pytest.approx(expected_compute, rel=1e-6)
 
-        # memory_cycles: loads charged at stick granularity, stores at packed bytes.
-        # Per core: 2 loads + 1 store.  Each op handles `tile` f16 elements.
+        # memory_cycles: HBM is stick-addressed, so both loads and stores
+        # ceil to stick boundary. Per core: 2 loads + 1 store, each op
+        # handles `tile` f16 elements over a contiguous, stick-aligned
+        # tile (the kernel splits along the leading dim only).
         from ktir_cpu.memory import HBMSimulator
         STICK_BYTES = HBMSimulator.STICK_BYTES
         bpe = 2  # f16
         tile_bytes = tile * bpe
-        # Contiguous stick-aligned loads: ceil to stick boundary
-        load_sticks = (tile_bytes + STICK_BYTES - 1) // STICK_BYTES
-        load_bytes_per_op = load_sticks * STICK_BYTES
-        store_bytes_per_op = tile_bytes
-        mem_bytes_per_core = 2 * load_bytes_per_op + store_bytes_per_op
+        sticks_per_op = (tile_bytes + STICK_BYTES - 1) // STICK_BYTES
+        bytes_per_op = sticks_per_op * STICK_BYTES
+        mem_bytes_per_core = 3 * bytes_per_op
         expected_mem = mem_bytes_per_core / cfg.hbm_bytes_per_cycle_per_core
         assert report.counters[0].memory_cycles == pytest.approx(expected_mem, rel=1e-6)
 
@@ -546,16 +546,17 @@ class TestModelingAssumptions:
         expected_compute = (tile / cfg.simd_elements_per_cycle) * cfg.transcendental_penalty
         assert compute_vals[0] == pytest.approx(expected_compute, rel=1e-6)
 
-        # memory_cycles: loads at stick granularity, stores at packed bytes.
-        # Per core: 1 load + 1 store, each handling `tile` f16 elements.
+        # memory_cycles: HBM is stick-addressed — loads and stores both
+        # ceil to stick boundary. Per core: 1 load + 1 store, each
+        # handling `tile` f16 elements over a contiguous, stick-aligned
+        # tile.
         from ktir_cpu.memory import HBMSimulator
         STICK_BYTES = HBMSimulator.STICK_BYTES
         bpe = 2  # f16
         tile_bytes = tile * bpe
-        load_sticks = (tile_bytes + STICK_BYTES - 1) // STICK_BYTES
-        load_bytes = load_sticks * STICK_BYTES
-        store_bytes = tile_bytes
-        expected_memory = (load_bytes + store_bytes) / cfg.hbm_bytes_per_cycle_per_core
+        sticks_per_op = (tile_bytes + STICK_BYTES - 1) // STICK_BYTES
+        bytes_per_op = sticks_per_op * STICK_BYTES
+        expected_memory = (2 * bytes_per_op) / cfg.hbm_bytes_per_cycle_per_core
         assert memory_vals[0] == pytest.approx(expected_memory, rel=1e-6)
 
     # --- Test 4: tile size → memory cycles proportional ---


### PR DESCRIPTION
# [Fix] Make HBM stick accounting consistent across load and store

Addresses #61.

## The fix

Stores never returned the unique-stick count they computed. The latency model fell back to either source-tile `nbytes` (which undercounts non-stick-aligned scatter) or a no-IO mirror (which only existed because `indirect_store` discarded its own count).

The fix is structural: every store entry point — `MemoryOps.store`, `indirect_store`, `distributed_store` — returns an `int` unique-stick count, the `ktdp.store` handler propagates it as the op result, and `LatencyTracker._data_size` charges `result * STICK_BYTES`. KTIR-level semantics are unchanged (stores still produce no IR result; the `int` is an interpreter-only convention). All `v.data.nbytes` fallbacks are deleted on both load and store paths; any Tile or IAT operand whose unique-stick field is unpopulated raises `RuntimeError` so handler regressions surface immediately.

LX targets return `0`, not `None`. "Stick count is ill-defined for LX" stays a helper-level concept (`_MemAccessor.count_sticks` still returns `None`); the public-op return is "this op generated zero HBM sticks" — same type-shape as HBM, no `None` in the sideband channel.

`_MemAccessor.read_scattered` was rewritten to batch unique addresses into contiguous runs — one `sim.read` per run; runs may cross stick boundaries since DMA descriptors are `(start, length)`. The `_idx_unique_sticks_no_reads` helper is deleted; it existed only because `indirect_store` discarded its count.

## Where the change lives

- `ktir_cpu/ops/memory_ops.py` — `read_scattered` rewritten to contiguous-run batching; `MemoryOps.{store,indirect_store,distributed_store}` signatures `-> int`; `_idx_unique_sticks_no_reads` deleted; `_resolve_idx_reads` skips views whose enumerated address list is empty so a degenerate (zero-extent) variable space stops short-circuiting through a misleading post-loop invariant message.
- `ktir_cpu/dialects/ktdp_ops.py` — `ktdp.store` handler returns the `int` from each branch instead of `return None`.
- `ktir_cpu/latency.py` — `_data_size` dispatches on `isinstance(result, int)` first; `v.data.nbytes` fallback removed; strict raises pin the handler contract.
- `tests/test_latency.py` and `tests/test_latency_modeling.py` — see Tests.

## Concerns we worked through

**`read_scattered` cross-allocation invariant.** All addresses must lie within a single HBM allocation; cross-allocation calls would silently zero-fill because `HBMSimulator._read_flat` reads one allocation only. The invariant is declared in the docstring; hard-guarding requires the simulator to expose allocation extent and is tracked in #67.

**Run boundaries don't split at stick edges.** `read_scattered` cuts on `diff > bpe` only. Each run maps to a single DMA block transfer; `HBMSimulator._read_flat` already handles cross-stick reads within one allocation. Call count = run count, bounded by `unique_sticks` (best case = 1 for fully dense). Pinned by `test_read_scattered_run_crosses_stick_boundary_one_call`.

**LX = 0 sticks at the public-op boundary, not None.** Every store handler returns `int`, so the strict raises in `_data_size` only fire on genuine handler bugs, never on legitimate LX paths. The "ill-defined for LX" semantics stay one layer down where they're useful for LX-vs-HBM dispatch.

**`distributed_store` returns `int` even though the original review didn't request it.** All three store variants share the same dialect-handler branch and the same `_data_size` consumer; one-off behavior on the distributed path would force the handler to dispatch on store type before deciding whether to return. Symmetric `int` keeps the contract uniform.

## Open question

- **Paged-attention E2E fixture.** We owe a paged-attention E2E (same shape family as RFC §5 Example 2, `(4, 8, 2048, 128)`). Reuse `examples/rfc/indirect-access-copy.mlir` if representative enough, or add a new `.mlir`. You know this repo's tolerance for new fixtures better than I do.

## Tests

In `tests/test_latency.py`:

- **`read_scattered` contract** — `test_read_scattered_*` (8 parametrize cases: dense/scattered/repeated/cross-stick/subset/LX) lock call count = run count, run boundaries cut on `diff > bpe`, intra-byte propagated, values reassembled in caller order.
- **Int-sideband semantics** — `test_data_size_int_sideband_charges_stick_bytes`, `test_data_size_int_sideband_direct_store_64x64_scatter` (C3 regression pin: `100 * 128 = 12800` vs the prior `64 * 64 * 2 = 8192` logical-bytes proxy — 4608-byte undercount).
- **Strict-raise guards** — `test_data_size_rejects_{tile,iat}_operand_with_none_result`, `test_data_size_raises_when_tile_result_missing_unique_sticks`, `test_data_size_raises_when_iat_load_result_missing_index_unique_sticks`. All use `pytest.raises(RuntimeError, match=...)`.
- **LX = 0 contract** — `test_store_returns_zero_for_lx_destination`, `test_indirect_store_returns_zero_for_all_lx`, `test_distributed_store_returns_zero_for_all_lx`.
- **Load ↔ store symmetry** — `test_indirect_store_index_sticks_mirrors_load` (`store_total_sticks - load_data_sticks == load_idx_sticks` on the same IAT), plus the preserved `test_indirect_load_index_sticks_simple_gather`.
- **Zero-extent IAT skip** — `test_resolve_idx_reads_zero_extent_skips_view`.
- Preserved load-side IAT pins: `test_data_size_charges_index_unique_sticks`, `test_data_size_iat_load_skips_operand_branch_when_result_field_set[…]`.

In `tests/test_latency_modeling.py`:

- `test_work_splitting_{elementwise,transcendental}[4|8]` — expected store cost changed from `tile_bytes` to `sticks_per_op * STICK_BYTES`. The earlier parametrization was pinning the C3 bug; under the fix the correct expectation is stick-granular.