### PR TITLE
[Feature] affine eq node: first-class == constraint in affine sets

### DIFF
--- a/ktir_cpu/affine.py
+++ b/ktir_cpu/affine.py
@@ -440,6 +440,7 @@ class BoxSet:
     def try_from_affine_set(cls, aset: "AffineSet") -> Optional["BoxSet"]:
         """Lower an axis-aligned :class:`AffineSet` to a ``BoxSet``.
 
+<<<<<<< HEAD
         Returns ``None`` when the set is not representable as an integer
         box.  Lowering succeeds iff every constraint has the form
         ``c * d_i + k(syms) >= 0`` with ``c ∈ {+1, -1}`` (single dim,
@@ -458,6 +459,27 @@ class BoxSet:
         that themselves carry a symbol, or non-linear symbol products
         cause this function to return ``None`` so the set stays on the
         AffineSet slow path.
+=======
+        Returns ``None`` when the set cannot be represented as an integer box.
+
+        Each constraint must be a single-dim, unit-coefficient expression:
+
+          Inequality  ``±d_i + const >= 0``:
+            +d_i  →  d_i >= -const          →  tightens lo[i]
+            -d_i  →  d_i <=  const          →  tightens hi[i] (exclusive: const+1)
+
+          Equality  ``±d_i + const == 0``:
+            +d_i  →  d_i == -const          →  pins both lo[i] = -const, hi[i] = -const+1
+            -d_i  →  d_i ==  const          →  pins both lo[i] =  const, hi[i] =  const+1
+
+        Multiple constraints on the same axis intersect: lo takes the max,
+        hi takes the min.  Lowering fails if any axis ends up with no lo or
+        no hi bound.
+
+        TODO: symbolic sets (n_syms > 0) are rejected — BoxSet carries only
+        integer bounds.  getattr keeps this correct on older AffineSet objects
+        without n_syms.
+>>>>>>> f0cfdbf ([Feature] affine eq node: first-class == constraint in affine sets)
         """
         from .parser_ast import sym_add, sym_max, sym_min, sym_neg
 
@@ -466,7 +488,9 @@ class BoxSet:
         los: List[Optional["Bound"]] = [None] * n
         his: List[Optional["Bound"]] = [None] * n
         for c in aset.constraints:
-            lin = _constraint_to_linear_syms(c, n, n_syms)
+            is_eq = (c[0] == "eq")
+            expr = c[1] if is_eq else c
+            lin = _constraint_to_linear_syms(expr, n, n_syms)
             if lin is None:
                 return None
             dim_coeffs, sym_coeffs, const = lin
@@ -475,18 +499,24 @@ class BoxSet:
                 return None
             i = nz[0]
             k = dim_coeffs[i]
-            # Build k(syms) as a Bound: int constant + sum(sym_coeffs[j] * s_j).
+            if abs(k) != 1:
+                return None
+            # Build k(syms): int constant + sum(sym_coeffs[j] * s_j).
             sym_term = _build_sym_term(sym_coeffs, const)
-            if k == 1:
+            if is_eq:
+                # k*d_i + k(syms) == 0  →  d_i == pin
+                pin = sym_neg(sym_term) if k == 1 else sym_term
+                los[i] = pin             if los[i] is None else sym_max(los[i], pin)
+                his[i] = sym_add(pin, 1) if his[i] is None else sym_min(his[i], sym_add(pin, 1))
+            elif k == 1:
                 # d_i + k(syms) >= 0  →  d_i >= -k(syms)
                 candidate = sym_neg(sym_term)
                 los[i] = candidate if los[i] is None else sym_max(los[i], candidate)
-            elif k == -1:
-                # -d_i + k(syms) >= 0  →  d_i <= k(syms)  →  hi = k(syms) + 1
+            else:
+                # -d_i + k(syms) >= 0  →  d_i <= k(syms)  →  hi exclusive = k(syms) + 1
                 candidate = sym_add(sym_term, 1)
                 his[i] = candidate if his[i] is None else sym_min(his[i], candidate)
