### PR TITLE
parser utilities for inter-tile communication

### DIFF
--- a/ktir_cpu/parser.py
+++ b/ktir_cpu/parser.py
@@ -342,7 +342,29 @@ class KTIRParser(KTIRParserBase):
                 starts_ssa = re.match(
                     r'(?:%\w+\s*,\s*)*%\w+\s*=\s', stripped
                 )
-                if self._is_op_complete(accumulated) or starts_ssa:
+                # Two-stage flush decision:
+                #
+                #   Stage 1 — positive *evidence* the previous op is
+                #   complete: either it has a terminal type annotation
+                #   (``: T`` / ``-> T``) or the new line starts a fresh
+                #   SSA assignment (``%name = ...``).  Evidence, not
+                #   proof — see Stage 2.
+                #
+                #   Stage 2 — negative evidence the next line *cannot*
+                #   start a new op.  A bare ``{`` is a region-body
+                #   opener, not an op header — emitting a flush here
+                #   would orphan a region-bearing op (the region would
+                #   attach to whatever follows instead).  This lets
+                #   ops like ``ktdp.inter_tile_produce`` whose type
+                #   annotation lands on the last attribute line keep
+                #   their trailing ``{ ... }`` region attached.
+                #
+                # Stage 2 is a veto over Stage 1.  As more "can't start
+                # an op" shapes turn up, extend ``next_cannot_start_op``
+                # rather than complicating the flush condition.
+                prev_op_probably_done = self._is_op_complete(accumulated) or starts_ssa
+                next_cannot_start_op = stripped == '{'
+                if prev_op_probably_done and not next_cannot_start_op:
                     results.append((accumulated, current_regions))
                     current_op_lines = []
                     current_regions = []

