### PR TITLE
Support non-identity variables_space_order in indirect_load/store

### DIFF
--- a/ktir_cpu/affine.py
+++ b/ktir_cpu/affine.py
@@ -98,7 +98,7 @@ class AffineMap:
         return eval_affine_map(self, dims)
 
     def is_identity(self) -> bool:
-        """Return True if this map is the identity: output == input for all inputs.
+        """Return True if this map is the identity: output[i] == d_i for every i.
 
         Used at parse time to detect trivial coordinate-order maps.  When
         ``access_tile_order`` is an identity map it has no effect on which
@@ -106,16 +106,51 @@ class AffineMap:
         ``coordinate_order`` to ``None``.  This allows load/store to skip
         the per-coord ``cso.eval()`` calls and, combined with a full
         ``coordinate_set``, enables the contiguous fast path entirely.
+
+        Implemented structurally: each output expression must flatten to
+        ``1 * d_i + 0`` with output position ``i`` matching the dim index.
+        A probe-based ``eval(probe) == probe`` check would accept maps
+        like ``(d0, d1) -> (d1 - 1, d0 + 1)`` (probe ``[1,2]`` → ``(1,2)``),
+        which are not identity.
         """
-        # Quick structural check: same number of inputs and outputs, and each
-        # output expression is just the corresponding input dimension variable.
         if len(self.exprs) != self.n_dims:
             return False
-        # Verify by evaluation: identity map satisfies eval(dims) == dims for
-        # a non-trivial probe vector.  Using [1, 2, ..., n_dims] avoids false
-        # positives from constant-zero expressions.
-        probe = list(range(1, self.n_dims + 1))
-        return list(self.eval(probe)) == probe
+        for i, expr in enumerate(self.exprs):
+            idx = _expr_as_single_dim(expr, self.n_dims)
+            if idx != i:
+                return False
+        return True
+
+    def is_permutation(self) -> bool:
+        """Return True if this map permutes its input dimensions.
+
+        A permutation map is square (output count equals input count) and
+        each output expression is exactly one dim variable, with every dim
+        index appearing exactly once.  Accepts coordinate permutations
+        like ``(d0, d1, d2) -> (d2, d0, d1)``; rejects shears, scalings,
+        constant offsets, and many-to-one collapses.
+
+        Used by ops whose semantics require iteration over the input space
+        in a permuted order (e.g. ``variables_space_order`` on indirect
+        access tiles): the implementation sorts enumerated points by the
+        map's image, which is well-defined only when the image is a
+        permutation of the original points.
+
+        Implemented structurally on the parsed AST.  A probe-based
+        ``sorted(eval(probe)) == probe`` check would accept linear
+        combinations such as ``(d0, d1) -> (d0 + d1 - 2, d0 + d1 - 1)``
+        (probe ``[1,2]`` → ``(1,2)``), which are not coordinate
+        permutations.
+        """
+        if len(self.exprs) != self.n_dims:
+            return False
+        seen = set()
+        for expr in self.exprs:
+            idx = _expr_as_single_dim(expr, self.n_dims)
+            if idx is None or idx in seen:
+                return False
+            seen.add(idx)
+        return True
 
 
 @dataclass(frozen=True)
@@ -323,6 +358,29 @@ class BoxSet:
         if any(v is None for v in los) or any(v is None for v in his):
             return None
         return cls(lo=tuple(los), hi=tuple(his))  # type: ignore[arg-type]
+
+
+def _expr_as_single_dim(node: "_Node", n_dims: int) -> Optional[int]:
+    """Return ``i`` if *node* is structurally equivalent to ``1 * d_i + 0``.
+
+    Returns ``None`` for any expression that flattens to a linear form
+    with a non-zero constant, a non-unit coefficient, or coefficients on
+    more than one dim variable.  Used by :meth:`AffineMap.is_identity`
+    and :meth:`AffineMap.is_permutation` for structural checks that
+    cannot be fooled by linear combinations whose evaluation on a
+    specific probe happens to coincide with the probe (e.g.
+    ``d0 + d1 - 2`` evaluates to ``1`` on probe ``[1, 2]``).
+    """
+    lin = _constraint_to_linear(node, n_dims)
+    if lin is None:
+        return None
+    coeffs, const = lin
+    if const != 0:
+        return None
+    nz = [i for i, k in enumerate(coeffs) if k != 0]
+    if len(nz) != 1 or coeffs[nz[0]] != 1:
+        return None
+    return nz[0]
 
 
 def _constraint_to_linear(node: "_Node", n_dims: int) -> Optional[Tuple[List[int], int]]:

--- a/ktir_cpu/affine.py
+++ b/ktir_cpu/affine.py
@@ -116,7 +116,7 @@ class AffineMap:
         if len(self.exprs) != self.n_dims:
             return False
         for i, expr in enumerate(self.exprs):
-            idx = _expr_as_single_dim(expr, self.n_dims)
+            idx = _match_pure_dim_ref(expr, self.n_dims)
             if idx != i:
                 return False
         return True
@@ -146,7 +146,7 @@ class AffineMap:
             return False
         seen = set()
         for expr in self.exprs:
-            idx = _expr_as_single_dim(expr, self.n_dims)
+            idx = _match_pure_dim_ref(expr, self.n_dims)
             if idx is None or idx in seen:
                 return False
             seen.add(idx)
@@ -360,16 +360,31 @@ class BoxSet:
         return cls(lo=tuple(los), hi=tuple(his))  # type: ignore[arg-type]
 
 
-def _expr_as_single_dim(node: "_Node", n_dims: int) -> Optional[int]:
-    """Return ``i`` if *node* is structurally equivalent to ``1 * d_i + 0``.
+def _match_pure_dim_ref(node: "_Node", n_dims: int) -> Optional[int]:
+    """Match *node* against ``1 * d_i + 0`` and return ``i``, else ``None``.
 
-    Returns ``None`` for any expression that flattens to a linear form
-    with a non-zero constant, a non-unit coefficient, or coefficients on
-    more than one dim variable.  Used by :meth:`AffineMap.is_identity`
-    and :meth:`AffineMap.is_permutation` for structural checks that
-    cannot be fooled by linear combinations whose evaluation on a
-    specific probe happens to coincide with the probe (e.g.
-    ``d0 + d1 - 2`` evaluates to ``1`` on probe ``[1, 2]``).
+    A "pure dim ref" is an expression that flattens (via
+    :func:`_constraint_to_linear`) to exactly one dim variable with unit
+    coefficient and zero constant.  Used by :meth:`AffineMap.is_identity`
+    and :meth:`AffineMap.is_permutation` for structural checks that cannot
+    be fooled by linear combinations whose evaluation on a specific probe
+    happens to coincide with the probe (e.g. ``d0 + d1 - 2`` evaluates to
+    ``1`` on probe ``[1, 2]``).
+
+    Because matching goes through ``_constraint_to_linear``,
+    algebraically-equivalent forms collapse to the same flattened
+    representation: ``d0 + 0`` and ``d0 + d1 - d1`` both flatten to
+    ``1 * d0 + 0`` and match identically to bare ``d0``.
+
+    Examples (n_dims=3)::
+
+        d0           -> 0
+        d2           -> 2
+        d1 + 0       -> 1     # zero constant ok
+        d0 + 1       -> None  # non-zero constant
+        2 * d0       -> None  # non-unit coefficient
+        d0 + d1      -> None  # more than one dim
+        -d0          -> None  # coefficient -1, not 1
     """
     lin = _constraint_to_linear(node, n_dims)
     if lin is None:

--- a/ktir_cpu/ops/memory_ops.py
+++ b/ktir_cpu/ops/memory_ops.py
@@ -167,6 +167,25 @@ class _MemAccessor:
         self._sim.write(*self._args, data, **self._kwargs)
 
 
+def _enumerate_in_vso_order(iat: "IndirectAccessTile") -> List[Tuple[int, ...]]:
+    """Enumerate variable-space points in ``variables_space_order``-permuted order.
+
+    Identity (or absent) ``vso`` returns the natural row-major enumeration;
+    otherwise points are sorted by ``vso.eval(pt)`` per RFC 0682 §473.
+
+    Both :func:`_resolve_idx_reads` and :func:`_build_indirect_coords` route
+    through this so their pt iteration stays in lockstep — they consume
+    ``idx_values`` positionally, so any divergence would silently mismatch
+    indirect dims to coords.  Callers are expected to have already rejected
+    non-permutation ``vso`` upstream; this function trusts the guard.
+    """
+    points = iat.variables_space_set.enumerate(iat.shape)
+    vso = iat.variables_space_order
+    if vso is not None and not vso.is_identity():
+        points = sorted(points, key=lambda pt: vso.eval(pt))
+    return points
+
+
 def _resolve_idx_reads(
     context: CoreContext, iat: "IndirectAccessTile",
 ) -> Tuple[Dict[int, np.ndarray], int]:
@@ -195,7 +214,7 @@ def _resolve_idx_reads(
     ``indirect_store`` both call it so their stick accounting stays in
     sync (guard symmetry).
     """
-    points = iat.variables_space_set.enumerate(iat.shape)
+    points = _enumerate_in_vso_order(iat)
     indirect_subs = [s for s in iat.dim_subscripts if s.get("kind") == "indirect"]
 
     # Hoist per-view loop-invariants once before enumerating points.
@@ -263,7 +282,7 @@ def _build_indirect_coords(
     Shared by ``indirect_load`` and ``indirect_store`` so their coord
     construction stays in lockstep (guard symmetry).
     """
-    points = iat.variables_space_set.enumerate(iat.shape)
+    points = _enumerate_in_vso_order(iat)
     idx_iters = {iv_idx: iter(values) for iv_idx, values in idx_values.items()}
 
     coords: List[Tuple[int, ...]] = []
@@ -579,17 +598,26 @@ class MemoryOps:
         (direct dims use the variable value, indirect dims look up the
         index in an index memref), then delegates to :meth:`load`.
 
-        Raises NotImplementedError if ``variables_space_order`` is non-identity.
+        ``variables_space_order``, when non-identity, sets a permuted
+        iteration order over the variable space: enumerated points are
+        sorted by the map's image and visited in that order.  Subscript
+        resolution evaluates each ``idx_exprs`` against the variable-space
+        point.  The map must be a coordinate permutation; non-permutation
+        maps are rejected with ``ValueError``.  See RFC 0682 §473.
         """
         vso = iat.variables_space_order
-        if vso is not None and not vso.is_identity():
-            raise NotImplementedError(
-                "indirect_load: output tile permutation via non-identity "
-                "variables_space_order is not yet implemented"
+        if vso is not None and not vso.is_permutation():
+            raise ValueError(
+                f"indirect_load: variables_space_order must permute its input "
+                f"dimensions; got non-permutation map: {vso.source}"
             )
 
         # Resolve every idx-tensor read up front: one accessor per index
         # view, one read_scattered call, sticks deduped inside the accessor.
+        # Both helpers route their pt enumeration through
+        # _enumerate_in_vso_order, so non-identity vso permutes the
+        # iteration order consistently across idx reads and coord build
+        # (RFC 0682 §473).
         idx_values, idx_unique_sticks = _resolve_idx_reads(context, iat)
         coords = _build_indirect_coords(iat, idx_values)
 
@@ -907,15 +935,17 @@ class MemoryOps:
             )
 
         vso = iat.variables_space_order
-        if vso is not None and not vso.is_identity():
-            raise NotImplementedError(
-                "indirect_store: output tile permutation via non-identity "
-                "variables_space_order is not yet implemented"
+        if vso is not None and not vso.is_permutation():
+            raise ValueError(
+                f"indirect_store: variables_space_order must permute its input "
+                f"dimensions; got non-permutation map: {vso.source}"
             )
 
         # Resolve idx reads (returns idx_unique_sticks: int, 0 for all-LX
         # views) and delegate the data write to MemoryOps.store (returns
-        # int: HBM stick count, 0 for LX).
+        # int: HBM stick count, 0 for LX).  Both helpers enumerate via
+        # _enumerate_in_vso_order so non-identity vso permutes the
+        # iteration order consistently with indirect_load (RFC 0682 §473).
         idx_values, idx_unique_sticks = _resolve_idx_reads(context, iat)
         coords = _build_indirect_coords(iat, idx_values)
         data_sticks = MemoryOps.store(

--- a/tests/test_affine.py
+++ b/tests/test_affine.py
@@ -148,6 +148,17 @@ class TestAffineMapIsIdentity:
         m = parse_affine_map("affine_map<(d0, d1) -> (d0 + 0, 1 * d1)>")
         assert m.is_identity()
 
+    def test_identity_through_cancellation(self):
+        """Subtractive cancellation must collapse through flatten.
+
+        ``d0 + d1 - d1`` flattens to ``1 * d0 + 0`` and ``d1 + d0 - d0``
+        flattens to ``1 * d1 + 0``, so the map is identity.  Pins the
+        flatten-form contract: a future syntactic-only matcher would
+        reject these forms and silently regress the structural check.
+        """
+        m = parse_affine_map("affine_map<(d0, d1) -> (d0 + d1 - d1, d1 + d0 - d0)>")
+        assert m.is_identity()
+
 
 class TestAffineSetObject:
     """AffineSet behaviour on sets that are *not* lowerable to BoxSet."""

--- a/tests/test_affine.py
+++ b/tests/test_affine.py
@@ -55,6 +55,100 @@ class TestAffineMapObject:
             m.n_dims = 99  # type: ignore[misc]
 
 
+class TestAffineMapIsPermutation:
+    """is_permutation() detects coordinate-permutation affine maps.
+
+    Used as a precondition guard for ops whose semantics require sorting
+    enumerated points by the map's image (e.g. ``variables_space_order``
+    on indirect access tiles).  Non-permutation maps would produce
+    duplicate sort keys with undefined relative output positions.
+    """
+
+    def test_1d_identity(self):
+        """1-D edge: ``(d0) -> (d0)`` is the trivial permutation."""
+        m = parse_affine_map("affine_map<(d0) -> (d0)>")
+        assert m.is_permutation()
+
+    def test_identity(self):
+        m = parse_affine_map("affine_map<(d0, d1, d2) -> (d0, d1, d2)>")
+        assert m.is_permutation()
+
+    def test_2d_swap(self):
+        m = parse_affine_map("affine_map<(d0, d1) -> (d1, d0)>")
+        assert m.is_permutation()
+
+    def test_3d_cycle(self):
+        m = parse_affine_map("affine_map<(d0, d1, d2) -> (d2, d0, d1)>")
+        assert m.is_permutation()
+
+    def test_shear_rejected(self):
+        m = parse_affine_map("affine_map<(d0, d1) -> (d0 + d1, d1)>")
+        assert not m.is_permutation()
+
+    def test_many_to_one_rejected(self):
+        m = parse_affine_map("affine_map<(d0, d1) -> (d0, d0)>")
+        assert not m.is_permutation()
+
+    def test_non_square_rejected(self):
+        m = parse_affine_map("affine_map<(d0, d1) -> (d0)>")
+        assert not m.is_permutation()
+
+    def test_linear_combination_rejected(self):
+        """Regression: probe-based ``sorted(eval(probe)) == probe`` accepts
+        ``(d0+d1-2, d0+d1-1)`` because probe ``[1,2]`` happens to give
+        ``(1,2)``.  Structural check rejects it: neither output is a
+        single dim variable.  pt=(3,1) → (2,3), confirming non-permutation
+        behaviour at runtime.
+        """
+        m = parse_affine_map("affine_map<(d0, d1) -> (d0 + d1 - 2, d0 + d1 - 1)>")
+        assert not m.is_permutation()
+        assert m.eval([3, 1]) == (2, 3)  # would shift the box if accepted
+
+    def test_constant_offset_rejected(self):
+        """``(d1-1, d0+1)`` shifts both coordinates; not a coordinate
+        permutation.  Probe ``[1,2]`` evaluates to ``(1,2)`` and would slip
+        past a probe-based check.
+        """
+        m = parse_affine_map("affine_map<(d0, d1) -> (d1 - 1, d0 + 1)>")
+        assert not m.is_permutation()
+
+    def test_trivial_wrappers_accepted(self):
+        """Permutations expressed with redundant ``+0`` / ``1*`` wrappers
+        still accepted — the structural check flattens to linear form
+        before inspecting coefficients.
+        """
+        m = parse_affine_map("affine_map<(d0, d1) -> (1 * d1 + 0, d0)>")
+        assert m.is_permutation()
+
+
+class TestAffineMapIsIdentity:
+    """is_identity() detects the strict coordinate-identity map.
+
+    Regression for a probe-based check that accepts linear combinations
+    whose evaluation on ``[1, 2, ..., n]`` happens to coincide with the
+    probe (e.g. ``(d1-1, d0+1)`` on probe ``[1,2]`` returns ``(1,2)``).
+    The structural check requires each output ``i`` to be exactly
+    ``d_i``.
+    """
+
+    def test_identity_accepted(self):
+        m = parse_affine_map("affine_map<(d0, d1) -> (d0, d1)>")
+        assert m.is_identity()
+
+    def test_swap_rejected(self):
+        m = parse_affine_map("affine_map<(d0, d1) -> (d1, d0)>")
+        assert not m.is_identity()
+
+    def test_constant_offset_rejected(self):
+        m = parse_affine_map("affine_map<(d0, d1) -> (d1 - 1, d0 + 1)>")
+        assert not m.is_identity()
+
+    def test_trivial_wrappers_accepted(self):
+        """``d0 + 0`` and ``1 * d0`` flatten to ``d0`` and remain identity."""
+        m = parse_affine_map("affine_map<(d0, d1) -> (d0 + 0, 1 * d1)>")
+        assert m.is_identity()
+
+
 class TestAffineSetObject:
     """AffineSet behaviour on sets that are *not* lowerable to BoxSet."""
 

--- a/tests/test_indirect_access.py
+++ b/tests/test_indirect_access.py
@@ -472,3 +472,383 @@ def test_negative_indirect_index_raises(mlir, func_name):
 
     with pytest.raises(IndexError, match="is negative"):
         interp.execute_function(func_name)
+
+
+# ---------------------------------------------------------------------------
+# Non-identity variables_space_order
+# ---------------------------------------------------------------------------
+# RFC 0682 §473: vso defines lexicographic traversal order over the variable
+# space (rightmost output = innermost iteration).  These fixtures exercise the
+# non-identity branch by templating the vso affine_map into a 4x4 IAT shell.
+
+def _gather_vso_mlir_4x4(vso_str: str, func_name: str) -> str:
+    """4x4 indirect gather fixture parameterised on variables_space_order."""
+    return f"""
+#coord_set_4x4   = affine_set<(d0, d1) : (d0 >= 0, -d0 + 3 >= 0, d1 >= 0, -d1 + 3 >= 0)>
+#var_space_order = affine_map<{vso_str}>
+#cso_identity    = affine_map<(d0, d1) -> (d0, d1)>
+
+module {{
+  func.func @{func_name}() attributes {{grid = [1, 1]}} {{
+    %X_addr    = arith.constant 0 : index
+    %IDX1_addr = arith.constant 1 : index
+    %IDX2_addr = arith.constant 2 : index
+    %Y_addr    = arith.constant 3 : index
+
+    %X = ktdp.construct_memory_view %X_addr, sizes: [4, 4], strides: [4, 1] {{
+        coordinate_set = #coord_set_4x4,
+        memory_space = #ktdp.spyre_memory_space<HBM>
+    }} : memref<4x4xf16>
+
+    %IDX1 = ktdp.construct_memory_view %IDX1_addr, sizes: [4, 4], strides: [4, 1] {{
+        coordinate_set = #coord_set_4x4,
+        memory_space = #ktdp.spyre_memory_space<HBM>
+    }} : memref<4x4xi32>
+
+    %IDX2 = ktdp.construct_memory_view %IDX2_addr, sizes: [4, 4], strides: [4, 1] {{
+        coordinate_set = #coord_set_4x4,
+        memory_space = #ktdp.spyre_memory_space<HBM>
+    }} : memref<4x4xi32>
+
+    %Y_view = ktdp.construct_memory_view %Y_addr, sizes: [4, 4], strides: [4, 1] {{
+        coordinate_set = #coord_set_4x4,
+        memory_space = #ktdp.spyre_memory_space<HBM>
+    }} : memref<4x4xf16>
+
+    %X_access_tile = ktdp.construct_indirect_access_tile
+        intermediate_variables(%m, %k)
+        %X[ind(%IDX1[%m, %k]), ind(%IDX2[%m, %k])] {{
+            variables_space_set = #coord_set_4x4,
+            variables_space_order = #var_space_order
+        }} : memref<4x4xf16>, memref<4x4xi32>, memref<4x4xi32> -> !ktdp.access_tile<4x4xindex>
+
+    %c0 = arith.constant 0 : index
+    %Y_access_tile = ktdp.construct_access_tile %Y_view[%c0, %c0] {{
+        access_tile_set   = #coord_set_4x4,
+        access_tile_order = #cso_identity
+    }} : memref<4x4xf16> -> !ktdp.access_tile<4x4xindex>
+
+    %X_data_tile = ktdp.load %X_access_tile : !ktdp.access_tile<4x4xindex> -> tensor<4x4xf16>
+    ktdp.store %X_data_tile, %Y_access_tile : tensor<4x4xf16>, !ktdp.access_tile<4x4xindex>
+
+    return
+  }}
+}}
+"""
+
+
+def _scatter_vso_mlir_4x4(vso_str: str, func_name: str) -> str:
+    """4x4 indirect scatter fixture parameterised on variables_space_order."""
+    return f"""
+#coord_set_4x4   = affine_set<(d0, d1) : (d0 >= 0, -d0 + 3 >= 0, d1 >= 0, -d1 + 3 >= 0)>
+#var_space_order = affine_map<{vso_str}>
+#cso_identity    = affine_map<(d0, d1) -> (d0, d1)>
+
+module {{
+  func.func @{func_name}() attributes {{grid = [1, 1]}} {{
+    %X_addr    = arith.constant 0 : index
+    %IDX1_addr = arith.constant 1 : index
+    %IDX2_addr = arith.constant 2 : index
+    %Y_addr    = arith.constant 3 : index
+
+    %X_view = ktdp.construct_memory_view %X_addr, sizes: [4, 4], strides: [4, 1] {{
+        coordinate_set = #coord_set_4x4,
+        memory_space = #ktdp.spyre_memory_space<HBM>
+    }} : memref<4x4xf16>
+
+    %IDX1 = ktdp.construct_memory_view %IDX1_addr, sizes: [4, 4], strides: [4, 1] {{
+        coordinate_set = #coord_set_4x4,
+        memory_space = #ktdp.spyre_memory_space<HBM>
+    }} : memref<4x4xi32>
+
+    %IDX2 = ktdp.construct_memory_view %IDX2_addr, sizes: [4, 4], strides: [4, 1] {{
+        coordinate_set = #coord_set_4x4,
+        memory_space = #ktdp.spyre_memory_space<HBM>
+    }} : memref<4x4xi32>
+
+    %Y_view = ktdp.construct_memory_view %Y_addr, sizes: [4, 4], strides: [4, 1] {{
+        coordinate_set = #coord_set_4x4,
+        memory_space = #ktdp.spyre_memory_space<HBM>
+    }} : memref<4x4xf16>
+
+    %c0 = arith.constant 0 : index
+    %X_access_tile = ktdp.construct_access_tile %X_view[%c0, %c0] {{
+        access_tile_set   = #coord_set_4x4,
+        access_tile_order = #cso_identity
+    }} : memref<4x4xf16> -> !ktdp.access_tile<4x4xindex>
+
+    %Y_access_tile = ktdp.construct_indirect_access_tile
+        intermediate_variables(%m, %k)
+        %Y_view[ind(%IDX1[%m, %k]), ind(%IDX2[%m, %k])] {{
+            variables_space_set = #coord_set_4x4,
+            variables_space_order = #var_space_order
+        }} : memref<4x4xf16>, memref<4x4xi32>, memref<4x4xi32> -> !ktdp.access_tile<4x4xindex>
+
+    %X_data_tile = ktdp.load %X_access_tile : !ktdp.access_tile<4x4xindex> -> tensor<4x4xf16>
+    ktdp.store %X_data_tile, %Y_access_tile : tensor<4x4xf16>, !ktdp.access_tile<4x4xindex>
+
+    return
+  }}
+}}
+"""
+
+
+def _seed_swap_4x4(interp):
+    """X = 0..15 row-major; IDX1[m,k]=m; IDX2[m,k]=k; Y zeroed."""
+    _orig = interp._prepare_execution
+    def _prepare_and_seed(grid_shape):
+        _orig(grid_shape)
+        hbm = interp.memory.hbm
+        hbm.write(0, np.arange(16, dtype=np.float16))                       # X[m,k] = m*4+k
+        hbm.write(1, np.repeat(np.arange(4, dtype=np.int32), 4))            # IDX1[m,k] = m
+        hbm.write(2, np.tile(np.arange(4, dtype=np.int32), 4))              # IDX2[m,k] = k
+        hbm.write(3, np.zeros(16, dtype=np.float16))                        # Y zeroed
+    interp._prepare_execution = _prepare_and_seed
+
+
+@pytest.mark.parametrize(
+    "mlir_factory,func_name",
+    [
+        (_gather_vso_mlir_4x4,  "gather_swap_vso"),
+        (_scatter_vso_mlir_4x4, "scatter_swap_vso"),
+    ],
+    ids=["indirect_load_4x4_swap", "indirect_store_4x4_swap"],
+)
+def test_swap_vso(mlir_factory, func_name):
+    """A swap vso (d0,d1)->(d1,d0) reorders iteration to (d1,d0); with
+    identity-coord IDX (IDX1[m,k]=m, IDX2[m,k]=k) the result Y equals X
+    transposed.
+
+    The same expected Y holds for both load (gather X via IAT then store
+    direct) and store (load X direct then scatter via IAT) — vso is applied
+    on the IAT side in both directions.
+
+    Subscript resolution must use the variable-space point (not vso(pt)):
+    IDX values are sensitive to which point is passed in, so a wrong
+    implementation that fed vso(pt) to the subscripts would produce X
+    itself rather than X^T at non-symmetric positions.
+    """
+    mlir = mlir_factory("(d0, d1) -> (d1, d0)", func_name)
+    interp = KTIRInterpreter()
+    interp.load(mlir)
+    _seed_swap_4x4(interp)
+    interp.execute_function(func_name)
+
+    y_data = interp.memory.hbm.read(3, 16, "f16").reshape(4, 4)
+    # Y[r, c] = X[c, r] = c*4 + r
+    expected = np.array(
+        [[c * 4 + r for c in range(4)] for r in range(4)],
+        dtype=np.float16,
+    )
+    np.testing.assert_array_equal(y_data, expected)
+
+
+# 3-D 2x2x2 fixture for the canonical 3-cycle vso example (RFC 0682 §473
+# worked through in issue #58 discussion).  The 3-cycle is non-involution,
+# so this case distinguishes the sort-then-gather implementation from any
+# apply-then-load alternative that happens to coincide on involutions.
+_SMALL_3D_INDIRECT_GATHER_3CYCLE_MLIR = """
+#coord_set_2x2x2 = affine_set<(d0, d1, d2) : (d0 >= 0, -d0 + 1 >= 0, d1 >= 0, -d1 + 1 >= 0, d2 >= 0, -d2 + 1 >= 0)>
+#vso_3cycle      = affine_map<(d0, d1, d2) -> (d2, d0, d1)>
+#cso_identity_3d = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+
+module {
+  func.func @small_3d_indirect_gather_3cycle() attributes {grid = [1, 1]} {
+    %X_addr   = arith.constant 0 : index
+    %IDX_addr = arith.constant 1 : index
+    %Y_addr   = arith.constant 2 : index
+
+    %X = ktdp.construct_memory_view %X_addr, sizes: [2, 2, 2], strides: [4, 2, 1] {
+        coordinate_set = #coord_set_2x2x2,
+        memory_space = #ktdp.spyre_memory_space<HBM>
+    } : memref<2x2x2xf16>
+
+    %IDX = ktdp.construct_memory_view %IDX_addr, sizes: [2, 2, 2], strides: [4, 2, 1] {
+        coordinate_set = #coord_set_2x2x2,
+        memory_space = #ktdp.spyre_memory_space<HBM>
+    } : memref<2x2x2xi32>
+
+    %Y_view = ktdp.construct_memory_view %Y_addr, sizes: [2, 2, 2], strides: [4, 2, 1] {
+        coordinate_set = #coord_set_2x2x2,
+        memory_space = #ktdp.spyre_memory_space<HBM>
+    } : memref<2x2x2xf16>
+
+    %X_access_tile = ktdp.construct_indirect_access_tile
+        intermediate_variables(%m, %k, %l)
+        %X[ind(%IDX[%m, %k, %l]), (%k), (%l)] {
+            variables_space_set = #coord_set_2x2x2,
+            variables_space_order = #vso_3cycle
+        } : memref<2x2x2xf16>, memref<2x2x2xi32> -> !ktdp.access_tile<2x2x2xindex>
+
+    %c0 = arith.constant 0 : index
+    %Y_access_tile = ktdp.construct_access_tile %Y_view[%c0, %c0, %c0] {
+        access_tile_set   = #coord_set_2x2x2,
+        access_tile_order = #cso_identity_3d
+    } : memref<2x2x2xf16> -> !ktdp.access_tile<2x2x2xindex>
+
+    %X_data_tile = ktdp.load %X_access_tile : !ktdp.access_tile<2x2x2xindex> -> tensor<2x2x2xf16>
+    ktdp.store %X_data_tile, %Y_access_tile : tensor<2x2x2xf16>, !ktdp.access_tile<2x2x2xindex>
+
+    return
+  }
+}
+"""
+
+
+def test_indirect_load_with_3cycle_vso():
+    """3-D non-involution vso (d0,d1,d2)->(d2,d0,d1) — the canonical
+    worked example from RFC 0682 §473 / issue #58.
+
+    Setup: X[m,k,l] = m*4+k*2+l (values 0..7), IDX[m,k,l] = m, dims 1+2 are
+    direct (k, l) — so the gather coordinate is just (m, k, l) and each
+    point reads X[pt].
+
+    Sort key under the 3-cycle is (l, m, k); enumerated points sorted by
+    this key visit (in lex sort-key order):
+        (0,0,0)→X=0, (0,1,0)→X=2, (1,0,0)→X=4, (1,1,0)→X=6,
+        (0,0,1)→X=1, (0,1,1)→X=3, (1,0,1)→X=5, (1,1,1)→X=7
+    Reshaped to (2,2,2) row-major:
+        [[[0, 2], [4, 6]],
+         [[1, 3], [5, 7]]]
+
+    A non-3-cycle implementation (e.g. apply-then-load) would land at a
+    different layout for this input — distinguishing this from the
+    involution case caught by test_swap_vso.
+    """
+    interp = KTIRInterpreter()
+    interp.load(_SMALL_3D_INDIRECT_GATHER_3CYCLE_MLIR)
+    _orig = interp._prepare_execution
+    def _prepare_and_seed(grid_shape):
+        _orig(grid_shape)
+        hbm = interp.memory.hbm
+        hbm.write(0, np.arange(8, dtype=np.float16))                        # X
+        hbm.write(1, np.array([0, 0, 0, 0, 1, 1, 1, 1], dtype=np.int32))    # IDX[m,k,l]=m
+        hbm.write(2, np.zeros(8, dtype=np.float16))                         # Y zeroed
+    interp._prepare_execution = _prepare_and_seed
+
+    interp.execute_function("small_3d_indirect_gather_3cycle")
+
+    y_data = interp.memory.hbm.read(2, 8, "f16").reshape(2, 2, 2)
+    expected = np.array(
+        [[[0, 2], [4, 6]],
+         [[1, 3], [5, 7]]],
+        dtype=np.float16,
+    )
+    np.testing.assert_array_equal(y_data, expected)
+
+
+_SMALL_3D_INDIRECT_SCATTER_3CYCLE_MLIR = """
+#coord_set_2x2x2 = affine_set<(d0, d1, d2) : (d0 >= 0, -d0 + 1 >= 0, d1 >= 0, -d1 + 1 >= 0, d2 >= 0, -d2 + 1 >= 0)>
+#vso_3cycle      = affine_map<(d0, d1, d2) -> (d2, d0, d1)>
+#cso_identity_3d = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+
+module {
+  func.func @small_3d_indirect_scatter_3cycle() attributes {grid = [1, 1]} {
+    %X_addr   = arith.constant 0 : index
+    %IDX_addr = arith.constant 1 : index
+    %Y_addr   = arith.constant 2 : index
+
+    %X_view = ktdp.construct_memory_view %X_addr, sizes: [2, 2, 2], strides: [4, 2, 1] {
+        coordinate_set = #coord_set_2x2x2,
+        memory_space = #ktdp.spyre_memory_space<HBM>
+    } : memref<2x2x2xf16>
+
+    %IDX = ktdp.construct_memory_view %IDX_addr, sizes: [2, 2, 2], strides: [4, 2, 1] {
+        coordinate_set = #coord_set_2x2x2,
+        memory_space = #ktdp.spyre_memory_space<HBM>
+    } : memref<2x2x2xi32>
+
+    %Y_view = ktdp.construct_memory_view %Y_addr, sizes: [2, 2, 2], strides: [4, 2, 1] {
+        coordinate_set = #coord_set_2x2x2,
+        memory_space = #ktdp.spyre_memory_space<HBM>
+    } : memref<2x2x2xf16>
+
+    %c0 = arith.constant 0 : index
+    %X_access_tile = ktdp.construct_access_tile %X_view[%c0, %c0, %c0] {
+        access_tile_set   = #coord_set_2x2x2,
+        access_tile_order = #cso_identity_3d
+    } : memref<2x2x2xf16> -> !ktdp.access_tile<2x2x2xindex>
+
+    %Y_access_tile = ktdp.construct_indirect_access_tile
+        intermediate_variables(%m, %k, %l)
+        %Y_view[ind(%IDX[%m, %k, %l]), (%k), (%l)] {
+            variables_space_set = #coord_set_2x2x2,
+            variables_space_order = #vso_3cycle
+        } : memref<2x2x2xf16>, memref<2x2x2xi32> -> !ktdp.access_tile<2x2x2xindex>
+
+    %X_data_tile = ktdp.load %X_access_tile : !ktdp.access_tile<2x2x2xindex> -> tensor<2x2x2xf16>
+    ktdp.store %X_data_tile, %Y_access_tile : tensor<2x2x2xf16>, !ktdp.access_tile<2x2x2xindex>
+
+    return
+  }
+}
+"""
+
+
+def test_indirect_store_with_3cycle_vso():
+    """Mirror of :func:`test_indirect_load_with_3cycle_vso` on the store
+    side.  Read X identity-direct, scatter through Y with vso=3-cycle.
+
+    Sort key under the 3-cycle is (l, m, k); enumerated points sort to:
+        [(0,0,0), (0,1,0), (1,0,0), (1,1,0),
+         (0,0,1), (0,1,1), (1,0,1), (1,1,1)]
+    With IDX[m,k,l]=m the resolved write coord equals the variable-space
+    point itself, so ``Y[sorted_pts[i]] = X.flatten()[i]``.
+
+    Crucial vs the involution case in :func:`test_swap_vso`: a 3-cycle is
+    non-self-inverse, so any implementation that writes ``Y[vso(pt)]``
+    instead of using vso only as an iteration sort key would land at a
+    different layout — distinguishing the spec'd sort-then-scatter
+    semantics from any apply-then-store alternative.
+    """
+    interp = KTIRInterpreter()
+    interp.load(_SMALL_3D_INDIRECT_SCATTER_3CYCLE_MLIR)
+    _orig = interp._prepare_execution
+    def _prepare_and_seed(grid_shape):
+        _orig(grid_shape)
+        hbm = interp.memory.hbm
+        hbm.write(0, np.arange(8, dtype=np.float16))                        # X[m,k,l]
+        hbm.write(1, np.array([0, 0, 0, 0, 1, 1, 1, 1], dtype=np.int32))    # IDX[m,k,l]=m
+        hbm.write(2, np.zeros(8, dtype=np.float16))                         # Y zeroed
+    interp._prepare_execution = _prepare_and_seed
+
+    interp.execute_function("small_3d_indirect_scatter_3cycle")
+
+    y_data = interp.memory.hbm.read(2, 8, "f16").reshape(2, 2, 2)
+    expected = np.array(
+        [[[0, 4], [1, 5]],
+         [[2, 6], [3, 7]]],
+        dtype=np.float16,
+    )
+    np.testing.assert_array_equal(y_data, expected)
+
+
+@pytest.mark.parametrize(
+    "mlir_factory,func_name",
+    [
+        (_gather_vso_mlir_4x4,  "gather_bad_vso"),
+        (_scatter_vso_mlir_4x4, "scatter_bad_vso"),
+    ],
+    ids=["indirect_load_non_perm", "indirect_store_non_perm"],
+)
+def test_non_permutation_vso_raises(mlir_factory, func_name):
+    """A non-permutation vso (here (d0,d1)->(d0,d0), which collapses two
+    inputs to the same output) must be rejected at op-execution time, not
+    silently ordered.  Stable sort on duplicate keys would cluster
+    same-key points together — that is well-defined Python but produces
+    semantically meaningless output for the spec."""
+    mlir = mlir_factory("(d0, d1) -> (d0, d0)", func_name)
+    interp = KTIRInterpreter()
+    interp.load(mlir)
+    _orig = interp._prepare_execution
+    def _prepare(grid_shape):
+        _orig(grid_shape)
+        hbm = interp.memory.hbm
+        hbm.write(0, np.zeros(16, dtype=np.float16))    # X
+        hbm.write(1, np.zeros(16, dtype=np.int32))      # IDX1
+        hbm.write(2, np.zeros(16, dtype=np.int32))      # IDX2
+        hbm.write(3, np.zeros(16, dtype=np.float16))    # Y
+    interp._prepare_execution = _prepare
+
+    with pytest.raises(ValueError, match="must permute its input dimensions"):
+        interp.execute_function(func_name)


### PR DESCRIPTION
Addresses #58.

## The change

Replaces the `NotImplementedError` for non-identity `variables_space_order` (vso) in `MemoryOps.indirect_load` / `MemoryOps.indirect_store` with a sort-then-gather implementation per RFC 0682 §473: enumerate the indirect access tile in declared order, then reorder by `vso.eval` before each gather/scatter.

## Where the change lives

- `ktir_cpu/ops/memory_ops.py` — drop `NotImplementedError`; add a permutation guard on vso at both `indirect_load` and `indirect_store` entries (rejects non-bijective maps with `ValueError("... must permute its input dimensions ...")`); introduce a module-level `_enumerate_in_vso_order(iat)` helper that returns the variable-space points sorted by `vso.eval` (identity / absent vso falls through to the natural row-major enumeration). The two #65 helpers `_resolve_idx_reads` and `_build_indirect_coords` each route their `points = ...` line through this helper, so the indirect-side and the coord-build side stay lockstep without changing #65's public helper API.
- `ktir_cpu/affine.py` — replace probe-based `is_identity` / `is_permutation` with structural AST checks (`_expr_as_single_dim` reusing `_constraint_to_linear`). The probe-based versions accepted false positives such as `(d0+d1-2, d0+d1-1)` evaluating to `(1, 2)` on probe `[1, 2]`. The structural check inspects each output expression at the AST level and admits only `1 * d_i + 0` forms.
- `tests/test_affine.py` — `TestAffineMapIsPermutation` (10 cases including 1-D edge, 3-cycle, shear/many-to-one/non-square/linear-combination/constant-offset rejections, trivial-wrapper acceptance) and `TestAffineMapIsIdentity` (4 cases pinning the probe-bug regressions).
- `tests/test_indirect_access.py` — swap-vso load+store, 3-cycle vso load+store on a 2×2×2 fixture (chosen because non-involution distinguishes correct sort-then-gather from any apply-then-load implementation), and a parameterised non-permutation-rejected case with `match="must permute its input dimensions"`.

## What is NOT changing

- **`coordinate_space_order` (cso) direct-path semantics.** This PR is scoped to vso on the indirect path; cso is untouched. See "Deferred" below.
- **Dynamic-shape / symbolic vso.** `AffineMap` parsing rejects symbol forms today; vso here is dim-only. Symbolic bounds will compose with the existing `n_syms` plumbing (PR #42) when needed.
- **ODS-level verification.** The bijection check lives in the runtime path; the dialect verifier in `ktir-mlir-frontend` is unchanged.

## Concerns we worked through

- **Sort-then-gather vs apply-then-load.** RFC §473's iteration-order wording, as clarified in #58's worked example, is satisfied by either implementation when vso is an involution (e.g. a single swap), but they diverge for non-involutions. The 2×2×2 3-cycle fixture pins this: expected outputs are derived by direct simulation, not closed-form, so any future implementation that drifts to apply-then-load will fail the test rather than silently match.
- **Why structural over probe for `is_identity` / `is_permutation`.** Any cheap probe has linear-combination collisions for general n; the structural check reuses the existing `_constraint_to_linear` primitive and admits only `1 * d_i + 0` per output.
- **Guard non-redundancy.** Identity is a permutation, so `not vso.is_identity() and not vso.is_permutation()` reduces to `not vso.is_permutation()`. Kept the single check; identity remains the fast path that skips the sort.
- **Store-side symmetry.** Store applies the same sort key as load. This matters for non-involution vso: the scatter-side ordering must match the gather-side ordering produced by an upstream `indirect_load`, otherwise a load→store round-trip with the same vso is not a no-op. Pinned by `test_indirect_store_with_3cycle_vso`.
- **Rebased on #65; sort placement.** #65 split the indirect path into `_resolve_idx_reads` + `_build_indirect_coords`, which both consume a separate `enumerate(iat.shape)`. A literal "hoist the sort before the helpers" form would have required widening #65's public helper signatures to take a pre-computed `points` argument. Instead, both helpers route their enumeration through `_enumerate_in_vso_order(iat)`, which is the single source of truth for vso ordering — same external behavior, no API churn on the just-merged #65 surface.

## Tests added

- `tests/test_affine.py` — 14 cases on `is_permutation` + `is_identity` (1-D edge through 3-cycle, plus probe-collision regressions: `(d0+d1-2, d0+d1-1)` and `(d1-1, d0+1)`).
- `tests/test_indirect_access.py` — 4×4 swap-vso load+store; 2×2×2 3-cycle load+store (expected from direct simulation, distinguishes sort-then-gather from apply-then-load on non-involutions); parameterised non-permutation rejection with `match="must permute its input dimensions"`.

Full suite went 775 → 795 passed (+20) on top of the post-#65 main baseline (1 skipped, 7 xfailed unchanged); the structural `is_identity` tightening did not break any existing fixture.

## Deferred to follow-ups

- **`coordinate_space_order` direct-path consistency.** RFC §394 (cso) and §473 (vso) use the same lexicographic-traversal language, but `MemoryOps.{load, store}` apply cso pointwise on the direct path while the indirect path here uses sort-then-gather. Either §394's text means something subtly different from §473, or the direct path has a latent inconsistency. Will file a separate issue once we agree on the reading — happy to draft it. Flag if you read §394 differently and this is a non-issue.
- Bulk vectorisation of the sort+gather path is scoped to #52 (bulk-read refactor across load/store); not in this PR.
- ODS-level vso bijection verifier in `ktir-mlir-frontend` (no second non-identity-permutation consumer yet).
- Symbolic / dynamic-shape vso composing with `n_syms` (no current consumer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)