-            else:
-                return None
+
         if any(v is None for v in los) or any(v is None for v in his):
             return None
         return cls(lo=tuple(los), hi=tuple(his))  # type: ignore[arg-type]

--- a/ktir_cpu/affine.py
+++ b/ktir_cpu/affine.py
@@ -440,46 +440,25 @@ class BoxSet:
     def try_from_affine_set(cls, aset: "AffineSet") -> Optional["BoxSet"]:
         """Lower an axis-aligned :class:`AffineSet` to a ``BoxSet``.
 
-<<<<<<< HEAD
         Returns ``None`` when the set is not representable as an integer
         box.  Lowering succeeds iff every constraint has the form
-        ``c * d_i + k(syms) >= 0`` with ``c ∈ {+1, -1}`` (single dim,
-        unit coeff) and every axis is pinned on **both** sides (at least
-        one ``+d_i`` and one ``-d_i`` constraint).  ``k(syms)`` may be
-        an integer constant or a linear combination of symbol variables
-        and integers — in the symbolic case the resulting ``lo`` / ``hi``
-        carry an AST node (see :data:`Bound`) instead of a plain ``int``.
+        ``c * d_i + k(syms) >= 0`` or ``c * d_i + k(syms) == 0`` with
+        ``c ∈ {+1, -1}`` (single dim, unit coeff) and every axis is
+        pinned on **both** sides.  ``k(syms)`` may be an integer constant
+        or a linear combination of symbol variables — in the symbolic case
+        the resulting ``lo`` / ``hi`` carry an AST node (see :data:`Bound`)
+        instead of a plain ``int``.
 
-        Bounds on the same axis that come from multiple constraints are
-        combined with ``max`` (lo) / ``min`` (hi) — see
-        :func:`sym_max` / :func:`sym_min` for the MVP folding.
+        Equality constraints pin both ``lo[i]`` and ``hi[i]`` to the
+        solved value (``hi`` is exclusive, so ``hi = pin + 1``).
+        Inequality / equality bounds on the same axis are combined with
+        ``sym_max`` (lo) / ``sym_min`` (hi).
 
         Assumes all symbols ``s_i >= 0`` (matches dim-size semantics).
         Constraints with non-``±1`` dim coefficients, dim coefficients
         that themselves carry a symbol, or non-linear symbol products
         cause this function to return ``None`` so the set stays on the
         AffineSet slow path.
-=======
-        Returns ``None`` when the set cannot be represented as an integer box.
-
-        Each constraint must be a single-dim, unit-coefficient expression:
-
-          Inequality  ``±d_i + const >= 0``:
-            +d_i  →  d_i >= -const          →  tightens lo[i]
-            -d_i  →  d_i <=  const          →  tightens hi[i] (exclusive: const+1)
-
-          Equality  ``±d_i + const == 0``:
-            +d_i  →  d_i == -const          →  pins both lo[i] = -const, hi[i] = -const+1
-            -d_i  →  d_i ==  const          →  pins both lo[i] =  const, hi[i] =  const+1
-
-        Multiple constraints on the same axis intersect: lo takes the max,
-        hi takes the min.  Lowering fails if any axis ends up with no lo or
-        no hi bound.
-
-        TODO: symbolic sets (n_syms > 0) are rejected — BoxSet carries only
-        integer bounds.  getattr keeps this correct on older AffineSet objects
-        without n_syms.
->>>>>>> f0cfdbf ([Feature] affine eq node: first-class == constraint in affine sets)
         """
         from .parser_ast import sym_add, sym_max, sym_min, sym_neg
 
@@ -489,7 +468,7 @@ class BoxSet:
         his: List[Optional["Bound"]] = [None] * n
         for c in aset.constraints:
             is_eq = (c[0] == "eq")
-            expr = c[1] if is_eq else c
+            expr = ("sub", c[1], c[2]) if is_eq else c
             lin = _constraint_to_linear_syms(expr, n, n_syms)
             if lin is None:
                 return None
@@ -519,6 +498,12 @@ class BoxSet:
 
         if any(v is None for v in los) or any(v is None for v in his):
             return None