--- a/ktir_cpu/parser_ast.py
+++ b/ktir_cpu/parser_ast.py
@@ -510,6 +510,49 @@ def enumerate_affine_set(aset: AffineSet, shape: Tuple[int, ...], symbols: Seque
     return [pt for pt in itertools.product(*ranges) if affine_set_contains(aset, pt, symbols)]
 
 
+def enumerate_membership_keys(
+    family: AffineSet,
+    domain: AffineSet,
+    point: Sequence[int],
+    bound: int,
+) -> List[int]:
+    """Return keys ``k ∈ domain ∩ [0, bound)`` for which ``point`` is in
+    ``family(k)``.
+
+    Treats *family* as a parameterised affine set ``(d)[k]`` — i.e. a
+    family of integer sets indexed by ``k``.  *domain* is an
+    unparameterised 1-D set restricting the legal keys.  For each
+    candidate ``k`` enumerated from *domain* over ``[0, bound)``, this
+    function asks whether *point* (a tuple of dim values) is contained
+    in ``family`` with the symbol slot bound to ``k``.
+
+    Naming uses ``family`` / ``domain`` / ``key`` rather than the
+    affine-grammar word "symbol" — this is a higher-level question
+    (which family member contains the point?) than the raw
+    ``[s0, s1, ...]`` symbol slot of an affine set, even if the
+    implementation maps the key onto symbol 0 underneath.
+
+    Args:
+        family: Parameterised set with at least one symbol (the key).
+        domain: Unparameterised 1-D set of legal keys.
+        point:  Concrete dim values for *family*; ``len(point)`` must
+                equal ``family.n_dims``.
+        bound:  Search range for ``k`` (exclusive upper bound).
+
+    Returns:
+        Keys ``k`` (integers) at which ``family`` admits *point*.
+
+    Raises:
+        ValueError: from underlying ``enumerate`` / ``contains`` if
+            shapes do not match (e.g. *domain* is not 1-D, or
+            ``len(point) != family.n_dims``).
+    """
+    return [
+        k for (k,) in domain.enumerate((bound,))
+        if family.contains(list(point), [k])
+    ]
+
+
 # ---------------------------------------------------------------------------
 # Symbolic bound helpers
 #

--- a/ktir_cpu/parser_utils.py
+++ b/ktir_cpu/parser_utils.py
@@ -238,6 +238,57 @@ def parse_attr_list(op_text: str, aliases: Optional[Dict] = None,
     return result
 
 
+def extract_named_attr(op_text: str, key: str,
+                       aliases: Optional[Dict] = None) -> Optional[str]:
+    """Extract a single bare ``key = value`` attribute from ``op_text``.
+
+    Sibling to :func:`parse_attr_block` for ops that carry attributes
+    *outside* a ``{ ... }`` block — e.g. ops whose attribute list lives
+    on the op header itself rather than wrapped in braces:
+    ``producer_tiles_per_group = #all_tiles, groups = #one_group``.
+
+    Returns the resolved value string (alias-resolved when applicable),
+    or ``None`` if not found.  Caller-driven: caller names the key it
+    expects.
+    """
+    m = re.search(rf'\b{re.escape(key)}\s*=\s*', op_text)
+    if not m:
+        return None
+    rest = op_text[m.end():].lstrip()
+
+    # #alias reference
+    if rest.startswith('#'):
+        end = re.search(r'[,\n}]|\s+:|\s*->', rest)
+        raw = rest[:end.start()].strip() if end else rest.strip()
+        return aliases.get(raw, raw) if aliases else raw
+
+    # keyword<...> values — count <> depth, skip >= and ->
+    kw_m = re.match(r'[\w.]+<', rest)
+    if kw_m:
+        i = kw_m.end() - 1
+        depth = 0
+        while i < len(rest):
+            ch = rest[i]
+            if ch == '>' and i + 1 < len(rest) and rest[i + 1] == '=':
+                i += 2
+                continue
+            if ch == '-' and i + 1 < len(rest) and rest[i + 1] == '>':
+                i += 2
+                continue
+            if ch == '<':
+                depth += 1
+            elif ch == '>':
+                depth -= 1
+                if depth == 0:
+                    return rest[:i + 1]
+            i += 1
+        return rest
+
+    # Plain token up to next comma / newline / brace / colon / arrow.
+    end = re.search(r'[,\n}]|\s+:|\s*->', rest)
+    return rest[:end.start()].strip() if end else rest.strip()
+
+
 def _extract_attr_value(text: str, aliases: Optional[Dict]) -> tuple:
     """Extract one attribute value from the start of *text*.
 


### PR DESCRIPTION
**Stacked on [#70](https://github.com/torch-spyre/ktir-cpu/pull/70) (`affine-eq-node`).** Branch off `affine-eq-node`'s tip; rebase before merge once #70 lands. The PR diff currently includes `f0cfdbf` (the `affine-eq-node` commit) until #70 merges into `main`.

Three pure-additive parser-side helpers. No callers in this PR — they're prerequisites for the inter-tile-reduce work coming next.

## Commits

- **`a207238` `parser`: split flush condition into two-stage evidence/veto.**
  Tokenizer's "is the previous op done" reframed as Stage 1 (positive evidence: type-terminal OR new SSA assignment) + Stage 2 veto (a bare `{` is a region-body opener, never an op header). Lets ops whose type annotation lands on the *last attribute line* and whose region opens on the *next line* keep their region attached. Behaviour-preserving for every existing kernel.

- **`b494048` `parser_utils`: add `extract_named_attr`.**
  Public, caller-driven extractor for the bare `key = value` form some ops use *outside* a `{ ... }` block. Sibling to `parse_attr_block`. Caller names the key it expects.

- **`39c0416` `parser_ast`: add `enumerate_membership_keys`.**
  Generic affine-set primitive: \"for which keys `k ∈ domain` does `family(k)` admit `point`?\" Two-line implementation via `domain.enumerate` + `family.contains`, so it works for both `AffineSet` and `BoxSet`. Naming uses `family` / `domain` / `key` rather than the loaded affine-grammar word \"symbol.\"

## Why now

The follow-up `inter-tile-reduce` PR uses all three:

- ops whose attributes live on the op header (no `{ ... }` block) → `extract_named_attr`.
- ops whose region opens on the line after the type annotation → two-stage flush.
- \"which group does this core belong to?\" lookup in the consume handler → `enumerate_membership_keys`.

Landing them as a focused parser PR keeps the inter-tile review surface smaller and gives the helpers room to be reused by other dialects.

## Tests

\`820 passed, 1 skipped, 7 xfailed\`. No new tests — the helpers have no callers yet; their consumers ship in the inter-tile-reduce PR with full coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)