+        # For concrete boxes, detect contradictions early (e.g. d0 >= 5, d0 <= 3).
+        # Symbolic boxes may resolve to contradictions at specialize time; callers
+        # can detect that via is_empty(symbols=...) after specialising.
+        if all(isinstance(lo, int) and isinstance(hi, int) for lo, hi in zip(los, his)):
+            if any(los[i] >= his[i] for i in range(n)):  # type: ignore[operator]
+                return None
         return cls(lo=tuple(los), hi=tuple(his))  # type: ignore[arg-type]
 
 

--- a/ktir_cpu/parser_ast.py
+++ b/ktir_cpu/parser_ast.py
@@ -95,7 +95,7 @@ _TOKEN_RE = re.compile(
     r'(%[a-zA-Z_]\w*)'               # named reference %name (group 1)
     r'|([a-zA-Z_]\w*)'               # bare identifier  (group 2)
     r'|(-?\d+)'                      # integer literal, possibly negative (group 3)
-    r'|(>=|<=|->|[+\-*(),:[\]])'     # operator / punctuation incl. [ ]  (group 4)
+    r'|(==|>=|<=|->|[+\-*(),:[\]])'  # operator / punctuation; == before >= (group 4)
     r')'
 )
 
@@ -284,27 +284,27 @@ class _Parser:
         return exprs
 
     def parse_constraint_list(self) -> List[_Node]:
-        """Parse ``(lhs >= rhs, lhs <= rhs, ...)`` and return normalised nodes.
+        """Parse ``(lhs >= rhs, lhs <= rhs, lhs == rhs, ...)`` and return nodes.
 
-        Each constraint is normalised to ``lhs - rhs >= 0``:
+        Inequality constraints are normalised to ``lhs - rhs >= 0``:
           - ``lhs >= rhs``  → stored as ``("sub", lhs, rhs)``
           - ``lhs <= rhs``  → stored as ``("sub", rhs, lhs)``
 
-        The special case ``expr >= 0`` / ``expr <= 0`` is handled naturally
-        since ``("sub", expr, 0_const)`` evaluates identically to ``expr``.
+        Equality constraints are stored as a first-class node:
+          - ``lhs == rhs``  → stored as ``("eq", lhs, rhs)``
         """
         self.consume("(")
         constraints: List[_Node] = []
         while self.peek() != ")":
             lhs = self.parse_expr()
-            op = self.consume()  # ">=" or "<="
+            op = self.consume()  # ">=", "<=", or "=="
             rhs = self.parse_expr()
             if op == ">=":
-                # lhs >= rhs  →  lhs - rhs >= 0
                 node = ("sub", lhs, rhs)
             elif op == "<=":
-                # lhs <= rhs  →  rhs - lhs >= 0
                 node = ("sub", rhs, lhs)
+            elif op == "==":
+                node = ("eq", ("sub", lhs, rhs))
             else:
                 raise ValueError(f"Unsupported constraint operator: {op!r}")
             constraints.append(node)
@@ -453,6 +453,8 @@ def _eval_node(node: _Node, dims: List[int], syms: Optional[List[int]] = None) -
         return max(_eval_node(node[1], dims, syms), _eval_node(node[2], dims, syms))
     if tag == "min":
         return min(_eval_node(node[1], dims, syms), _eval_node(node[2], dims, syms))
+    if tag == "eq":
+        return _eval_node(node[1], dims, syms)
     raise ValueError(f"Unknown AST node tag: {tag!r}")  # pragma: no cover
 
 
@@ -481,7 +483,10 @@ def affine_set_contains(aset: AffineSet, point: Sequence[int], symbols: Sequence
     """Return True if *point* satisfies all constraints in *aset*."""
     env = list(point)
     syms = list(symbols)
-    return all(_eval_node(c, env, syms) >= 0 for c in aset.constraints)
+    return all(
+        _eval_node(c, env, syms) == 0 if c[0] == "eq" else _eval_node(c, env, syms) >= 0
+        for c in aset.constraints
+    )
 
 
 def enumerate_affine_set(aset: AffineSet, shape: Tuple[int, ...], symbols: Sequence[int] = ()) -> List[Tuple[int, ...]]:

--- a/ktir_cpu/parser_ast.py
+++ b/ktir_cpu/parser_ast.py
@@ -290,7 +290,7 @@ class _Parser:
           - ``lhs >= rhs``  → stored as ``("sub", lhs, rhs)``
           - ``lhs <= rhs``  → stored as ``("sub", rhs, lhs)``
 
-        Equality constraints are stored as a first-class node:
+        Equality constraints are stored as a first-class 3-tuple:
           - ``lhs == rhs``  → stored as ``("eq", lhs, rhs)``
         """
         self.consume("(")
@@ -304,7 +304,7 @@ class _Parser:
             elif op == "<=":
                 node = ("sub", rhs, lhs)
             elif op == "==":
-                node = ("eq", ("sub", lhs, rhs))
+                node = ("eq", lhs, rhs)
             else:
                 raise ValueError(f"Unsupported constraint operator: {op!r}")
             constraints.append(node)
@@ -453,8 +453,6 @@ def _eval_node(node: _Node, dims: List[int], syms: Optional[List[int]] = None) -
         return max(_eval_node(node[1], dims, syms), _eval_node(node[2], dims, syms))
     if tag == "min":
         return min(_eval_node(node[1], dims, syms), _eval_node(node[2], dims, syms))
-    if tag == "eq":
-        return _eval_node(node[1], dims, syms)
     raise ValueError(f"Unknown AST node tag: {tag!r}")  # pragma: no cover
 
 
@@ -484,7 +482,8 @@ def affine_set_contains(aset: AffineSet, point: Sequence[int], symbols: Sequence
     env = list(point)
     syms = list(symbols)
     return all(
-        _eval_node(c, env, syms) == 0 if c[0] == "eq" else _eval_node(c, env, syms) >= 0
+        _eval_node(c[1], env, syms) == _eval_node(c[2], env, syms) if c[0] == "eq"
+        else _eval_node(c, env, syms) >= 0
         for c in aset.constraints
     )
 

--- a/tests/test_affine.py
+++ b/tests/test_affine.py
@@ -378,10 +378,32 @@ class TestTryFromAffineSet:
         aset = self._parse_aset("affine_set<(d0) : (2 * d0 >= 0, -d0 + 3 >= 0)>")
         assert BoxSet.try_from_affine_set(aset) is None
 
+    def test_accept_eq_and_range(self):
+        """d0 == 2, 1 <= d1 <= 3  →  BoxSet(lo=(2, 1), hi=(3, 4))."""
+        aset = self._parse_aset(
+            "affine_set<(d0, d1) : (d0 - 2 == 0, d1 - 1 >= 0, -d1 + 3 >= 0)>"
+        )
+        box = BoxSet.try_from_affine_set(aset)
+        assert box == BoxSet(lo=(2, 1), hi=(3, 4))
+
     def test_reject_one_axis_unpinned(self):
         """2D set where d1 has no upper bound."""
         aset = self._parse_aset(
             "affine_set<(d0, d1) : (d0 >= 0, -d0 + 3 >= 0, d1 >= 0)>"
+        )
+        assert BoxSet.try_from_affine_set(aset) is None
+
+    def test_reject_axis_with_no_constraints(self):
+        """2D set where d1 has no constraints at all — both lo and hi missing."""
+        aset = self._parse_aset(
+            "affine_set<(d0, d1) : (d0 >= 0, -d0 + 3 >= 0)>"
+        )
+        assert BoxSet.try_from_affine_set(aset) is None
+
+    def test_reject_eq_pins_one_axis_other_unconstrained(self):
+        """2D set where d0 is pinned by eq but d1 has no constraints."""
+        aset = self._parse_aset(
+            "affine_set<(d0, d1) : (d0 == 0)>"
         )
         assert BoxSet.try_from_affine_set(aset) is None
 
@@ -523,3 +545,79 @@ def eval_bound_eq(b, symbols, expected):
     """Helper: evaluate a Bound and assert it matches *expected*."""
     from ktir_cpu.parser_ast import eval_bound
     return eval_bound(b, symbols) == expected
+
+
+class TestEqualityBoxSetLowering:
+    """BoxSet.try_from_affine_set handles ("eq", lhs, rhs) directly."""
+
+    def test_eq_pins_single_dim(self):
+        """affine_set<(g) : (g == 0)> lowers to BoxSet(lo=(0,), hi=(1,))."""
+        s = parse_affine_set("affine_set<(g) : (g == 0)>")
+        assert isinstance(s, BoxSet)
+        assert s == BoxSet(lo=(0,), hi=(1,))
+
+    def test_eq_i_equals_zero(self):
+        """Spec example: affine_set<(i) : (i == 0)>."""
+        s = parse_affine_set("affine_set<(i) : (i == 0)>")
+        assert isinstance(s, BoxSet)
+        assert s == BoxSet(lo=(0,), hi=(1,))
+
+    def test_eq_nonzero_pin(self):
+        """g == 3 lowers to BoxSet(lo=(3,), hi=(4,))."""
+        s = parse_affine_set("affine_set<(g) : (g - 3 == 0)>")
+        assert isinstance(s, BoxSet)
+        assert s == BoxSet(lo=(3,), hi=(4,))
+
+    def test_eq_pin_and_ineq_intersection(self):
+        """g == 0 combined with inequality g <= 5 — pin wins: lo=0, hi=1."""
+        from ktir_cpu.parser_ast import parse_affine_set_raw
+        from ktir_cpu.affine import BoxSet as _BoxSet
+        aset = parse_affine_set_raw("affine_set<(g) : (g == 0, -g + 5 >= 0)>")
+        box = _BoxSet.try_from_affine_set(aset)
+        assert box == BoxSet(lo=(0,), hi=(1,))
+
+    def test_eq_negative_coeff_pin(self):
+        """-g + 3 == 0 means g == 3 → BoxSet(lo=(3,), hi=(4,))."""
+        from ktir_cpu.parser_ast import parse_affine_set_raw
+        from ktir_cpu.affine import BoxSet as _BoxSet
+        aset = parse_affine_set_raw("affine_set<(g) : (-g + 3 == 0)>")
+        box = _BoxSet.try_from_affine_set(aset)
+        assert box == BoxSet(lo=(3,), hi=(4,))
+
+    def test_eq_multi_dim_rejected(self):
+        """p - c == 0 involves two dims — cannot lower to BoxSet.
+
+        TODO: remove or update when PR #69 lands (symbolic/multi-dim eq support).
+        """
+        from ktir_cpu.parser_ast import parse_affine_set_raw
+        from ktir_cpu.affine import BoxSet as _BoxSet
+        aset = parse_affine_set_raw("affine_set<(p, c) : (p - c == 0)>")
+        assert _BoxSet.try_from_affine_set(aset) is None
+
+    def test_spec_example_g_eq_0(self):
+        """Full spec example: affine_set<(g) : (g == 0)>."""
+        s = parse_affine_set("affine_set<(g) : (g == 0)>")
+        assert isinstance(s, BoxSet)
+        assert s.lo == (0,)
+        assert s.hi == (1,)
+
+    def test_symbolic_eq_pin(self):
+        """d0 == s0 lowers to a symbolic BoxSet that specialises to a point."""
+        from ktir_cpu.parser_ast import parse_affine_set_raw
+        from ktir_cpu.affine import BoxSet as _BoxSet
+        aset = parse_affine_set_raw("affine_set<(d0)[s0] : (d0 - s0 == 0)>")
+        box = _BoxSet.try_from_affine_set(aset)
+        assert box is not None
+        assert not box.is_concrete
+        assert box.specialize([3]) == BoxSet(lo=(3,), hi=(4,))
+        assert box.specialize([7]) == BoxSet(lo=(7,), hi=(8,))
+
+    def test_symbolic_eq_with_offset(self):
+        """p - c + 2 == 0  →  p == c - 2; specialise([5]) → BoxSet(lo=(3,), hi=(4,))."""
+        from ktir_cpu.parser_ast import parse_affine_set_raw
+        from ktir_cpu.affine import BoxSet as _BoxSet
+        aset = parse_affine_set_raw("affine_set<(p)[c] : (p - c + 2 == 0)>")
+        box = _BoxSet.try_from_affine_set(aset)
+        assert box is not None
+        assert not box.is_concrete
+        assert box.specialize([5]) == BoxSet(lo=(3,), hi=(4,))

--- a/tests/test_affine.py
+++ b/tests/test_affine.py
@@ -621,3 +621,18 @@ class TestEqualityBoxSetLowering:
         assert box is not None
         assert not box.is_concrete
         assert box.specialize([5]) == BoxSet(lo=(3,), hi=(4,))
+
+    def test_reject_conflicting_eq_constraints(self):
+        from ktir_cpu.parser_ast import parse_affine_set_raw
+        aset = parse_affine_set_raw("affine_set<(d0) : (d0 == 2, d0 == 3)>")
+        assert BoxSet.try_from_affine_set(aset) is None
+
+    def test_reject_eq_ineq_conflict(self):
+        from ktir_cpu.parser_ast import parse_affine_set_raw
+        aset = parse_affine_set_raw("affine_set<(d0) : (d0 == 2, d0 >= 5)>")
+        assert BoxSet.try_from_affine_set(aset) is None
+
+    def test_reject_conflicting_inequalities(self):
+        from ktir_cpu.parser_ast import parse_affine_set_raw
+        aset = parse_affine_set_raw("affine_set<(d0) : (d0 >= 5, -d0 + 3 >= 0)>")
+        assert BoxSet.try_from_affine_set(aset) is None

--- a/tests/test_ast.py
+++ b/tests/test_ast.py
@@ -402,6 +402,97 @@ class TestEnumerateAffineSet:
 
 
 # ===========================================================================
+# Equality constraints — ("eq", lhs, rhs) node
+# ===========================================================================
+
+class TestEqualityConstraints:
+    """Tests for the ("eq", lhs, rhs) first-class AST node."""
+
+    # --- tokeniser ---
+
+    def test_tokenise_eq_operator(self):
+        tokens = _tokenise("(g == 0)")
+        assert "==" in tokens
+
+    def test_tokenise_eq_before_geq(self):
+        """== must be tokenised as a single token, not as two separate tokens."""
+        tokens = _tokenise("(d0 == 1, d1 >= 0)")
+        assert "==" in tokens
+        assert ">=" in tokens
+        # Ensure == was not split into two tokens
+        assert "=" not in tokens
+
+    # --- parse → AST structure ---
+
+    def test_parse_eq_simple(self):
+        s = parse_affine_set("affine_set<(g) : (g == 0)>")
+        assert len(s.constraints) == 1
+        c = s.constraints[0]
+        assert c[0] == "eq"
+        # Normalised to ("eq", ("sub", lhs, rhs)) — lhs - rhs == 0
+        assert c[1] == ("sub", ("dim", 0), ("const", 0))
+
+    def test_parse_eq_one_node_not_two(self):
+        """A single == must produce one constraint node, not two sub nodes."""
+        s = parse_affine_set("affine_set<(g) : (g == 0)>")
+        assert len(s.constraints) == 1
+        assert s.constraints[0][0] == "eq"
+
+    def test_parse_eq_with_expression(self):
+        # p - c + 2 == 0
+        s = parse_affine_set("affine_set<(p)[c] : (p - c + 2 == 0)>")
+        assert len(s.constraints) == 1
+        assert s.constraints[0][0] == "eq"
+
+    def test_parse_eq_complex_lhs_rhs(self):
+        # p + c - 8*g - 3 == 0
+        s = parse_affine_set("affine_set<(p)[c, g] : (p + c - 8*g - 3 == 0)>")
+        assert len(s.constraints) == 1
+        assert s.constraints[0][0] == "eq"
+
+    def test_parse_mixed_eq_and_ineq(self):
+        s = parse_affine_set("affine_set<(d0, d1) : (d0 == 0, d1 >= 0)>")
+        assert len(s.constraints) == 2
+        assert s.constraints[0][0] == "eq"
+        assert s.constraints[1][0] == "sub"
+
+    # --- evaluation ---
+
+    def test_eq_contains_matching_point(self):
+        s = parse_affine_set("affine_set<(g) : (g == 0)>")
+        assert affine_set_contains(s, [0])
+
+    def test_eq_contains_nonmatching_point(self):
+        s = parse_affine_set("affine_set<(g) : (g == 0)>")
+        assert not affine_set_contains(s, [1])
+        assert not affine_set_contains(s, [-1])
+
+    def test_eq_enumerate_single_point(self):
+        s = parse_affine_set("affine_set<(g) : (g == 0)>")
+        pts = enumerate_affine_set(s, (4,))
+        assert pts == [(0,)]
+
+    def test_eq_i_equals_zero(self):
+        """Spec example: affine_set<(i) : (i == 0)>"""
+        s = parse_affine_set("affine_set<(i) : (i == 0)>")
+        assert affine_set_contains(s, [0])
+        assert not affine_set_contains(s, [1])
+
+    def test_eq_symbolic_constraint(self):
+        """p - c + 2 == 0 with symbol c=3 means p == 1."""
+        s = parse_affine_set("affine_set<(p)[c] : (p - c + 2 == 0)>")
+        assert affine_set_contains(s, [1], symbols=[3])   # 1 - 3 + 2 == 0
+        assert not affine_set_contains(s, [2], symbols=[3])
+
+    def test_eq_complex_symbolic(self):
+        """p + c - 8*g - 3 == 0 with c=5, g=1 means p == 6."""
+        s = parse_affine_set("affine_set<(p)[c, g] : (p + c - 8*g - 3 == 0)>")
+        # p + 5 - 8 - 3 == 0  →  p == 6
+        assert affine_set_contains(s, [6], symbols=[5, 1])
+        assert not affine_set_contains(s, [5], symbols=[5, 1])
+
+
+# ===========================================================================
 # Edge-case tests — non-rectangular sets, conflicting constraints, zero-dim maps
 # ===========================================================================
 

--- a/tests/test_ast.py
+++ b/tests/test_ast.py
@@ -429,8 +429,8 @@ class TestEqualityConstraints:
         assert len(s.constraints) == 1
         c = s.constraints[0]
         assert c[0] == "eq"
-        # Normalised to ("eq", ("sub", lhs, rhs)) — lhs - rhs == 0
-        assert c[1] == ("sub", ("dim", 0), ("const", 0))
+        assert c[1] == ("dim", 0)
+        assert c[2] == ("const", 0)
 
     def test_parse_eq_one_node_not_two(self):
         """A single == must produce one constraint node, not two sub nodes."""


### PR DESCRIPTION
Introduces `("eq", expr)` as a first-class AST node for equality constraints in affine sets, replacing the previous parse-time rewrite (from `inter-tile-reduce` / `4bdf137`) that expanded `==` into two `>=` inequalities.

## Changes

- **Tokeniser**: `==` added to `_TOKEN_RE` before `>=` (longest-match)
- **`parse_constraint_list`**: `lhs == rhs` emits `("eq", ("sub", lhs, rhs))` — one node, normalised to `expr == 0` form (mirrors how `>=` constraints normalise to `expr >= 0`)
- **`_eval_node`**: `eq` tag returns the inner expression value
- **`affine_set_contains`**: checks `== 0` for `eq` nodes, `>= 0` for everything else
- **`BoxSet.try_from_affine_set`**: unified pin logic handles `eq` (sets both `lo` and `hi`) alongside existing inequality bounds; duplicated linearise-then-extract code removed

## Spec examples (all parse and evaluate correctly)

- `affine_set<(g) : (g == 0)>`
- `affine_set<(i) : (i == 0)>`
- `affine_set<(p)[c] : (p - c + 2 == 0)>`
- `affine_set<(p)[c, g] : (p + c - 8*g - 3 == 0)>`

## Coordination with PR #69

`test_eq_multi_dim_rejected` in `tests/test_affine.py` is marked with a `TODO` and will need to be revisited when PR #69 lands.