### PR TITLE
[Experimental] Inter tile reduce

### DIFF
--- a/docs/cross_core_scheduling.md
+++ b/docs/cross_core_scheduling.md
@@ -56,33 +56,10 @@ KTIRInterpreter
 
 | Layer | Responsibility | Notes |
 |---|---|---|
-| **`CommOps`** | High-level **per-core** comm primitives. Stable surface for dialect handlers. Today: `reduce` (passthrough to a `ReduceBackend`). | Dialect handlers call into here, not into scheduler primitives directly. |
 | **`CoreContext`** | Per-core SSA scope, LX scratchpad, and the public `send_to` / `get_lx` methods. Per-run scheduler bindings (`_send_fn`, `_transfer_fn`) are installed via `attach_scheduler` and cleared via `detach_scheduler`. | |
 | **`CoreExecutionStack`** | Wraps one core's op list as a generator. The only place that calls `.send()` / `next()` on client generators. Bubbles `RecvRequest` to the scheduler via `yield from`. | Internal. |
 | **`GridExecutor`** | Owns cores, the message queue, and the scheduler loop. Attaches scheduler bindings on every core before stepping; drives every generator to completion or raises on deadlock. | Internal. |
 | **`ReduceBackend`** / **`TransferBackend`** | Pluggable algorithms / transports. `ReduceBackend.run` is per-core, may yield `RecvRequest`. `TransferBackend.run` resolves remote LX access. Siblings under the scheduler protocol; distinct purposes. | See "Pluggable …" sections. |
-
----
-
-## Per-core semantics
-
-`CommOps` primitives describe **one core's behavior**. The function
-runs once per participating core; the scheduler runs N copies
-concurrently; they cooperate via the message queue.
-
-### `CommOps.reduce` — passthrough to a `ReduceBackend`
-
-```python
-@staticmethod
-def reduce(ctx, tile, core_group, backend: ReduceBackend):
-    return backend.run(ctx, tile, core_group)
-```
-
-The algorithm — ring rounds, LX-scratchpad accumulation, etc. — lives
-in the backend. `CommOps.reduce` exists so dialect handlers and tests
-have a single stable entry point regardless of which algorithm is in
-play. See `RingReduceBackend` for the canonical ring algorithm and a
-worked example.
 
 ---
 
@@ -100,9 +77,9 @@ A handler that calls a generator-shaped backend must **propagate**
 the generator — don't call it and discard the result:
 
 ```python
-return CommOps.reduce(ctx, tile, group, backend)              # OK — scheduler drives it
-return (yield from CommOps.reduce(ctx, tile, group, backend)) # OK — handler is itself a generator
-CommOps.reduce(ctx, tile, group, backend)                     # BUG — generator created, body never runs
+return backend.run(ctx, tile, group, reduce_fn)              # OK — scheduler drives it
+return (yield from backend.run(ctx, tile, group, reduce_fn)) # OK — handler is itself a generator
+backend.run(ctx, tile, group, reduce_fn)                     # BUG — generator created, body never runs
 ```
 
 **Key invariant:** `send_to` is fire-and-forget — the sender never
@@ -114,14 +91,13 @@ sender-side deadlock in symmetric patterns (all-to-all, ring).
 ## Control flow: blocking recv (end-to-end)
 
 ```
-dialect handler / test handler
-  └── CommOps.reduce(ctx, tile, group, backend)   ← passthrough
-        backend.run(ctx, tile, group)             ← generator object
-          for each round:
-            ctx.send_to(next_core, tile)          ← enqueues immediately
-            received = yield RecvRequest(src=prev) ← suspends here
-            ...
-          return result
+dialect handler
+  └── backend.run(ctx, tile, group, reduce_fn)    ← generator object
+        for each round:
+          ctx.send_to(next_core, tile)            ← enqueues immediately
+          received = yield RecvRequest(src=prev)  ← suspends here
+          ...
+        return result
 
 CoreExecutionStack._execute_until_block
   result = execute_op(op, core)                   ← gets the generator
@@ -166,26 +142,30 @@ scheduler raises this error.
 
 ## Pluggable reduction backends
 
-`CommOps.reduce` is a passthrough — the algorithm lives in a
-`ReduceBackend`. The motivation is hardware variety: ring is one of
-several plausible implementations of "combine values across a group."
-Tree, recursive halving-doubling, and an LX-scratchpad reduction
-(each core writes its partial into a designated LX slot on a target
-core, no ring messages) all have valid cost profiles depending on
-tile size, group shape, and available bandwidth.
+The algorithm — ring rounds, LX-scratchpad accumulation, etc. — lives
+in a `ReduceBackend`. The motivation is hardware variety: ring is one
+of several plausible implementations of "combine values across a
+group." Tree, recursive halving-doubling, and an LX-scratchpad
+reduction (each core writes its partial into a designated LX slot on a
+target core, no ring messages) all have valid cost profiles depending
+on tile size, group shape, and available bandwidth.
 
-The design separates *what* (semantics: combine N tiles into one)
-from *how* (algorithm: ring vs. tree vs. LX):
+The design separates *what* (semantics: combine N tiles into one) from
+*how* (algorithm: ring vs. tree vs. LX):
 
 ```python
 class ReduceBackend(ABC):
     """Owns the full reduce protocol: messaging, compute, completion."""
 
     @abstractmethod
-    def run(self, ctx: CoreContext, tile: Tile,
-            core_group: List[int]) -> Generator[RecvRequest, Tile, Tile]:
+    def run(self, ctx, tile, core_group, reduce_fn):
         ...
 ```
+
+`reduce_fn` arrives as a parameter to `run`, not the constructor —
+this lets the same backend instance back any delivery op
+(`inter_tile_reduce`, `inter_tile_reduce_scatter`, …) by passing a
+different fold at call time. See "Inter-tile communication" below.
 
 Concrete backends:
 
@@ -195,29 +175,6 @@ Concrete backends:
   a target core's LX scratchpad slot via `ctx.get_lx(target_core)`.
   Synchronous (no yields) when LX is directly addressable. Useful
   when partition count is small and ring latency dominates.
-
-### Backend selection
-
-The dialect handler picks the backend. Selection happens at the
-handler boundary, not in `CommOps` and not via the execution
-environment — backend choice belongs with the IR.
-
-The pattern uses a small explicit registry, mirroring the existing
-parser/handler registries:
-
-```python
-@register("ktdp.reduce", latency_category=LC.COMM)
-@register_reduce_backend("ktdp.reduce", RingReduceBackend)
-def ktdp__reduce(op, context, env):
-    backend_cls = get_reduce_backend(op.op_type)
-    reduce_fn = lambda t1, t2: ArithOps.addf(t1, t2)
-    return CommOps.reduce(context, tile, core_group, backend_cls(reduce_fn))
-```
-
-When a second backend lands, the handler resolves it from the same
-registry. Whether a single op type with a `kind` attribute or a
-sibling op type (`ktdp.reduce_ring`, `ktdp.reduce_lx`) is the right
-shape is a future decision — both put the choice in the IR.
 
 ---
 
@@ -249,6 +206,19 @@ scheduler protocol but distinct purposes (algorithm vs. memory), so
 they remain separate hierarchies rather than merging under a common
 base.
 
+**Instance counts.** A `ReduceBackend` is constructed by the
+`inter_tile_produce` handler — once per core per produce op. A
+`TransferBackend` is constructed once per execution by the
+interpreter and shared across all cores via curried per-core
+`transfer_fn`s. The asymmetry reflects what each tracks: reduce
+backends carry no state across calls (they could equally be free
+generator functions; the class wrapper exists only because the
+registry keys on a class), while a transfer backend is just a name
+resolver pointing at the workgroup-shared `SpyreMemoryHierarchy`.
+
+NOTE: for future consistency, will consider to also make
+`TransferBackend` to be constructed once per transfer.
+
 ---
 
 ## Per-core scheduler bindings
@@ -276,12 +246,311 @@ detached `CoreContext` raises clearly when `send_to` or remote
 
 ---
 
+# Inter-tile communication: produce + reduce, end to end
+
+This section walks the `ktdp.inter_tile_produce` + `ktdp.inter_tile_reduce`
+op pair from IR through the scheduler, and explains how `%fut` is
+designed as a per-core handle so no cross-core shared state is
+needed at the dialect level.
+
+The example is the 4-core all-reduce in
+`examples/ktir/ring_reduce.mlir`: every core holds a
+`tensor<1x128xf16>` partial, and every core ends up holding the sum.
+
+## How an MLIR kernel reaches the scheduler
+
+The KTIR backend simulates a multi-core accelerator. One *kernel*
+(an MLIR function annotated with `grid = [N]`) runs across N cores
+of the grid. **Every core runs the same kernel** — the same op list,
+the same handler functions — but each core has its own
+`CoreContext` (its own `core_id`, its own LX scratchpad, its own
+SSA value bindings). When `ktdp.get_compute_tile_id` runs on core 3
+it returns 3; on core 0 it returns 0.
+
+This is "every core runs the same code with different identity" —
+the standard accelerator execution model. There is no host
+coordinator and no shared memory map at the SSA level; cores
+exchange data only by going through the scheduler's mailbox.
+
+So when an op like `ktdp.inter_tile_produce` returns a `TileFuture`,
+the handler runs *N times in total* (once per core), each time
+producing a separate `TileFuture` instance bound to that core's
+local `%fut` SSA name. There is no single, workgroup-shared
+`TileFuture` object.
+
+### Why per-core, not workgroup-shared
+
+The alternative is to have one workgroup-shared object that every
+core's `%fut` resolves to (an earlier draft of this design used a
+shared dict on `GridExecutor`).  Both shapes can satisfy the spec's
+"workgroup-visible" property — the difference is where the
+abstraction line falls.
+
+The per-core design is the natural fit for two reasons:
+
+1. **Consistent execution model across delivery patterns.**  When
+   the future drives a per-tile dependency
+   (`producer_dependency_per_consumer` — e.g. butterfly mirror or
+   pairwise exchange), each consumer needs a distinct subset of
+   producers.  In a shared-future model, the consumer would have to
+   reach into someone else's contribution slot in the dict.  In the
+   per-core model, the same scheduler protocol that already moves
+   plain tiles (`send_to` + `RecvRequest`) moves the per-tile
+   partials too — one mechanism, one ordering story.
+
+2. **No out-of-band shared state at the dialect level.**  Cross-core
+   data flows exclusively through the scheduler's mailbox, which we
+   already trust as the single visibility boundary.  The dialect
+   handler stays a thin translator from IR to obligation; it doesn't
+   need a private side channel.
+
+The trade-off: in the all-reduce case the per-core model does
+**redundant compute** — every core runs the producer region and
+materialises its own partial, even though logically one reusable
+materialisation could feed all consumers.  We accept that cost (it
+matches what the hardware actually does — every tile runs the
+kernel) in exchange for one execution model that covers the full
+inter-tile op family.
+
+### Counting comm cost — charge per message at delivery
+
+`send_to` is fire-and-forget on the sender; the actual ring
+bandwidth gets consumed when a message is **delivered** to its
+destination — i.e. inside `_try_deliver`, after the message has
+been popped off `messages[(src, dst)]`.  That's the natural place
+to charge the latency model.
+
+Sends from different cores are disjoint events (each `send_to`
+queues a distinct `(src, dst, payload)` triple), so there is no
+double-counting in the message-count sense.  What the per-handler
+`@register("ktdp.inter_tile_reduce", latency_category=LC.COMM)`
+annotation gets *wrong* is something different: it charges
+fixed-per-op cycles N times (once per core) and re-derives bytes
+from the dialect-level operand sizes, which mismatches what the
+transport actually moved when delivery patterns are asymmetric
+(per-tile sync, butterfly).  Per-message charging at delivery is
+exact for any topology.
+
+**Hook into the existing latency surface.**  The latency tracker
+already exposes `record_op(core_id, op_type, result, operands)`
+which the interpreter calls once per dialect-handler invocation.
+The scheduler can call the same method at delivery, with a
+synthetic op type that the tracker recognises as a wire-transit
+charge:
+
+```python
+# in GridExecutor._try_deliver, after pop succeeds:
+self._latency_tracker.record_op(
+    core_id=dst,                  # the receiving core absorbs the wire
+    op_type="scheduler.message",  # resolves to LC.COMM in latency.py
+    result=tile,                  # gives _comm_size the byte count
+    operands=[],
+)
+```
+
+In `latency.py`'s `_estimate`, the `LC.COMM` arm becomes:
+
+```python
+if category == LC.COMM:
+    nbytes = self._data_size(result, [])
+    cycles = nbytes / self.config.ring_bytes_per_cycle
+    return ("comm", cycles, 0.0, nbytes)
+```
+
+— with the existing
+`if op_type == "ktdp.inter_tile_reduce": cycles *= rounds`
+special-case removed (the rounds are real messages now, each
+charged once).  And `inter_tile_*` registrations drop
+`latency_category=LC.COMM` so the per-handler call no longer
+contributes a parallel charge.
+
+**Provenance for breakdowns.**  For "how much comm time was
+`ktdp.inter_tile_reduce`?", tag the message at `send_to` time with
+the dialect op currently running on the sender, and pass that tag
+through to `record_op` at delivery:
+
+```python
+core.send_to(dst, tile, op_type="ktdp.inter_tile_reduce")  # tagged
+# scheduler later:
+self._latency_tracker.record_op(dst, msg.op_type, msg.payload, [])
+```
+
+For v1 a single bucket (`"scheduler.message"`) is enough; tagging
+is additive when we want per-op breakdowns.
+
+**Status.**  Unimplemented today.  The current code carries
+`LC.COMM` on `inter_tile_*` and the tracker double-charges across
+cores.  See the
+[GitHub issue]() (TODO once filed) for the migration plan.
+
+## Two functions, two phases
+
+The four-op design (see [RFC 0682](https://github.com/torch-spyre/RFCs/blob/main/0682-KtirSpec/0682-KtirSpecRFC.md)
+§5 and
+[`docs/inter-tile-communication.md`](https://github.com/torch-spyre/ktir-mlir-frontend/blob/main/docs/inter-tile-communication.md)
+in the frontend repo) hands the
+backend two different functions at different points:
+
+| Function | Defined by | Bound at | Used at |
+|---|---|---|---|
+| **producer function** | the body of `inter_tile_produce`'s region (`yield_partial %x`) | produce-handler time | produce-handler time — execute it to materialise this core's partial |
+| **reducer function** | the body of the delivery op's region (`yield_reduced %sum`) | consume-handler time | consume-handler time — passed to `backend.run` so the transport knows how to fold partials |
+
+Concretely the two handlers do this:
+
+```python
+# inter_tile_produce handler — runs once per core
+local_partial = run_producer_region()        # executes yield_partial body
+fut = TileFuture(
+    local_partial = local_partial,
+    backend       = RingReduceBackend(),     # not-yet-running
+    producer_set  = ...,                     # parsed IR sets
+    groups_set    = ...,
+    group_idx     = this_core_group,
+)
+return fut                                    # bound to %fut on THIS core only
+
+# inter_tile_reduce handler — runs once per core
+fut        = ctx.get_value(%fut)
+core_group = compute_core_group(fut, op.attributes)
+reduce_fn  = build_reducer_from_region(op.regions[0])
+return fut.backend.run(ctx, fut.local_partial, core_group, reduce_fn)
+```
+
+The produce handler builds the future and returns immediately — no
+cross-core movement, no blocking. The consume handler hands a
+`reduce_fn` to the future's backend; that's where the
+generator-driven blocking begins.
+
+## Why `%fut` is per-core
+
+The KTIR spec calls `%fut` "workgroup-visible" — every consumer
+must be able to see the partials the producers contributed. We
+satisfy that *logically*: when a consumer reads `%fut` on its core
+and triggers `backend.run`, the data it needs arrives via the
+scheduler's mailbox. Physical visibility is the transport's job.
+
+So per-core futures are the natural fit. Each core's `%fut` SSA
+binding holds a different `TileFuture` instance, carrying *that*
+core's local partial. Cores never read each other's futures — they
+read each other's partials through `ctx.send_to` + `RecvRequest`,
+the same path every other comm op uses. This negates the need for 
+a class of shared-state bookkeeping in the design. The drawback is
+we need to design to avoid double counting messages that are actually
+shared in an actual implementation.
+
+The def-use edge `%fut → consume(%fut)` is a *per-core* edge that
+serialises produce-then-consume on each individual core. Cross-core
+ordering is provided by the transport.
+
+## RingReduceBackend — what the generator does
+
+Per-core (one generator instance per core, all running the same code):
+
+```python
+def run(self, context, tile, core_group, reduce_fn):
+    if context.core_id not in core_group:
+        return tile     # opt out — never yields
+
+    n_cores = len(core_group)
+    my_idx     = core_group.index(context.core_id)
+    next_core  = core_group[(my_idx + 1) % n_cores]
+    prev_core  = core_group[(my_idx - 1) % n_cores]
+
+    result      = tile.copy()   # accumulator
+    to_forward  = tile.copy()   # what to send next round (round 1: local tile)
+
+    for _ in range(n_cores - 1):
+        context.send_to(next_core, to_forward)        # → scheduler queue
+        received = yield RecvRequest(src=prev_core)   # ← scheduler delivery
+        result = reduce_fn(result, received)
+        to_forward = received                         # forward received tile, not accumulator
+
+    return result
+```
+
+State per generator instance:
+
+- `result`, `to_forward` — the protocol's local working set.
+- `core_group`, `n_cores`, `my_idx`, `next_core`, `prev_core` —
+  derived once at entry.
+
+The **algorithmic invariant** (forward `received`, not `result`) is
+what keeps each starting tile visiting every other core exactly once
+over `n_cores - 1` rounds. Sending the accumulator instead would
+double-count the reduction result.
+
+## End-to-end trace for the 4-core all-reduce
+
+`core_group = [0, 1, 2, 3]`. Local tiles `t0`, `t1`, `t2`, `t3`.
+
+```
+Setup loop (each core runs until first yield):
+
+core 0:  send_to(1, t0)   →  messages[(0,1)] = [t0]
+         yield RecvRequest(src=3)              waiting[0] = 3
+core 1:  send_to(2, t1)   →  messages[(1,2)] = [t1]
+         yield RecvRequest(src=0)              waiting[1] = 0
+core 2:  send_to(3, t2)   →  messages[(2,3)] = [t2]
+         yield RecvRequest(src=1)              waiting[2] = 1
+core 3:  send_to(0, t3)   →  messages[(3,0)] = [t3]
+         yield RecvRequest(src=2)              waiting[3] = 2
+
+State after setup:
+  messages = {(0,1):[t0], (1,2):[t1], (2,3):[t2], (3,0):[t3]}
+  waiting  = {0:3, 1:0, 2:1, 3:2}
+
+Delivery loop drives each core through the remaining rounds. Per-core
+view of all three rounds:
+
+core 0:  starts with t0
+         R1: send t0→1, recv t3 from 3,  result=t0+t3,        forward=t3
+         R2: send t3→1, recv t2 from 3,  result=t0+t3+t2,     forward=t2
+         R3: send t2→1, recv t1 from 3,  result=t0+t3+t2+t1,  done
+core 1:  starts with t1
+         R1: send t1→2, recv t0 from 0,  result=t1+t0,        forward=t0
+         R2: send t0→2, recv t3 from 0,  result=t1+t0+t3,     forward=t3
+         R3: send t3→2, recv t2 from 0,  result=t1+t0+t3+t2,  done
+core 2:  starts with t2
+         R1: send t2→3, recv t1 from 1,  result=t2+t1,        forward=t1
+         R2: send t1→3, recv t0 from 1,  result=t2+t1+t0,     forward=t0
+         R3: send t0→3, recv t3 from 1,  result=t2+t1+t0+t3,  done
+core 3:  starts with t3
+         R1: send t3→0, recv t2 from 2,  result=t3+t2,        forward=t2
+         R2: send t2→0, recv t1 from 2,  result=t3+t2+t1,     forward=t1
+         R3: send t1→0, recv t0 from 2,  result=t3+t2+t1+t0,  done
+```
+
+Each generator returns its final `result`; `_execute_until_block`
+rebinds `%reduced` to the actual tile; the scheduler tears down the
+stack.
+
+## Where state lives
+
+| State | Owner | Lifetime |
+|---|---|---|
+| `messages: Dict[(src,dst), deque]` | `GridExecutor.execute_with_communication` (local var) | One execution invocation |
+| `waiting: Dict[core_id, src]` | same | One execution invocation |
+| `stacks: Dict[core_id, CoreExecutionStack]` | same | One execution invocation |
+| `result`, `to_forward` | local frame inside each suspended `RingReduceBackend.run` generator | Per-call; reclaimed when the generator returns |
+| `core_group`, `reduce_fn` | passed as args to `RingReduceBackend.run` | Per-call |
+| `_send_fn` on `CoreContext` | wired in setup loop via `attach_scheduler` | One execution invocation |
+| `TileFuture` instance (per `%fut`, per core) | the producing core's `CoreContext` SSA scope | Until `inter_tile_reduce` consumes it |
+
+No cross-core shared state at the dialect level. Everything cross-core
+flows through the scheduler's mailbox; everything per-core lives in a
+`CoreContext` SSA binding or a suspended generator frame.
+
+---
+
 ## Where things are defined
 
 | Symbol | File |
 |---|---|
 | `RecvRequest`, `CoreContext`, `CoreExecutionStack`, `GridExecutor` | `ktir_cpu/grid.py` |
-| `CommOps`, `ReduceBackend`, `RingReduceBackend` | `ktir_cpu/ops/comm_ops.py` |
+| `ReduceBackend`, `RingReduceBackend` | `ktir_cpu/ops/comm_ops.py` |
 | `TransferBackend`, `InstantTransferBackend` | `ktir_cpu/ops/comm_ops.py` |
 | `register_reduce_backend`, `get_reduce_backend` | `ktir_cpu/ops/comm_ops.py` |
+| `TileFuture` | `ktir_cpu/ir_types.py` |
+| `ktdp.inter_tile_produce` / `ktdp.inter_tile_reduce` handlers | `ktir_cpu/dialects/ktdp_ops.py` |
 | `ExecutionEnv` | `ktir_cpu/dialects/registry.py` |

--- a/docs/cross_core_scheduling.md
+++ b/docs/cross_core_scheduling.md
@@ -443,6 +443,35 @@ The def-use edge `%fut → consume(%fut)` is a *per-core* edge that
 serialises produce-then-consume on each individual core. Cross-core
 ordering is provided by the transport.
 
+### Def-use is simulated by `TileFuture`, not walked
+
+The spec uses the SSA def-use edge for two roles: (1) pin produce
+before consume in execution order, and (2) identify *which* produce
+a delivery op is paired with (the spec's "single-use" invariant).
+This simulator does not walk the IR's def-use graph for either
+role.  Both are absorbed by the per-core `TileFuture` object:
+
+- **Ordering.**  Each core executes its IR top-down; the consume
+  handler reads `%fut` via `ctx.get_value`, which only succeeds if
+  the produce op already bound it.  Standard SSA scoping is the
+  ordering check.
+- **Pairing.**  The `TileFuture` instance returned by produce *is*
+  the edge.  When the consume handler picks up `%fut`, it gets
+  exactly the future the matching produce built — there's no
+  IR-level "trace from this consume back to its produce" step
+  because the producer-side data already lives on the future the
+  consumer holds.
+
+Spec invariants that *do* require checking the producer-side
+attributes against the consumer-side attributes — `groups` match,
+`producer_dependency_per_consumer ⊆ producer_tiles_per_group`,
+coverage of producers by consumers' deps — are not enforced today.
+They are deferred until the upstream spec finalises (see
+`ktir_cpu/dialects/ktdp_ops.py` "Verification — deferred"); when
+they land they'll fit in `CommPlan.for_reduce` (subset / coverage)
+and a small consume-handler-entry check (`groups` match via
+bounded enumeration over `ctx.num_cores`).
+
 ## RingReduceBackend — what the generator does
 
 Per-core (one generator instance per core, all running the same code):

--- a/docs/gap_analysis.md
+++ b/docs/gap_analysis.md
@@ -1,9 +1,9 @@
 # KTIR Spec RFC vs. `ktir_cpu` Implementation — Gap Analysis
 
-**Date**: 2026-04-22
+**Date**: 2026-05-30
 **Spec**: [RFC 0682 — KTIR Spec](https://github.com/torch-spyre/RFCs/blob/main/0682-KtirSpec/0682-KtirSpecRFC.md)
 
-**Legend**: ✅ implemented — 🟡 partial — ❌ not implemented
+**Legend**: ✅ implemented — 🟡 partial — ❌ not implemented — 🧪 experimental (tracks an unmerged upstream spec PR; semantics may change)
 
 ---
 
@@ -13,6 +13,10 @@
 |---|---------------|--------|-------|
 | 1 | `ktdp.construct_distributed_memory_view` | ✅ | Handler and parser implemented in `ktir_cpu/dialects/ktdp_ops.py`; produces `DistributedMemRef` (composition of N per-partition `MemRef`s). Per-partition routing at access time via `MemoryOps.distributed_tile_access` → `DistributedTileRef`. Tests in `tests/test_distributed_view.py`. |
 | 2 | `ktdp.construct_indirect_access_tile` | ✅ | Handler and parser implemented in `ktir_cpu/dialects/ktdp_ops.py`; tests passing in `tests/test_indirect_access.py`. Both `ktdp.load` (gather, via `MemoryOps.indirect_load`) and `ktdp.store` (scatter, via `MemoryOps.indirect_store`) accept `IndirectAccessTile` (#44 closed). |
+| 2a | `ktdp.inter_tile_produce` + `ktdp.inter_tile_reduce` (four-op design, reduce path) | 🧪 experimental | **Spec status: not yet merged** — the four-op design lives in [ktir-mlir-frontend PR #23](https://github.com/torch-spyre/ktir-mlir-frontend/pull/23). Implemented here ahead of merge so the simulator can exercise it. Op names, attribute keys, and `!ktdp.tile_future<...>` type may change to track the upstream PR. Implementation: handlers and parsers in `ktir_cpu/dialects/ktdp_ops.py`; `TileFuture` per-core handle binds the local partial and a not-yet-running `RingReduceBackend`; reduce delivery triggers the backend with the combiner region as `reduce_fn`. Per-core wire bytes flow to the latency tracker via `Tile.comm_bytes` (mirrors `unique_sticks`). End-to-end test: `tests/test_examples.py::TestRingReduceExecution`. Replaces the legacy `ktdp.reduce` / `ktdp.transfer` ops. See `docs/cross_core_scheduling.md`. |
+| 2b | `ktdp.inter_tile_consume` (broadcast delivery) | ❌ experimental | Same upstream PR. Not implemented. |
+| 2c | `ktdp.inter_tile_reduce_scatter` | ❌ experimental | Same upstream PR. Not implemented. |
+| 2d | `producer_dependency_per_consumer` (per-tile sync) | 🟡 experimental | Same upstream PR. Parsed and stored on the delivery op AST; runtime is full-barrier mode (waits for all producers). Per-tile mode unimplemented. |
 
 ## B. `ktdp` Types & Attributes
 
@@ -38,7 +42,7 @@ The spec lists these SCF operations as "currently contemplated":
 
 | # | Operation | Status | Notes |
 |---|-----------|--------|-------|
-| 9 | `scf.reduce` | ❌ | Only `ktdp.reduce` exists for inter-core comm, which is semantically different |
+| 9 | `scf.reduce` | ❌ | Inter-core reduction is covered by the experimental `ktdp.inter_tile_produce` + `ktdp.inter_tile_reduce` pair (rows 2a–2d), which is semantically different from SCF-level reductions. |
 | 10 | `scf.reduce.return` | ❌ | |
 | 11 | `scf.parallel` | ❌ | |
 | 12 | `scf.forall` | ❌ | |
@@ -82,11 +86,11 @@ The spec references the [full Math dialect](https://mlir.llvm.org/docs/Dialects/
 
 ### Linalg dialect
 
-The spec references the [full Linalg dialect](https://mlir.llvm.org/docs/Dialects/Linalg/). Currently implemented: `linalg.reduce`, `linalg.matmul`, `linalg.generic`, `linalg.broadcast`, `linalg.transpose`.
+The spec references the [full Linalg dialect](https://mlir.llvm.org/docs/Dialects/Linalg/). Currently implemented: `linalg.reduce`, `linalg.matmul`, `linalg.generic`, `linalg.broadcast`, `linalg.transpose`, `linalg.add`, `linalg.fill`.
 
 | # | Operation | Status | Notes |
 |---|-----------|--------|-------|
-| 25 | `linalg.add` | ❌ | Used in the spec's primary matrix-add example — won't execute today |
+| 25 | `linalg.add` | ✅ | Implemented in `ktir_cpu/dialects/linalg_ops.py` as elementwise `Tile + Tile`. Used by `ktdp.inter_tile_reduce`'s combiner region in the rewritten `ring_reduce.mlir` example. |
 | 26 | `linalg.generic` | ✅ | Full `bb0` block handling in `ktir_cpu/dialects/linalg_ops.py` |
 | 27 | `linalg.map`, `linalg.broadcast`, `linalg.transpose` | 🟡 | `broadcast` and `transpose` implemented; `map` still missing |
 
@@ -131,7 +135,6 @@ The spec explicitly mentions `memref.subview` for view-based transformations. **
 ### High Priority
 Blocks running spec-compliant KTIR programs:
 
-- **#25**: ❌ `linalg.add` — used in the spec's primary example and won't execute
 - **#5**: 🟡 `coordinate_set` on memory views preserved but not enforced
 
 ### Medium Priority
@@ -154,11 +157,15 @@ Extensibility and completeness:
 - **#2**: ✅ `construct_indirect_access_tile`
 - **#6, #7, #8**: ✅ `access_tile_set`, `access_tile_order`, `base_map`
 - **#20–24**: ✅ All math ops (rsqrt, log2, log1p, tanh, sin, cos, absf, ceil, floor, erf, powf, fma)
+- **#25**: ✅ `linalg.add`
 - **#26**: ✅ `linalg.generic`
 - **#33, #34, #35**: ✅ Access tile coordinate semantics
 - **#37, #38**: ✅ Affine expression evaluation and alias support
 
-## I. Status as of 2026-04-22
+### Experimental (tracks unmerged upstream spec PRs)
+- **#2a–2d**: 🧪 Inter-tile communication four-op design — see [ktir-mlir-frontend#23](https://github.com/torch-spyre/ktir-mlir-frontend/pull/23). Reduce path implemented; broadcast / reduce-scatter / per-tile sync not.
+
+## I. Status as of 2026-05-30
 
 Significant progress since the original writeup:
 
@@ -168,16 +175,24 @@ Significant progress since the original writeup:
   `ktdp.load`/`ktdp.store` to enumerate coordinate tuples.
 - `linalg.generic` (#26) is implemented with full `bb0` block handling.
 - `linalg.broadcast`, `linalg.transpose` (#27 partial), `tensor.collapse_shape`
-  (#29 partial), and `math.log` are now implemented.
+  (#29 partial), `math.log`, and **`linalg.add` (#25)** are now implemented.
+- 🧪 **Experimental** inter-tile reduce path (rows 2a, 2d): the four-op
+  design from [ktir-mlir-frontend#23](https://github.com/torch-spyre/ktir-mlir-frontend/pull/23)
+  is implemented for `inter_tile_produce` + `inter_tile_reduce` (reduce
+  delivery only) ahead of upstream merge. Per-core wire bytes flow to the
+  latency tracker via `Tile.comm_bytes`. End-to-end ring_reduce test
+  passes. Op surface may shift to track the upstream PR.
 
 Remaining notable gaps:
 
-- `linalg.add` (#25) is still missing — the RFC's canonical matrix-add example
-  cannot execute without it.
 - `coordinate_set` on memory views (#5) is preserved in the IR but not used
   to enforce coordinate constraints during dispatch.
 - SCF parallel/reduce ops (#9–12), `tensor.extract_slice` (#28), and the
   entire `memref` dialect (#30–31) remain unimplemented.
+- 🧪 Inter-tile broadcast (`inter_tile_consume`, row 2b) and reduce-scatter
+  (`inter_tile_reduce_scatter`, row 2c) not yet implemented; per-tile sync
+  (`producer_dependency_per_consumer`, row 2d) is parsed but runs in
+  full-barrier mode.
 
 ## J. Prioritized Conformance Roadmap
 
@@ -196,16 +211,16 @@ Goal: cover the RFC-defined `ktdp` surface.
 - Preserve dynamic `access_tile` dimensions (`?`) in the IR even if runtime
   support is initially partial.
 
-### Close The RFC-Explicit Non-KTDP Gaps ❌
+### Close The RFC-Explicit Non-KTDP Gaps 🟡
 
 Goal: support the rest of the ops the RFC explicitly calls out.
 
-- Add `linalg.add` so the RFC's canonical matrix-add example can execute
+- ✅ Add `linalg.add` so the RFC's canonical matrix-add example can execute
   without translation.
-- Add `tensor.extract_slice`.
-- Add `memref.subview` and the minimal `memref` dialect support required to
+- ❌ Add `tensor.extract_slice`.
+- ❌ Add `memref.subview` and the minimal `memref` dialect support required to
   interpret it.
-- Add the missing SCF ops explicitly named by the RFC:
+- ❌ Add the missing SCF ops explicitly named by the RFC:
   `scf.reduce`,
   `scf.reduce.return`,
   `scf.parallel`,
@@ -273,9 +288,12 @@ If we want the fastest path to meaningful conformance progress:
 2. ✅ Rework `ktdp.load` / `ktdp.store` around that representation.
 3. ✅ Add `construct_indirect_access_tile`.
 4. ✅ Add `construct_distributed_memory_view`.
-5. ❌ Add `linalg.add`, `tensor.extract_slice`, and `memref.subview`.
+5. 🟡 Add `linalg.add` (✅), `tensor.extract_slice` (❌), and `memref.subview` (❌).
 6. ❌ Fill in the missing RFC-listed SCF ops.
 7. ❌ Expand broader Arith/Math/Linalg coverage as compiler demand appears.
+8. 🧪 Track [ktir-mlir-frontend#23](https://github.com/torch-spyre/ktir-mlir-frontend/pull/23)
+   to upstream merge; reconcile any op-surface drift in the experimental
+   four-op inter-tile path (rows 2a–2d).
 
 ### Definition Of "Good Enough" For A First Conformance Milestone
 
@@ -284,5 +302,7 @@ A strong first milestone would be:
 - ✅ affine attributes are preserved and exercised in tests
 - ✅ `ktdp.load` / `ktdp.store` operate over real coordinate collections
 - ✅ all RFC-defined `ktdp` ops parse and execute
-- ❌ the RFC matrix-add example can run with only mechanical syntax adaptation
+- 🟡 the RFC matrix-add example can run with only mechanical syntax adaptation
+  (`linalg.add` ✅; pending `tensor.extract_slice` / `memref.subview` if the
+  example uses them)
 - ❌ the repo has explicit tests for unsupported versus supported RFC surface

--- a/examples/ktir/ring_reduce.mlir
+++ b/examples/ktir/ring_reduce.mlir
@@ -1,29 +1,39 @@
-// Ring reduce: 4 cores, each holds a 1×128 row in HBM, reduce-sum into core 0.
+// Ring reduce: 4 cores, each holds a 1×128 row in HBM, reduce-sum across all 4.
 //
 // Grid: [4, 1, 1] — axis 0 distributes work.
 //
+// HBM addressing.  ``%in_ptr`` / ``%out_ptr`` are *stick* indices on
+// HBM; one stick is 128 bytes (= 64 f16 elements), so each 1×128 f16
+// row spans **2 sticks**.  Per-core stride = 2 sticks.
+//
 // Each core c:
-//   1. Constructs a memory view for its row at hbm_ptr + c*128 elements.
+//   1. Constructs a memory view for its row at in_ptr + c*2 sticks.
 //   2. Loads it into a tensor<1x128xf16> partial.
-//   3. Calls ktdp.reduce (reduce_to_core<0>, sum across axis 0).
+//   3. Calls ktdp.inter_tile_produce + ktdp.inter_tile_reduce — every
+//      core ends up holding the full sum (all-reduce).
 //   4. Core 0 (pid == 0) stores the reduced tile back to HBM output.
 //
 // After execution, output[0..127] = sum of all 4 input rows.
 
-#row_set  = affine_set<(d0, d1) : (d0 >= 0, -d0 >= 0, d1 >= 0, -d1 + 127 >= 0)>
-#identity = affine_map<(d0, d1) -> (d0, d1)>
+#row_set    = affine_set<(d0, d1) : (d0 >= 0, -d0 >= 0, d1 >= 0, -d1 + 127 >= 0)>
+#identity   = affine_map<(d0, d1) -> (d0, d1)>
+
+// Single group containing all 4 cores: i in [4*g, 4*g+3], with g == 0.
+#all_tiles  = affine_set<(i)[g] : (i - 4*g >= 0, -i + 4*g + 3 >= 0)>
+#one_group  = affine_set<(g) : (g == 0)>
 
 module {
   func.func @ring_reduce(%in_ptr: index, %out_ptr: index)
-      attributes {grid = array<i64: 4>} {
+      attributes {grid = [4]} {
 
-    %c0   = arith.constant 0   : index
-    %c128 = arith.constant 128 : index
+    %c0   = arith.constant 0 : index
+    // 1×128 f16 = 256 bytes = 2 HBM sticks per row.
+    %row_sticks = arith.constant 2 : index
 
     %pid = ktdp.get_compute_tile_id : index
 
-    // Base pointer for this core's input row: in_ptr + pid * 128
-    %offs = arith.muli %pid, %c128 : index
+    // Stick-index of this core's input row: in_ptr + pid * 2.
+    %offs = arith.muli %pid, %row_sticks : index
     %row_ptr = arith.addi %in_ptr, %offs : index
 
     // (1) Memory view over this core's 1×128 row
@@ -42,17 +52,42 @@ module {
     %partial = ktdp.load %row_acc
                 : !ktdp.access_tile<1x128xindex> -> tensor<1x128xf16>
 
-    // (3) Cross-core reduce-sum: result lands on group-rank 0 (pid_k == 0).
-    //     On other cores %reduced is unspecified / poison.
-    %reduced = ktdp.reduce %partial {
-      kind   = #ktdp.reduce_kind<sum>,
-      mode   = #ktdp.reduce_mode<reduce_to_core<0>>,
-      across = #ktdp.grid_axis<0>
-    } : tensor<1x128xf16> -> tensor<1x128xf16>
+    // (3a) Produce: every core contributes its 1×128 partial.
+    %fut = ktdp.inter_tile_produce
+        producer_tiles_per_group = #all_tiles,
+        groups                   = #one_group
+        : tensor<1x128xf16> -> !ktdp.tile_future<tensor<1x128xf16>>
+    {
+      ^bb0(%gid: index):
+        ktdp.yield_partial %partial : tensor<1x128xf16>
+    }
 
-    // (4) Only core 0 stores the result to HBM output
+    // (3b) Reduce: every core (consumer set == producer set) ends up holding
+    //      the same 128-element group sum.
+    %c_zero    = arith.constant 0.0 : f16
+    %id_init   = tensor.empty() : tensor<1x128xf16>
+    %add_id    = linalg.fill ins(%c_zero : f16) outs(%id_init : tensor<1x128xf16>)
+                   -> tensor<1x128xf16>
+
+    %reduced = ktdp.inter_tile_reduce(%fut)
+        consumer_tiles_per_group = #all_tiles,
+        groups                   = #one_group,
+        identity(%add_id : tensor<1x128xf16>)
+        : !ktdp.tile_future<tensor<1x128xf16>> -> tensor<128xf16>
+    {
+      ^bb0(%lhs: tensor<1x128xf16>, %rhs: tensor<1x128xf16>):
+        %init = tensor.empty() : tensor<1x128xf16>
+        %sum  = linalg.add ins(%lhs, %rhs : tensor<1x128xf16>, tensor<1x128xf16>)
+                           outs(%init : tensor<1x128xf16>) -> tensor<1x128xf16>
+        ktdp.yield_reduced %sum : tensor<1x128xf16>
+    }
+
+    // (4) Only core 0 stores the result back as a 1×128 row
     %is_writer = arith.cmpi eq, %pid, %c0 : index
     scf.if %is_writer {
+      %reduced_2d = tensor.expand_shape %reduced [[0, 1]] output_shape [1, 128]
+                      : tensor<128xf16> into tensor<1x128xf16>
+
       %out_view = ktdp.construct_memory_view %out_ptr,
                     sizes: [1, 128], strides: [128, 1] {
         coordinate_set = #row_set,
@@ -64,7 +99,7 @@ module {
         access_tile_order = #identity
       } : memref<1x128xf16> -> !ktdp.access_tile<1x128xindex>
 
-      ktdp.store %reduced, %out_acc
+      ktdp.store %reduced_2d, %out_acc
         : tensor<1x128xf16>, !ktdp.access_tile<1x128xindex>
     }
 

--- a/examples/latency/ring_reduce_multi_group.mlir
+++ b/examples/latency/ring_reduce_multi_group.mlir
@@ -1,0 +1,131 @@
+// Multi-group ring reduce: 16 cores split into 4 groups of 4.
+//
+// Grid: [16, 1, 1] — axis 0 distributes work across 16 cores.
+//
+// HBM addressing.  ``%in_ptr`` / ``%out_ptr`` are *stick* indices on
+// HBM; one stick is 128 bytes (= 64 f16 elements), so each 1×128 f16
+// row spans **2 sticks**.  Per-core stride = 2 sticks.
+//
+// Each core c:
+//   1. Constructs a memory view for its row at in_ptr + c*2 sticks.
+//   2. Loads it into a tensor<1x128xf16> partial.
+//   3. Calls ktdp.inter_tile_produce + ktdp.inter_tile_reduce — every
+//      core in group g (= c / 4) ends up holding the sum of that
+//      group's 4 partials (all-reduce within the group).
+//   4. The first core of each group (c % 4 == 0) stores the reduced
+//      tile to its group's output slot at out_ptr + g*2 sticks.
+//
+// After execution, output[g, 0..127] = sum of group g's 4 input rows
+// for g in [0, 4).
+//
+// This kernel is the multi-group analogue of
+// ``examples/ktir/ring_reduce.mlir``; the latency-test harness uses
+// it to validate that ``RingReduceBackend.run`` produces correct
+// per-group results when the workgroup hosts multiple concurrent
+// reductions, and that the ring still spans the whole 16-core
+// workgroup.
+
+#row_set    = affine_set<(d0, d1) : (d0 >= 0, -d0 >= 0, d1 >= 0, -d1 + 127 >= 0)>
+#identity   = affine_map<(d0, d1) -> (d0, d1)>
+
+// 4 groups of 4 cores: i in [4*g, 4*g+3], with g in [0, 3].
+#all_tiles  = affine_set<(i)[g] : (i - 4*g >= 0, -i + 4*g + 3 >= 0)>
+#all_groups = affine_set<(g) : (g >= 0, -g + 3 >= 0)>
+
+module {
+  func.func @ring_reduce_multi_group(%in_ptr: index, %out_ptr: index)
+      attributes {grid = [16, 1, 1]} {
+
+    %c0 = arith.constant 0 : index
+    %c4 = arith.constant 4 : index
+    // 1×128 f16 = 256 bytes = 2 HBM sticks per row.
+    %row_sticks = arith.constant 2 : index
+
+    %pid = ktdp.get_compute_tile_id : index
+
+    // Stick-index of this core's input row: in_ptr + pid * 2.
+    %in_offs = arith.muli %pid, %row_sticks : index
+    %row_ptr = arith.addi %in_ptr, %in_offs : index
+
+    // (1) Memory view over this core's 1×128 row
+    %row_view = ktdp.construct_memory_view %row_ptr,
+                  sizes: [1, 128], strides: [128, 1] {
+      coordinate_set = #row_set,
+      memory_space   = #ktdp.spyre_memory_space<HBM>
+    } : memref<1x128xf16>
+
+    // (2) Access tile and load
+    %row_acc = ktdp.construct_access_tile %row_view[%c0, %c0] {
+      access_tile_set   = #row_set,
+      access_tile_order = #identity
+    } : memref<1x128xf16> -> !ktdp.access_tile<1x128xindex>
+
+    %partial = ktdp.load %row_acc
+                : !ktdp.access_tile<1x128xindex> -> tensor<1x128xf16>
+
+    // (3a) Produce: every core contributes its 1×128 partial.
+    //      ``groups`` defines 4 groups; each core's group is derived
+    //      from its position in ``producer_tiles_per_group``.
+    %fut = ktdp.inter_tile_produce
+        producer_tiles_per_group = #all_tiles,
+        groups                   = #all_groups
+        : tensor<1x128xf16> -> !ktdp.tile_future<tensor<1x128xf16>>
+    {
+      ^bb0(%gid: index):
+        ktdp.yield_partial %partial : tensor<1x128xf16>
+    }
+
+    // (3b) Reduce: within each group of 4, every core holds the same
+    //      group sum.  consumer_tiles_per_group = producer_tiles_per_group
+    //      → in-group all-reduce.
+    %c_zero    = arith.constant 0.0 : f16
+    %id_init   = tensor.empty() : tensor<1x128xf16>
+    %add_id    = linalg.fill ins(%c_zero : f16) outs(%id_init : tensor<1x128xf16>)
+                   -> tensor<1x128xf16>
+
+    %reduced = ktdp.inter_tile_reduce(%fut)
+        consumer_tiles_per_group = #all_tiles,
+        groups                   = #all_groups,
+        identity(%add_id : tensor<1x128xf16>)
+        : !ktdp.tile_future<tensor<1x128xf16>> -> tensor<128xf16>
+    {
+      ^bb0(%lhs: tensor<1x128xf16>, %rhs: tensor<1x128xf16>):
+        %init = tensor.empty() : tensor<1x128xf16>
+        %sum  = linalg.add ins(%lhs, %rhs : tensor<1x128xf16>, tensor<1x128xf16>)
+                           outs(%init : tensor<1x128xf16>) -> tensor<1x128xf16>
+        ktdp.yield_reduced %sum : tensor<1x128xf16>
+    }
+
+    // (4) The first core of each group writes its group's result.
+    //     Writer condition: pid % 4 == 0.  Output offset: g * 2 sticks
+    //     where g = pid / 4.  So core 0 writes to out_ptr+0, core 4
+    //     writes to out_ptr+2, core 8 writes to out_ptr+4, core 12
+    //     writes to out_ptr+6.
+    %lane      = arith.remui %pid, %c4 : index
+    %is_writer = arith.cmpi eq, %lane, %c0 : index
+    scf.if %is_writer {
+      %reduced_2d = tensor.expand_shape %reduced [[0, 1]] output_shape [1, 128]
+                      : tensor<128xf16> into tensor<1x128xf16>
+
+      %group_idx = arith.divui %pid, %c4 : index
+      %out_offs  = arith.muli %group_idx, %row_sticks : index
+      %group_out = arith.addi %out_ptr, %out_offs : index
+
+      %out_view = ktdp.construct_memory_view %group_out,
+                    sizes: [1, 128], strides: [128, 1] {
+        coordinate_set = #row_set,
+        memory_space   = #ktdp.spyre_memory_space<HBM>
+      } : memref<1x128xf16>
+
+      %out_acc = ktdp.construct_access_tile %out_view[%c0, %c0] {
+        access_tile_set   = #row_set,
+        access_tile_order = #identity
+      } : memref<1x128xf16> -> !ktdp.access_tile<1x128xindex>
+
+      ktdp.store %reduced_2d, %out_acc
+        : tensor<1x128xf16>, !ktdp.access_tile<1x128xindex>
+    }
+
+    return
+  }
+}

--- a/ktir_cpu/dialects/ktdp_helpers.py
+++ b/ktir_cpu/dialects/ktdp_helpers.py
@@ -13,20 +13,27 @@
 # limitations under the License.
 
 """
-KTDP subscript-expression helpers.
-
-These functions parse and evaluate subscript descriptors used by
-``construct_indirect_access_tile`` and ``load``/``store``.  They live in
-this separate module (rather than in ``ktdp_ops`` or ``affine``) to avoid
-circular imports: ``ktdp_ops`` imports ``MemoryOps`` from
-``ops/memory_ops``, which in turn needs ``eval_subscript_expr``.
+KTDP dialect helpers.
 
 Functions
 ---------
-parse_subscript_expr  — parse one subscript token into an AST tuple
-eval_subscript_expr   — evaluate a subscript tuple against a variable point
-_classify_refs        — post-process ("ref", ...) nodes from the text-parser path
-_reclassify_dims      — post-process ("dim", N) nodes from the MLIR-frontend-parser path
+Subscript-expression helpers — parse and evaluate subscript
+descriptors used by ``construct_indirect_access_tile`` and
+``load``/``store``.  They live in this module (rather than in
+``ktdp_ops`` or ``affine``) to avoid circular imports: ``ktdp_ops``
+imports ``MemoryOps`` from ``ops/memory_ops``, which in turn needs
+``eval_subscript_expr``.
+
+  parse_subscript_expr  — parse one subscript token into an AST tuple
+  eval_subscript_expr   — evaluate a subscript tuple against a variable point
+  _classify_refs        — post-process ``("ref", ...)`` nodes (text parser path)
+  _reclassify_dims      — post-process ``("dim", N)`` nodes (frontend path)
+
+Region- and post-processing helpers — small utilities used by
+region-bearing inter-tile op handlers.
+
+  reshape_tile_to_target  — collapse a tile to its declared ``T_r`` shape
+  attach_reshape          — drive a backend generator and reshape its return
 """
 
 from __future__ import annotations
@@ -156,3 +163,63 @@ def eval_subscript_expr(expr: tuple, pt: tuple) -> int:
     if expr[0] == "mod":
         return pt[expr[1]] % expr[2]
     return _eval_node(expr, list(pt))
+
+
+# ---------------------------------------------------------------------------
+# Region / post-processing helpers
+# ---------------------------------------------------------------------------
+
+
+def reshape_tile_to_target(reduced, target_shape):
+    """Reshape a ``Tile`` to ``target_shape``, validating element count.
+
+    Returns ``reduced`` unchanged when ``target_shape`` is ``None`` or
+    already matches.  Used by inter-tile reduce to collapse the
+    within-group tile axis (``T_p → T_r``) on the post-ring tile.
+
+    Raises:
+        TypeError: if ``reduced`` is not a ``Tile`` (the backend's
+            return contract is violated).
+        ValueError: if reshape is requested but element counts differ.
+    """
+    from ..ir_types import Tile
+    if not isinstance(reduced, Tile):
+        raise TypeError(
+            f"reshape_tile_to_target: expected Tile, got {type(reduced).__name__}"
+        )
+    if target_shape is None or reduced.shape == tuple(target_shape):
+        return reduced
+    from numpy import prod
+    if int(prod(reduced.shape)) != int(prod(target_shape)):
+        raise ValueError(
+            f"reshape_tile_to_target: result shape {reduced.shape} and "
+            f"declared shape {target_shape} have different element counts"
+        )
+    new_tile = Tile(
+        reduced.data.reshape(target_shape),
+        reduced.dtype,
+        tuple(target_shape),
+        unique_sticks=reduced.unique_sticks,
+        index_unique_sticks=reduced.index_unique_sticks,
+    )
+    # Tile() doesn't construct comm_bytes (mirrors how copy() leaves
+    # it None for produced-from-data copies).  Reshape is a structural
+    # rewrite of an already-comm-stamped tile, so propagate explicitly.
+    new_tile.comm_bytes = reduced.comm_bytes
+    return new_tile
+
+
+def attach_reshape(gen, target_shape):
+    """Drive ``gen`` to completion and reshape its return value.
+
+    Returns a generator that proxies every ``yield`` from ``gen`` and
+    post-processes the return through :func:`reshape_tile_to_target`.
+    The handler that wants its backend's output reshaped writes::
+
+        return attach_reshape(backend.run(...), target_shape)
+
+    instead of an inline ``def _gen(): reduced = yield from ...``
+    closure.
+    """
+    reduced = yield from gen
+    return reshape_tile_to_target(reduced, target_shape)

--- a/ktir_cpu/dialects/ktdp_ops.py
+++ b/ktir_cpu/dialects/ktdp_ops.py
@@ -33,7 +33,7 @@ from ..ops.arith_ops import ArithOps
 from ..ops.comm_ops import CommPlan, RingReduceBackend
 from ..ops.grid_ops import GridOps
 from ..ops.memory_ops import MemoryOps
-from ..parser_ast import parse_affine_map, parse_affine_set
+from ..parser_ast import enumerate_membership_keys, parse_affine_map, parse_affine_set
 from ..parser_utils import _extract_bracket_content, extract_named_attr, find_ssa_names, parse_attr_block, parse_multi_result_lhs, parse_tensor_type, split_top_level
 from .registry import ParseContext, register, register_parser
 
@@ -846,28 +846,61 @@ def parse_construct_indirect_access_tile(op_text, parse_ctx: ParseContext):
 # Not implemented: `inter_tile_consume` (broadcast),
 # `inter_tile_reduce_scatter`, per-tile sync runtime.
 #
+# Def-use edge — how it's simulated.  The spec uses the SSA def-use
+# edge ``%fut → consume(%fut)`` to pin produce-then-consume ordering
+# and identify which produce a delivery op is paired with.  In this
+# simulator we don't walk the def-use graph: each core's
+# ``inter_tile_produce`` returns a per-core ``TileFuture`` instance
+# bound to that core's local ``%fut``; the consume handler reads
+# ``%fut`` via ``ctx.get_value`` and dispatches.  The TileFuture
+# *is* the def-use edge for our purposes — its identity per core
+# substitutes for tracing the IR-level chain.
+#
+# Verification — deferred until the upstream spec is final.  Once
+# ktir-mlir-frontend#23 lands, add:
+#
+#   A2. ``groups`` match between produce and consume.
+#       Bounded-enumeration equality over ``ctx.num_cores`` —
+#       compare ``{g : groups_a.contains([g])}`` and
+#       ``{g : groups_b.contains([g])}`` once at consume-handler
+#       entry.  No polyhedral set difference needed.
+#
+#   B1. Subset.  ``producer_dependency_per_consumer ⊆
+#       producer_tiles_per_group`` for every (p, c) the deps name.
+#       Trivial post-check on ``CommPlan.for_reduce`` — every
+#       producer-id mentioned in ``deps`` must be in ``producers``.
+#
+#   B2. Coverage.  Every producer in ``producer_tiles_per_group(g)``
+#       must be the dependency of at least one consumer in
+#       ``consumer_tiles_per_group(g)``.  Same place as B1, post
+#       ``CommPlan.for_reduce``.
+#
+# These are spec invariants the runtime currently trusts.  They
+# should be enforced when the upstream surface stabilises so we
+# don't lock in error messages keyed on names that may yet change.
+#
 # See `docs/cross_core_scheduling.md` for the simulator design and
 # `docs/gap_analysis.md` rows 2a–2d for status.
 # ---------------------------------------------------------------------------
 
 
-def _find_tile_group(tile_id, producer_set, groups_set):
-    """Return the unique group index ``g`` whose membership set contains
-    ``tile_id``.
+def _find_tile_group(tile_id, producer_set, groups_set, num_cores):
+    """Return the unique group index ``g`` whose membership set
+    contains ``tile_id``.
 
-    ``producer_set`` is a 1-D parameterized affine set ``(i)[g] : ...``;
-    ``groups_set`` is an unparameterized 1-D affine set over the group
-    index.  Iterates ``g`` over a generous shape (the per-group max is
-    bounded by the workgroup size) and picks the unique containing
-    group.
+    Thin wrapper over :func:`enumerate_membership_keys`: ``producer_set``
+    is the family ``(i)[g]``, ``groups_set`` is the key domain, and
+    we want the keys ``g`` for which ``tile_id`` is in the family.
+    Group count is upper-bounded by ``num_cores`` (every group must
+    contain at least one core).  Raises if zero or more than one
+    match — the spec's disjointness invariant says exactly one.
     """
-    # Enumerate possible g values from the groups set.  We don't know the
-    # max group count a priori; use a sentinel upper bound large enough
-    # for any real workgroup.  This is a v1 heuristic — a follow-up could
-    # propagate workgroup size through the IR.
-    GROUP_BOUND = 1024
-    candidates = groups_set.enumerate((GROUP_BOUND,))
-    matches = [g[0] for g in candidates if producer_set.contains([tile_id], [g[0]])]
+    matches = enumerate_membership_keys(
+        family=producer_set,
+        domain=groups_set,
+        point=(tile_id,),
+        bound=num_cores,
+    )
     if not matches:
         raise RuntimeError(
             f"tile {tile_id} is not contained in any producer group "
@@ -913,7 +946,7 @@ def ktdp__inter_tile_produce(op, context, env):
     partial_types = op.attributes["partial_tensor_types"]
 
     tile_id = context.core_id
-    gid = _find_tile_group(tile_id, producer_set, groups_set)
+    gid = _find_tile_group(tile_id, producer_set, groups_set, context.num_cores)
 
     region = op.regions[0] if op.regions else []
     bb0_op = next((o for o in region if o.op_type == "region.bb0_args"), None)

--- a/ktir_cpu/dialects/ktdp_ops.py
+++ b/ktir_cpu/dialects/ktdp_ops.py
@@ -824,12 +824,30 @@ def parse_construct_indirect_access_tile(op_text, parse_ctx: ParseContext):
 # ---------------------------------------------------------------------------
 # Inter-tile communication — `ktdp.inter_tile_produce` / `inter_tile_reduce`
 # ---------------------------------------------------------------------------
-# Spec: docs/inter-tile-communication.md (in ktir-mlir-frontend).
+# 🧪 EXPERIMENTAL — TRACKS UNMERGED UPSTREAM SPEC PR
 #
-# Production op returns a !ktdp.tile_future<T_p>; the delivery op consumes it.
-# v1 supports a single partial role (N=1) and the full-barrier sync model
-# (no producer_dependency_per_consumer execution semantics — parsed but not
-# honoured at runtime).
+# The four-op inter-tile design (produce + consume / reduce / reduce_scatter)
+# lives in ktir-mlir-frontend PR #23:
+#   https://github.com/torch-spyre/ktir-mlir-frontend/pull/23
+#
+# The spec PR is not yet merged.  Op names, attribute keys (e.g.
+# ``producer_tiles_per_group``, ``consumer_tiles_per_group``,
+# ``producer_dependency_per_consumer``), and the ``!ktdp.tile_future<...>``
+# type may shift to track the upstream PR before it lands on main.  Avoid
+# baking these names into stable APIs until the spec is final.
+#
+# Implemented here: the reduce path only — `ktdp.inter_tile_produce` +
+# `ktdp.inter_tile_reduce`, with `yield_partial` / `yield_reduced` region
+# terminators.  Production returns a `!ktdp.tile_future<T_p>`; the delivery
+# op consumes it.  v1 supports a single partial role (N=1) and the
+# full-barrier sync model (no `producer_dependency_per_consumer` execution
+# semantics — parsed but not honoured at runtime).
+#
+# Not implemented: `inter_tile_consume` (broadcast),
+# `inter_tile_reduce_scatter`, per-tile sync runtime.
+#
+# See `docs/cross_core_scheduling.md` for the simulator design and
+# `docs/gap_analysis.md` rows 2a–2d for status.
 # ---------------------------------------------------------------------------
 
 

--- a/ktir_cpu/dialects/ktdp_ops.py
+++ b/ktir_cpu/dialects/ktdp_ops.py
@@ -26,19 +26,15 @@ from ..ir_types import (
     MemRef,
     Operation,
     Tile,
+    TileFuture,
 )
 from ..latency import LatencyCategory as LC
 from ..ops.arith_ops import ArithOps
-from ..ops.comm_ops import (
-    CommOps,
-    RingReduceBackend,
-    get_reduce_backend,
-    register_reduce_backend,
-)
+from ..ops.comm_ops import RingReduceBackend
 from ..ops.grid_ops import GridOps
 from ..ops.memory_ops import MemoryOps
 from ..parser_ast import parse_affine_map, parse_affine_set
-from ..parser_utils import _extract_bracket_content, find_ssa_names, parse_attr_block, parse_multi_result_lhs, split_top_level
+from ..parser_utils import _extract_bracket_content, find_ssa_names, parse_attr_block, parse_multi_result_lhs, parse_tensor_type, split_top_level
 from .registry import ParseContext, register, register_parser
 
 
@@ -826,14 +822,408 @@ def parse_construct_indirect_access_tile(op_text, parse_ctx: ParseContext):
 
 
 # ---------------------------------------------------------------------------
-# Communication ops (moved from scf_ops.py)
+# Inter-tile communication — `ktdp.inter_tile_produce` / `inter_tile_reduce`
+# ---------------------------------------------------------------------------
+# Spec: docs/inter-tile-communication.md (in ktir-mlir-frontend).
+#
+# Production op returns a !ktdp.tile_future<T_p>; the delivery op consumes it.
+# v1 supports a single partial role (N=1) and the full-barrier sync model
+# (no producer_dependency_per_consumer execution semantics — parsed but not
+# honoured at runtime).
 # ---------------------------------------------------------------------------
 
-@register("ktdp.reduce", latency_category=LC.COMM)
-@register_reduce_backend("ktdp.reduce", RingReduceBackend)
-def ktdp__reduce(op, context, env):
-    tile = context.get_value(op.operands[0])
-    core_group = context.get_value(op.operands[1])
-    backend_cls = get_reduce_backend(op.op_type)
-    reduce_fn = lambda t1, t2: ArithOps.addf(t1, t2)
-    return CommOps.reduce(context, tile, core_group, backend_cls(reduce_fn))
+
+def _find_tile_group(tile_id, producer_set, groups_set):
+    """Return the unique group index ``g`` whose membership set contains
+    ``tile_id``.
+
+    ``producer_set`` is a 1-D parameterized affine set ``(i)[g] : ...``;
+    ``groups_set`` is an unparameterized 1-D affine set over the group
+    index.  Iterates ``g`` over a generous shape (the per-group max is
+    bounded by the workgroup size) and picks the unique containing
+    group.
+    """
+    # Enumerate possible g values from the groups set.  We don't know the
+    # max group count a priori; use a sentinel upper bound large enough
+    # for any real workgroup.  This is a v1 heuristic — a follow-up could
+    # propagate workgroup size through the IR.
+    GROUP_BOUND = 1024
+    candidates = groups_set.enumerate((GROUP_BOUND,))
+    matches = [g[0] for g in candidates if producer_set.contains([tile_id], [g[0]])]
+    if not matches:
+        raise RuntimeError(
+            f"tile {tile_id} is not contained in any producer group "
+            f"(producer_set={producer_set.source!r}, groups_set={groups_set.source!r})"
+        )
+    if len(matches) > 1:
+        raise RuntimeError(
+            f"tile {tile_id} matched multiple groups {matches} — "
+            f"violates the disjointness invariant"
+        )
+    return matches[0]
+
+
+def _extract_named_attr(op_text: str, key: str, aliases: dict | None = None):
+    """Extract a single bare ``key = value`` attribute from ``op_text``.
+
+    The four inter-tile ops carry their attributes bare (no enclosing
+    ``{ ... }`` block) — e.g.
+    ``producer_tiles_per_group = #all_tiles, groups = #one_group``.
+    Returns the resolved value string (alias-resolved when applicable),
+    or ``None`` if not found.
+    """
+    # Match `key =` then capture either an `#alias`, a `keyword<...>`
+    # value, or a bare token up to the next comma / colon / arrow / brace.
+    m = re.search(rf'\b{re.escape(key)}\s*=\s*', op_text)
+    if not m:
+        return None
+    rest = op_text[m.end():].lstrip()
+
+    if rest.startswith('#'):
+        end = re.search(r'[,\n}]|\s+:|\s*->', rest)
+        raw = rest[:end.start()].strip() if end else rest.strip()
+        return aliases.get(raw, raw) if aliases else raw
+
+    kw_m = re.match(r'[\w.]+<', rest)
+    if kw_m:
+        i = kw_m.end() - 1
+        depth = 0
+        while i < len(rest):
+            ch = rest[i]
+            if ch == '>' and i + 1 < len(rest) and rest[i + 1] == '=':
+                i += 2
+                continue
+            if ch == '-' and i + 1 < len(rest) and rest[i + 1] == '>':
+                i += 2
+                continue
+            if ch == '<':
+                depth += 1
+            elif ch == '>':
+                depth -= 1
+                if depth == 0:
+                    return rest[:i + 1]
+            i += 1
+        return rest
+
+    end = re.search(r'[,\n}]|\s+:|\s*->', rest)
+    return rest[:end.start()].strip() if end else rest.strip()
+
+
+def _producer_core_group(producer_set, group_idx, num_cores):
+    """Return the list of tile ids in ``producer_tiles_per_group(group_idx)``,
+    ascending. Used as the ``core_group`` argument to ``RingReduceBackend.run``.
+    """
+    return [
+        i for i in range(num_cores)
+        if producer_set.contains([i], [group_idx])
+    ]
+
+
+# ---------------------------------------------------------------------------
+# ktdp.inter_tile_produce
+# ---------------------------------------------------------------------------
+
+@register("ktdp.inter_tile_produce")
+def ktdp__inter_tile_produce(op, context, env):
+    """Materialise this core's partial and bind it into a per-core
+    TileFuture together with a not-yet-running transport backend.
+
+    Every core in the workgroup runs this handler once with its own
+    ``CoreContext``; each call returns a separate ``TileFuture``
+    bound to that core's local ``%fut`` SSA value.  No cross-core
+    shared state — partials reach consumers via the scheduler's
+    mailbox once the matching delivery op triggers
+    ``fut.backend.run``.  See ``docs/cross_core_scheduling.md``,
+    "Inter-tile communication: produce + reduce, end to end".
+
+    Steps:
+      1. Resolve this core's group index ``gid`` from the IR sets.
+      2. Execute the producer region with ``%gid`` bound; capture the
+         ``yield_partial`` value(s) as the local partial.
+      3. Construct a fresh ``RingReduceBackend()`` (no ``reduce_fn``
+         yet — the consumer attaches it at ``run`` time).
+      4. Wrap everything in a ``TileFuture`` and return.
+    """
+    producer_set = op.attributes["producer_tiles_per_group"]
+    groups_set = op.attributes["groups"]
+    partial_types = op.attributes["partial_tensor_types"]
+
+    tile_id = context.core_id
+    gid = _find_tile_group(tile_id, producer_set, groups_set)
+
+    region = op.regions[0] if op.regions else []
+    bb0_op = next((o for o in region if o.op_type == "region.bb0_args"), None)
+    body = [o for o in region if o.op_type != "region.bb0_args"]
+    if bb0_op is not None:
+        names = bb0_op.attributes.get("names", [])
+        if names:
+            context.set_value(names[0], gid)
+
+    yielded = env.execute_region(context, body)
+    if isinstance(yielded, Tile):
+        yielded = (yielded,)
+    local_partial = tuple(yielded) if yielded is not None else None
+
+    return TileFuture(
+        partial_tensor_types=partial_types,
+        local_partial=local_partial,
+        backend=RingReduceBackend(),
+        producer_set=producer_set,
+        groups_set=groups_set,
+        group_idx=gid,
+    )
+
+
+@register_parser("ktdp.inter_tile_produce")
+def parse_inter_tile_produce(op_text, parse_ctx: ParseContext):
+    m = re.match(r'(%\w+)\s*=\s*ktdp\.inter_tile_produce\b', op_text)
+    if not m:
+        return None
+    result_name = m.group(1)
+
+    producer_set_str = _extract_named_attr(
+        op_text, "producer_tiles_per_group", parse_ctx.aliases
+    )
+    if producer_set_str is None:
+        raise ValueError("ktdp.inter_tile_produce: missing producer_tiles_per_group")
+    groups_str = _extract_named_attr(op_text, "groups", parse_ctx.aliases)
+    if groups_str is None:
+        raise ValueError("ktdp.inter_tile_produce: missing groups")
+
+    producer_set = parse_affine_set(producer_set_str)
+    groups_set = parse_affine_set(groups_str)
+
+    # Result type:  !ktdp.tile_future<T_p_1, ..., T_p_N>
+    fut_match = re.search(r'!ktdp\.tile_future<(.+)>', op_text)
+    if not fut_match:
+        raise ValueError(
+            "ktdp.inter_tile_produce: missing !ktdp.tile_future<...> result type"
+        )
+    inner = fut_match.group(1).strip()
+    # split_top_level handles commas inside nested tensor<...> brackets.
+    partial_types = tuple(p.strip() for p in split_top_level(inner))
+
+    return Operation(
+        result=result_name,
+        op_type="ktdp.inter_tile_produce",
+        operands=[],
+        attributes={
+            "producer_tiles_per_group": producer_set,
+            "groups": groups_set,
+            "partial_tensor_types": partial_types,
+        },
+        result_type=f"!ktdp.tile_future<{inner}>",
+    )
+
+
+# ---------------------------------------------------------------------------
+# ktdp.yield_partial / ktdp.yield_reduced — region terminators
+# ---------------------------------------------------------------------------
+
+@register("ktdp.yield_partial")
+def ktdp__yield_partial(op, context, env):
+    values = [context.get_value(name) for name in op.operands]
+    return values[0] if len(values) == 1 else tuple(values)
+
+
+@register("ktdp.yield_reduced")
+def ktdp__yield_reduced(op, context, env):
+    values = [context.get_value(name) for name in op.operands]
+    return values[0] if len(values) == 1 else tuple(values)
+
+
+def _parse_yield(op_text, op_name):
+    m = re.match(rf'{re.escape(op_name)}\s+(.*)', op_text)
+    if not m:
+        return None
+    rest = m.group(1)
+    # Strip trailing type annotation
+    if ':' in rest:
+        rest = rest[:rest.rindex(':')]
+    operands = find_ssa_names(rest)
+    return Operation(
+        result=None,
+        op_type=op_name,
+        operands=operands,
+        attributes={},
+        result_type=None,
+    )
+
+
+@register_parser("ktdp.yield_partial")
+def parse_yield_partial(op_text, parse_ctx: ParseContext):
+    return _parse_yield(op_text, "ktdp.yield_partial")
+
+
+@register_parser("ktdp.yield_reduced")
+def parse_yield_reduced(op_text, parse_ctx: ParseContext):
+    return _parse_yield(op_text, "ktdp.yield_reduced")
+
+
+# ---------------------------------------------------------------------------
+# ktdp.inter_tile_reduce
+# ---------------------------------------------------------------------------
+
+@register("ktdp.inter_tile_reduce", latency_category=LC.COMM)
+def ktdp__inter_tile_reduce(op, context, env):
+    """Trigger the future's backend with this op's combiner region.
+
+    The future already carries this core's local partial and a
+    not-yet-running ``RingReduceBackend`` instance (constructed at
+    ``inter_tile_produce`` time).  This handler:
+
+      1. Builds a ``reduce_fn`` from the combiner region (``^bb0(%lhs,
+         %rhs) -> yield_reduced``).
+      2. Computes ``core_group`` from the producer set in the future +
+         the consumer set on this op.
+      3. Calls ``fut.backend.run(...)`` — that generator is where the
+         scheduler-visible blocking begins.
+      4. Reshapes the reduced tile into the declared ``T_r``.
+
+    See ``docs/cross_core_scheduling.md`` for the design.
+    """
+    fut = context.get_value(op.operands[0])
+    if not isinstance(fut, TileFuture):
+        raise TypeError(
+            f"ktdp.inter_tile_reduce: operand 0 must be a TileFuture, got {type(fut)}"
+        )
+
+    if fut.local_partial is None:
+        raise RuntimeError(
+            f"ktdp.inter_tile_reduce on core {context.core_id}: future has no "
+            f"local_partial — this core was not in producer_tiles_per_group"
+        )
+    local_tile = fut.local_partial[0]   # v1 N=1 role
+
+    num_cores = env.grid_executor.num_cores
+    core_group = _producer_core_group(fut.producer_set, fut.group_idx, num_cores)
+
+    # Build reduce_fn from the combiner region.
+    region = op.regions[0] if op.regions else []
+    bb0_op = next((o for o in region if o.op_type == "region.bb0_args"), None)
+    body = [o for o in region if o.op_type != "region.bb0_args"]
+    if bb0_op is None:
+        raise ValueError("ktdp.inter_tile_reduce: combiner region missing ^bb0 args")
+    bb0_names = bb0_op.attributes.get("names", [])
+    if len(bb0_names) < 2:
+        raise ValueError(
+            f"ktdp.inter_tile_reduce: combiner region needs >=2 block args "
+            f"(lhs, rhs), got {bb0_names}"
+        )
+    lhs_name, rhs_name = bb0_names[0], bb0_names[1]
+
+    def reduce_fn(t1: Tile, t2: Tile) -> Tile:
+        context.push_scope()
+        context.set_value(lhs_name, t1)
+        context.set_value(rhs_name, t2)
+        result = env.execute_region(context, body)
+        context.pop_scope()
+        if not isinstance(result, Tile):
+            raise TypeError(
+                f"ktdp.inter_tile_reduce: combiner did not yield a Tile, got {type(result)}"
+            )
+        return result
+
+    target_shape = op.attributes.get("_result_shape")
+
+    def _reshape(reduced) -> Tile:
+        if not isinstance(reduced, Tile):
+            raise TypeError(
+                f"ktdp.inter_tile_reduce: expected Tile from backend, "
+                f"got {type(reduced).__name__}"
+            )
+        if target_shape is None or reduced.shape == tuple(target_shape):
+            return reduced
+        from numpy import prod
+        if int(prod(reduced.shape)) != int(prod(target_shape)):
+            raise ValueError(
+                f"ktdp.inter_tile_reduce: result shape {reduced.shape} "
+                f"and declared T_r {target_shape} have different element counts"
+            )
+        return Tile(
+            reduced.data.reshape(target_shape),
+            reduced.dtype,
+            tuple(target_shape),
+            unique_sticks=reduced.unique_sticks,
+            index_unique_sticks=reduced.index_unique_sticks,
+        )
+
+    # Trigger the future's backend.  RingReduceBackend.run takes
+    # reduce_fn at run() time so the same backend instance can back
+    # any delivery op (reduce / reduce_scatter / consume).  The backend
+    # is a generator (yields RecvRequest); the wrapper drives it,
+    # reshapes T_p -> T_r, and stamps comm_bytes onto the result for the
+    # latency tracker.
+    raw = fut.backend.run(context, local_tile, core_group, reduce_fn)
+
+    def _gen():
+        reduced = yield from raw
+        final = _reshape(reduced)
+        final.comm_bytes = fut.backend.bytes_moved
+        return final
+    return _gen()
+
+
+@register_parser("ktdp.inter_tile_reduce")
+def parse_inter_tile_reduce(op_text, parse_ctx: ParseContext):
+    m = re.match(
+        r'(%\w+)\s*=\s*ktdp\.inter_tile_reduce\s*\(\s*(%\w+)\s*\)',
+        op_text,
+    )
+    if not m:
+        return None
+    result_name = m.group(1)
+    fut_operand = m.group(2)
+
+    consumer_set_str = _extract_named_attr(
+        op_text, "consumer_tiles_per_group", parse_ctx.aliases
+    )
+    if consumer_set_str is None:
+        raise ValueError("ktdp.inter_tile_reduce: missing consumer_tiles_per_group")
+    consumer_set = parse_affine_set(consumer_set_str)
+
+    groups_str = _extract_named_attr(op_text, "groups", parse_ctx.aliases)
+    if groups_str is None:
+        raise ValueError("ktdp.inter_tile_reduce: missing groups")
+    groups_set = parse_affine_set(groups_str)
+
+    pdpc_str = _extract_named_attr(
+        op_text, "producer_dependency_per_consumer", parse_ctx.aliases
+    )
+    pdpc = parse_affine_set(pdpc_str) if pdpc_str is not None else None
+
+    # identity(%add_id : T_p_1, ...): SSA operands hoisted before the op.
+    id_match = re.search(r'identity\s*\(([^)]*)\)', op_text)
+    identity_operands = []
+    if id_match:
+        for part in split_top_level(id_match.group(1)):
+            for name in find_ssa_names(part):
+                identity_operands.append(name)
+
+    # Result type: T_r (after collapsing within-group tile axes).
+    arrow_match = re.search(r'->\s*(.+?)\s*\{?\s*$', op_text)
+    result_type = arrow_match.group(1).strip() if arrow_match else None
+    result_shape = None
+    if result_type is not None:
+        parsed = parse_tensor_type(result_type)
+        if parsed is not None:
+            result_shape = parsed["shape"]
+
+    attributes = {
+        "consumer_tiles_per_group": consumer_set,
+        "groups": groups_set,
+    }
+    if pdpc is not None:
+        attributes["producer_dependency_per_consumer"] = pdpc
+    if result_shape is not None:
+        attributes["_result_shape"] = result_shape
+
+    operands = [fut_operand] + identity_operands
+
+    return Operation(
+        result=result_name,
+        op_type="ktdp.inter_tile_reduce",
+        operands=operands,
+        attributes=attributes,
+        result_type=result_type,
+    )

--- a/ktir_cpu/dialects/ktdp_ops.py
+++ b/ktir_cpu/dialects/ktdp_ops.py
@@ -30,7 +30,7 @@ from ..ir_types import (
 )
 from ..latency import LatencyCategory as LC
 from ..ops.arith_ops import ArithOps
-from ..ops.comm_ops import RingReduceBackend
+from ..ops.comm_ops import CommPlan, RingReduceBackend
 from ..ops.grid_ops import GridOps
 from ..ops.memory_ops import MemoryOps
 from ..parser_ast import parse_affine_map, parse_affine_set
@@ -881,40 +881,32 @@ def _find_tile_group(tile_id, producer_set, groups_set):
     return matches[0]
 
 
-def _producer_core_group(producer_set, group_idx, num_cores):
-    """Return the list of tile ids in ``producer_tiles_per_group(group_idx)``,
-    ascending. Used as the ``core_group`` argument to ``RingReduceBackend.run``.
-    """
-    return [
-        i for i in range(num_cores)
-        if producer_set.contains([i], [group_idx])
-    ]
-
-
 # ---------------------------------------------------------------------------
 # ktdp.inter_tile_produce
 # ---------------------------------------------------------------------------
 
 @register("ktdp.inter_tile_produce")
 def ktdp__inter_tile_produce(op, context, env):
-    """Materialise this core's partial and bind it into a per-core
-    TileFuture together with a not-yet-running transport backend.
+    """Materialise this core's partial and stash it on a per-core
+    TileFuture.
 
     Every core in the workgroup runs this handler once with its own
     ``CoreContext``; each call returns a separate ``TileFuture``
     bound to that core's local ``%fut`` SSA value.  No cross-core
     shared state — partials reach consumers via the scheduler's
-    mailbox once the matching delivery op triggers
-    ``fut.backend.run``.  See ``docs/cross_core_scheduling.md``,
-    "Inter-tile communication: produce + reduce, end to end".
+    mailbox once the matching delivery op runs.  See
+    ``docs/cross_core_scheduling.md``, "Inter-tile communication:
+    produce + reduce, end to end".
+
+    Backend selection happens at consume time, not here — the future
+    just carries the producer/groups affine sets and the bound
+    group index alongside the local partial.
 
     Steps:
       1. Resolve this core's group index ``gid`` from the IR sets.
-      2. Execute the producer region with ``%gid`` bound; capture the
-         ``yield_partial`` value(s) as the local partial.
-      3. Construct a fresh ``RingReduceBackend()`` (no ``reduce_fn``
-         yet — the consumer attaches it at ``run`` time).
-      4. Wrap everything in a ``TileFuture`` and return.
+      2. Execute the producer region with ``%gid`` bound; capture
+         the ``yield_partial`` value(s) as the local partial.
+      3. Wrap everything in a ``TileFuture`` and return.
     """
     producer_set = op.attributes["producer_tiles_per_group"]
     groups_set = op.attributes["groups"]
@@ -939,7 +931,6 @@ def ktdp__inter_tile_produce(op, context, env):
     return TileFuture(
         partial_tensor_types=partial_types,
         local_partial=local_partial,
-        backend=RingReduceBackend(),
         producer_set=producer_set,
         groups_set=groups_set,
         group_idx=gid,
@@ -1036,23 +1027,35 @@ def parse_yield_reduced(op_text, parse_ctx: ParseContext):
 # ktdp.inter_tile_reduce
 # ---------------------------------------------------------------------------
 
+def _select_reduce_backend(plan: CommPlan, op_attrs):
+    """Pick a ``ReduceBackend`` for an ``inter_tile_reduce`` op.
+
+    Today: a single fixed strategy (``RingReduceBackend``).  When
+    other strategies (tree, point-to-point for sparse deps, …) land,
+    this dispatcher pattern-matches on ``plan`` shape and selects.
+    """
+    return RingReduceBackend()
+
+
 @register("ktdp.inter_tile_reduce", latency_category=LC.COMM)
 def ktdp__inter_tile_reduce(op, context, env):
-    """Trigger the future's backend with this op's combiner region.
+    """Build a ``CommPlan``, pick a backend, run it.
 
-    The future already carries this core's local partial and a
-    not-yet-running ``RingReduceBackend`` instance (constructed at
-    ``inter_tile_produce`` time).  This handler:
+    Every core in the workgroup runs this handler, even cores not in
+    ``consumer_tiles_per_group`` — the backend's ring spans the whole
+    workgroup; ``CommPlan`` masks contributions and outputs.  See
+    ``docs/cross_core_scheduling.md`` §"Inter-tile communication".
 
-      1. Builds a ``reduce_fn`` from the combiner region (``^bb0(%lhs,
-         %rhs) -> yield_reduced``).
-      2. Computes ``core_group`` from the producer set in the future +
-         the consumer set on this op.
-      3. Calls ``fut.backend.run(...)`` — that generator is where the
-         scheduler-visible blocking begins.
-      4. Reshapes the reduced tile into the declared ``T_r``.
-
-    See ``docs/cross_core_scheduling.md`` for the design.
+    Steps:
+      1. Validate the ``%fut`` operand and resolve the ``identity``
+         operand to a Tile.
+      2. Build a ``CommPlan`` from the future's producer set (plus
+         this op's consumer set + optional dep set) at
+         ``ctx.num_cores``.
+      3. Build a ``reduce_fn`` from the combiner region
+         (``^bb0(%lhs, %rhs) → yield_reduced``).
+      4. Pick a backend and run it; ``attach_reshape`` collapses
+         ``T_p → T_r`` on the result tile.
     """
     fut = context.get_value(op.operands[0])
     if not isinstance(fut, TileFuture):
@@ -1060,15 +1063,20 @@ def ktdp__inter_tile_reduce(op, context, env):
             f"ktdp.inter_tile_reduce: operand 0 must be a TileFuture, got {type(fut)}"
         )
 
-    if fut.local_partial is None:
-        raise RuntimeError(
-            f"ktdp.inter_tile_reduce on core {context.core_id}: future has no "
-            f"local_partial — this core was not in producer_tiles_per_group"
-        )
-    local_tile = fut.local_partial[0]   # v1 N=1 role
+    # Producers see local_partial; non-producers seed the ring with
+    # the identity tensor instead.  ``RingReduceBackend.run`` does the
+    # mask check via ``plan.is_producer``.
+    local_tile = fut.local_partial[0] if fut.local_partial else None
+    identity = context.get_value(op.operands[1])
 
-    num_cores = env.grid_executor.num_cores
-    core_group = _producer_core_group(fut.producer_set, fut.group_idx, num_cores)
+    # Build the logical plan.
+    plan = CommPlan.for_reduce(
+        producer_set=fut.producer_set,
+        consumer_set=op.attributes["consumer_tiles_per_group"],
+        group_idx=fut.group_idx,
+        num_cores=context.num_cores,
+        dep_set=op.attributes.get("producer_dependency_per_consumer"),
+    )
 
     # Build reduce_fn from the combiner region.
     region = op.regions[0] if op.regions else []
@@ -1096,14 +1104,9 @@ def ktdp__inter_tile_reduce(op, context, env):
             )
         return result
 
-    # Trigger the future's backend.  RingReduceBackend.run takes
-    # reduce_fn at run() time so the same backend instance can back
-    # any delivery op (reduce / reduce_scatter / consume).  The
-    # backend is a generator (yields RecvRequest) and stamps its own
-    # ``comm_bytes`` on the result; ``attach_reshape`` drives it and
-    # collapses the within-group tile axis to give T_r.
+    backend = _select_reduce_backend(plan, op.attributes)
     target_shape = op.attributes.get("_result_shape")
-    raw = fut.backend.run(context, local_tile, core_group, reduce_fn)
+    raw = backend.run(context, local_tile, plan, reduce_fn, identity)
     return attach_reshape(raw, target_shape)
 
 

--- a/ktir_cpu/dialects/ktdp_ops.py
+++ b/ktir_cpu/dialects/ktdp_ops.py
@@ -16,7 +16,7 @@
 
 import re
 
-from .ktdp_helpers import parse_subscript_expr
+from .ktdp_helpers import attach_reshape, parse_subscript_expr
 from ..affine import BoxSet
 from ..ir_types import (
     AccessTile,
@@ -1096,44 +1096,15 @@ def ktdp__inter_tile_reduce(op, context, env):
             )
         return result
 
-    target_shape = op.attributes.get("_result_shape")
-
-    def _reshape(reduced) -> Tile:
-        if not isinstance(reduced, Tile):
-            raise TypeError(
-                f"ktdp.inter_tile_reduce: expected Tile from backend, "
-                f"got {type(reduced).__name__}"
-            )
-        if target_shape is None or reduced.shape == tuple(target_shape):
-            return reduced
-        from numpy import prod
-        if int(prod(reduced.shape)) != int(prod(target_shape)):
-            raise ValueError(
-                f"ktdp.inter_tile_reduce: result shape {reduced.shape} "
-                f"and declared T_r {target_shape} have different element counts"
-            )
-        return Tile(
-            reduced.data.reshape(target_shape),
-            reduced.dtype,
-            tuple(target_shape),
-            unique_sticks=reduced.unique_sticks,
-            index_unique_sticks=reduced.index_unique_sticks,
-        )
-
     # Trigger the future's backend.  RingReduceBackend.run takes
     # reduce_fn at run() time so the same backend instance can back
-    # any delivery op (reduce / reduce_scatter / consume).  The backend
-    # is a generator (yields RecvRequest); the wrapper drives it,
-    # reshapes T_p -> T_r, and stamps comm_bytes onto the result for the
-    # latency tracker.
+    # any delivery op (reduce / reduce_scatter / consume).  The
+    # backend is a generator (yields RecvRequest) and stamps its own
+    # ``comm_bytes`` on the result; ``attach_reshape`` drives it and
+    # collapses the within-group tile axis to give T_r.
+    target_shape = op.attributes.get("_result_shape")
     raw = fut.backend.run(context, local_tile, core_group, reduce_fn)
-
-    def _gen():
-        reduced = yield from raw
-        final = _reshape(reduced)
-        final.comm_bytes = fut.backend.bytes_moved
-        return final
-    return _gen()
+    return attach_reshape(raw, target_shape)
 
 
 @register_parser("ktdp.inter_tile_reduce")

--- a/ktir_cpu/dialects/ktdp_ops.py
+++ b/ktir_cpu/dialects/ktdp_ops.py
@@ -34,7 +34,7 @@ from ..ops.comm_ops import RingReduceBackend
 from ..ops.grid_ops import GridOps
 from ..ops.memory_ops import MemoryOps
 from ..parser_ast import parse_affine_map, parse_affine_set
-from ..parser_utils import _extract_bracket_content, find_ssa_names, parse_attr_block, parse_multi_result_lhs, parse_tensor_type, split_top_level
+from ..parser_utils import _extract_bracket_content, extract_named_attr, find_ssa_names, parse_attr_block, parse_multi_result_lhs, parse_tensor_type, split_top_level
 from .registry import ParseContext, register, register_parser
 
 
@@ -881,52 +881,6 @@ def _find_tile_group(tile_id, producer_set, groups_set):
     return matches[0]
 
 
-def _extract_named_attr(op_text: str, key: str, aliases: dict | None = None):
-    """Extract a single bare ``key = value`` attribute from ``op_text``.
-
-    The four inter-tile ops carry their attributes bare (no enclosing
-    ``{ ... }`` block) — e.g.
-    ``producer_tiles_per_group = #all_tiles, groups = #one_group``.
-    Returns the resolved value string (alias-resolved when applicable),
-    or ``None`` if not found.
-    """
-    # Match `key =` then capture either an `#alias`, a `keyword<...>`
-    # value, or a bare token up to the next comma / colon / arrow / brace.
-    m = re.search(rf'\b{re.escape(key)}\s*=\s*', op_text)
-    if not m:
-        return None
-    rest = op_text[m.end():].lstrip()
-
-    if rest.startswith('#'):
-        end = re.search(r'[,\n}]|\s+:|\s*->', rest)
-        raw = rest[:end.start()].strip() if end else rest.strip()
-        return aliases.get(raw, raw) if aliases else raw
-
-    kw_m = re.match(r'[\w.]+<', rest)
-    if kw_m:
-        i = kw_m.end() - 1
-        depth = 0
-        while i < len(rest):
-            ch = rest[i]
-            if ch == '>' and i + 1 < len(rest) and rest[i + 1] == '=':
-                i += 2
-                continue
-            if ch == '-' and i + 1 < len(rest) and rest[i + 1] == '>':
-                i += 2
-                continue
-            if ch == '<':
-                depth += 1
-            elif ch == '>':
-                depth -= 1
-                if depth == 0:
-                    return rest[:i + 1]
-            i += 1
-        return rest
-
-    end = re.search(r'[,\n}]|\s+:|\s*->', rest)
-    return rest[:end.start()].strip() if end else rest.strip()
-
-
 def _producer_core_group(producer_set, group_idx, num_cores):
     """Return the list of tile ids in ``producer_tiles_per_group(group_idx)``,
     ascending. Used as the ``core_group`` argument to ``RingReduceBackend.run``.
@@ -999,12 +953,12 @@ def parse_inter_tile_produce(op_text, parse_ctx: ParseContext):
         return None
     result_name = m.group(1)
 
-    producer_set_str = _extract_named_attr(
+    producer_set_str = extract_named_attr(
         op_text, "producer_tiles_per_group", parse_ctx.aliases
     )
     if producer_set_str is None:
         raise ValueError("ktdp.inter_tile_produce: missing producer_tiles_per_group")
-    groups_str = _extract_named_attr(op_text, "groups", parse_ctx.aliases)
+    groups_str = extract_named_attr(op_text, "groups", parse_ctx.aliases)
     if groups_str is None:
         raise ValueError("ktdp.inter_tile_produce: missing groups")
 
@@ -1193,19 +1147,19 @@ def parse_inter_tile_reduce(op_text, parse_ctx: ParseContext):
     result_name = m.group(1)
     fut_operand = m.group(2)
 
-    consumer_set_str = _extract_named_attr(
+    consumer_set_str = extract_named_attr(
         op_text, "consumer_tiles_per_group", parse_ctx.aliases
     )
     if consumer_set_str is None:
         raise ValueError("ktdp.inter_tile_reduce: missing consumer_tiles_per_group")
     consumer_set = parse_affine_set(consumer_set_str)
 
-    groups_str = _extract_named_attr(op_text, "groups", parse_ctx.aliases)
+    groups_str = extract_named_attr(op_text, "groups", parse_ctx.aliases)
     if groups_str is None:
         raise ValueError("ktdp.inter_tile_reduce: missing groups")
     groups_set = parse_affine_set(groups_str)
 
-    pdpc_str = _extract_named_attr(
+    pdpc_str = extract_named_attr(
         op_text, "producer_dependency_per_consumer", parse_ctx.aliases
     )
     pdpc = parse_affine_set(pdpc_str) if pdpc_str is not None else None

--- a/ktir_cpu/dialects/linalg_ops.py
+++ b/ktir_cpu/dialects/linalg_ops.py
@@ -218,6 +218,22 @@ def linalg__reduce(op, context, env):
     return result
 
 
+@register("linalg.add", latency_category=LC.COMPUTE_FLOAT)
+def linalg__add(op, context, env):
+    """Elementwise tensor add — ``%c = linalg.add ins(%a, %b) outs(%init)``.
+
+    Standard MLIR named op: result = a + b (the outs buffer provides the
+    destination shape only; its values are not accumulated into in v1).
+    """
+    tile_a = context.get_value(op.operands[0])
+    tile_b = context.get_value(op.operands[1])
+    if not isinstance(tile_a, Tile) or not isinstance(tile_b, Tile):
+        raise TypeError(
+            f"linalg.add: ins must be Tiles, got {type(tile_a)} and {type(tile_b)}"
+        )
+    return Tile(tile_a.data + tile_b.data, tile_a.dtype, tile_a.shape)
+
+
 @register("linalg.fill")
 def linalg__fill(op, context, env):
     """Fill a tensor with a scalar value."""

--- a/ktir_cpu/dialects/scf_ops.py
+++ b/ktir_cpu/dialects/scf_ops.py
@@ -80,9 +80,6 @@ def _return_alias(op, context, env):
     return func__return(op, context, env)
 
 
-# ktdp.transfer / ktdp.reduce moved to ktdp_ops.py (alongside other ktdp.* ops).
-
-
 # ---------------------------------------------------------------------------
 # Parsers
 # ---------------------------------------------------------------------------

--- a/ktir_cpu/grid.py
+++ b/ktir_cpu/grid.py
@@ -101,11 +101,13 @@ class CoreContext:
         # ring_backend → transfer_backend nomenclature site by site.
         self._send_fn: Optional[Callable[[int, "Tile"], None]] = None
         self._transfer_fn: Optional[Callable[[int], LXScratchpad]] = None
+        self._num_cores: Optional[int] = None
 
     def attach_scheduler(
         self,
         send_fn: Callable[[int, "Tile"], None],
         transfer_fn: Callable[[int], LXScratchpad],
+        num_cores: int,
     ) -> None:
         """Wire scheduler-managed cross-core access for the duration of a run.
 
@@ -114,16 +116,37 @@ class CoreContext:
         the scheduler's message queue; ``transfer_fn(src_core)`` returns
         the LXScratchpad for a remote core (only invoked for genuinely
         remote cores — local fast path stays in ``get_lx``).
+        ``num_cores`` is the workgroup size; backends read it via
+        :attr:`num_cores` to size their protocols (e.g. ``RingReduceBackend``
+        runs ``num_cores - 1`` rounds).
 
         The binding is valid until ``detach_scheduler`` is called.
         """
         self._send_fn = send_fn
         self._transfer_fn = transfer_fn
+        self._num_cores = num_cores
 
     def detach_scheduler(self) -> None:
         """Clear the scheduler bindings installed by :meth:`attach_scheduler`."""
         self._send_fn = None
         self._transfer_fn = None
+        self._num_cores = None
+
+    @property
+    def num_cores(self) -> int:
+        """Workgroup size, available while a scheduler is attached.
+
+        Distinct from ``HardwareConfig.num_cores`` — that one models
+        the chip's per-core HBM bandwidth divisor and stays where it
+        is.  This is the live workgroup size the IR's ``grid``
+        attribute names.
+        """
+        if self._num_cores is None:
+            raise RuntimeError(
+                f"CoreContext(core_id={self.core_id}).num_cores accessed "
+                f"without an attached scheduler"
+            )
+        return self._num_cores
 
     def get_lx(self, core_id: Optional[int] = None) -> LXScratchpad:
         """Return the LXScratchpad for *core_id*.
@@ -528,7 +551,11 @@ class GridExecutor:
                         "transfer_fn invoked but no transfer_backend was "
                         "passed to execute_with_communication."
                     )
-            core.attach_scheduler(send_fn=send_fn, transfer_fn=transfer_fn)
+            core.attach_scheduler(
+                send_fn=send_fn,
+                transfer_fn=transfer_fn,
+                num_cores=self.num_cores,
+            )
             stacks[core.core_id] = CoreExecutionStack(core, operations, input_ptrs, execute_op)
             _advance(core.core_id)
 

--- a/ktir_cpu/interpreter.py
+++ b/ktir_cpu/interpreter.py
@@ -223,13 +223,53 @@ class KTIRInterpreter:
                 if isinstance(result, Tile):
                     context.track_lx(op.result, result.size_bytes())
 
-        # Record latency
+        # Record latency.
+        # Sync handlers: charge now, with the final value.
+        # Generator handlers (comm ops): the handler returned a generator
+        # whose body has not yet run.  The "real" result is only known
+        # after the scheduler drives ``yield from`` to completion.  Wrap
+        # the generator so the record fires once it returns its final
+        # value.  Skip wrapping entirely when the tracker is off, so the
+        # cost-free path stays cost-free.
         if self._latency_tracker is not None:
-            self._latency_tracker.record_op(
-                context.core_id, op.op_type, result, resolved_operands
-            )
+            if inspect.isgenerator(result):
+                result = self._wrap_latency_counter(
+                    result, op, context, resolved_operands)
+            else:
+                self._latency_tracker.record_op(
+                    context.core_id, op.op_type, result, resolved_operands
+                )
 
         return result
+
+    def _wrap_latency_counter(
+        self,
+        gen: Generator,
+        op: Operation,
+        context: CoreContext,
+        resolved_operands: List[Any],
+    ) -> Generator:
+        """Wrap a handler-returned generator so ``record_op`` fires after
+        the generator yields its final value.
+
+        Used for comm ops (`ktdp.inter_tile_reduce`, etc.) whose handler
+        returns a generator whose body runs only after the scheduler
+        drives ``yield from``.  The wrapper preserves the original
+        generator's ``yield`` protocol (``RecvRequest``s flow through
+        unchanged via ``yield from``) and emits the latency record when
+        the inner generator returns, with the *real* final result rather
+        than the placeholder generator object.
+        """
+        tracker = self._latency_tracker
+        core_id = context.core_id
+        op_type = op.op_type
+
+        def _wrapped():
+            final = yield from gen
+            tracker.record_op(core_id, op_type, final, resolved_operands)
+            return final
+
+        return _wrapped()
 
     def arg_names(self, func_name: str) -> List[str]:
         """Return argument names for a function in declaration order (without %)."""

--- a/ktir_cpu/ir_types.py
+++ b/ktir_cpu/ir_types.py
@@ -30,10 +30,15 @@ Types are ordered by the data-flow pipeline:
 """
 
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 import numpy as np
 
 from .affine import AffineMap, AffineSet, BoxSet
+
+if TYPE_CHECKING:
+    # comm_ops imports Tile from this module; use a TYPE_CHECKING ref to
+    # avoid the cycle while still giving mypy/IDEs the precise type.
+    from .ops.comm_ops import ReduceBackend
 
 # Type alias for TileRef.coordinate_set: parsed affine sets lower to BoxSet
 # at parse time when axis-aligned; non-box sets stay as AffineSet; the
@@ -247,6 +252,15 @@ class Tile:
     # so that ``coalescing_efficiency`` retains its data-layout meaning.
     # None for direct loads (no index tensors) and compute-produced tiles.
     index_unique_sticks: Optional[int] = None
+    # Total bytes moved across cores by the comm op that produced this
+    # tile.  Set by ``ktdp.inter_tile_reduce`` (and future delivery ops)
+    # from the transport backend's accumulated send total.  None for any
+    # tile not produced by a comm op.  The latency tracker reads this
+    # off the result for stick-granular comm bandwidth accounting,
+    # mirroring how ``unique_sticks`` carries memory provenance.  Not
+    # propagated by ``copy()`` — the bytes belong to the production
+    # event, not to copies of the data.
+    comm_bytes: Optional[int] = None
 
     def copy(self) -> 'Tile':
         """Create a deep copy of this tile.
@@ -316,6 +330,40 @@ class IndirectAccessTile:
     index_views: List[MemRef]                   # index memrefs for indirect dims (used for byte_address)
     variables_space_set: AffineSet              # domain of intermediate variables
     variables_space_order: Optional[AffineMap]  # iteration order; None = default
+
+
+@dataclass
+class TileFuture:
+    """Per-core handle produced by ``ktdp.inter_tile_produce``.
+
+    Holds *this* core's contribution and the not-yet-running transport
+    backend that the matching delivery op will trigger. SPMD: each core
+    has its own ``TileFuture`` instance bound to its local ``%fut``
+    SSA value; cross-core data movement happens via the scheduler's
+    mailbox once ``backend.run`` starts, not by reading other cores'
+    futures.
+
+    Fields:
+      ``partial_tensor_types``: declared T_p_1, ..., T_p_N (verbatim).
+      ``local_partial``: this core's yielded tile(s) — the seed for the
+          transport. ``None`` when the core is in ``groups_set`` but
+          outside ``producer_set`` (would-be identity contribution; v1
+          rejects this case downstream).
+      ``backend``: a ``ReduceBackend`` instance with no ``reduce_fn``
+          bound yet. The delivery op constructs the fold from its own
+          combiner region and passes it to ``backend.run``.
+      ``producer_set`` / ``groups_set``: parsed IR sets, kept on the
+          future so the consumer handler can compute its core_group
+          without re-parsing.
+      ``group_idx``: the group this core belongs to, computed once at
+          produce time.
+    """
+    partial_tensor_types: Tuple[str, ...]
+    local_partial: Optional[Tuple['Tile', ...]]
+    backend: "ReduceBackend"
+    producer_set: AffineSet
+    groups_set: AffineSet
+    group_idx: int
 
 
 @dataclass

--- a/ktir_cpu/ir_types.py
+++ b/ktir_cpu/ir_types.py
@@ -30,15 +30,10 @@ Types are ordered by the data-flow pipeline:
 """
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 import numpy as np
 
 from .affine import AffineMap, AffineSet, BoxSet
-
-if TYPE_CHECKING:
-    # comm_ops imports Tile from this module; use a TYPE_CHECKING ref to
-    # avoid the cycle while still giving mypy/IDEs the precise type.
-    from .ops.comm_ops import ReduceBackend
 
 # Type alias for TileRef.coordinate_set: parsed affine sets lower to BoxSet
 # at parse time when axis-aligned; non-box sets stay as AffineSet; the
@@ -347,20 +342,17 @@ class TileFuture:
       ``partial_tensor_types``: declared T_p_1, ..., T_p_N (verbatim).
       ``local_partial``: this core's yielded tile(s) — the seed for the
           transport. ``None`` when the core is in ``groups_set`` but
-          outside ``producer_set`` (would-be identity contribution; v1
-          rejects this case downstream).
-      ``backend``: a ``ReduceBackend`` instance with no ``reduce_fn``
-          bound yet. The delivery op constructs the fold from its own
-          combiner region and passes it to ``backend.run``.
+          outside ``producer_set`` (non-producer cores still run the
+          delivery op so they participate in the workgroup-wide
+          protocol; the backend substitutes ``identity`` for them).
       ``producer_set`` / ``groups_set``: parsed IR sets, kept on the
-          future so the consumer handler can compute its core_group
+          future so the consumer handler can build a ``CommPlan``
           without re-parsing.
       ``group_idx``: the group this core belongs to, computed once at
           produce time.
     """
     partial_tensor_types: Tuple[str, ...]
     local_partial: Optional[Tuple['Tile', ...]]
-    backend: "ReduceBackend"
     producer_set: AffineSet
     groups_set: AffineSet
     group_idx: int

--- a/ktir_cpu/ir_types.py
+++ b/ktir_cpu/ir_types.py
@@ -331,25 +331,38 @@ class IndirectAccessTile:
 class TileFuture:
     """Per-core handle produced by ``ktdp.inter_tile_produce``.
 
-    Holds *this* core's contribution and the not-yet-running transport
-    backend that the matching delivery op will trigger. SPMD: each core
-    has its own ``TileFuture`` instance bound to its local ``%fut``
-    SSA value; cross-core data movement happens via the scheduler's
-    mailbox once ``backend.run`` starts, not by reading other cores'
-    futures.
+    Holds *this* core's contribution to the inter-tile op.  SPMD:
+    each core has its own ``TileFuture`` instance bound to its local
+    ``%fut`` SSA value; cross-core data movement happens via the
+    scheduler's mailbox once the matching delivery op runs, not by
+    reading other cores' futures.
+
+    Def-use simulation
+    ------------------
+    The KTIR spec uses the SSA def-use edge ``%fut → consume(%fut)``
+    to (1) order produce before consume on each core and (2) pair a
+    delivery op with its matching produce.  This simulator does not
+    walk the IR's def-use graph for either role.  Both are absorbed
+    by ``TileFuture`` itself:
+      - ordering: ordinary SSA scoping (``ctx.get_value`` only
+        succeeds after produce has bound the name);
+      - pairing: the ``TileFuture`` instance the consume handler
+        receives *is* the edge — the producer-side data already
+        lives on the future the consumer holds.
 
     Fields:
       ``partial_tensor_types``: declared T_p_1, ..., T_p_N (verbatim).
-      ``local_partial``: this core's yielded tile(s) — the seed for the
-          transport. ``None`` when the core is in ``groups_set`` but
-          outside ``producer_set`` (non-producer cores still run the
-          delivery op so they participate in the workgroup-wide
-          protocol; the backend substitutes ``identity`` for them).
+      ``local_partial``: this core's yielded tile(s) — the seed for
+          the transport.  ``None`` when the core is in
+          ``groups_set`` but outside ``producer_set`` (non-producer
+          cores still run the delivery op so they participate in the
+          workgroup-wide protocol; the backend substitutes
+          ``identity`` for them).
       ``producer_set`` / ``groups_set``: parsed IR sets, kept on the
           future so the consumer handler can build a ``CommPlan``
           without re-parsing.
-      ``group_idx``: the group this core belongs to, computed once at
-          produce time.
+      ``group_idx``: the group this core belongs to, computed once
+          at produce time.
     """
     partial_tensor_types: Tuple[str, ...]
     local_partial: Optional[Tuple['Tile', ...]]

--- a/ktir_cpu/latency.py
+++ b/ktir_cpu/latency.py
@@ -26,7 +26,6 @@ Kernel latency = max across all cores (critical path).
 from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import Any, Dict, List, Optional, Tuple
-import math
 import numpy as np
 
 from .ir_types import AccessTile, IndirectAccessTile, MemRef, Tile, TileRef
@@ -244,15 +243,15 @@ class LatencyTracker:
             return ("compute", cycles, float(n_elems), 0)
 
         if category == LC.COMM:
-            # Ring communication (allgather, reduce, …): bytes over
-            # ring bandwidth.  No FLOPs — pure data movement.
-            # Reduce requires log2(num_cores) rounds.
-            nbytes = self._comm_size(operands)
+            # Ring/transport bytes for this core's contribution to the
+            # comm op.  When the dialect handler stamps ``comm_bytes`` on
+            # the result Tile (as ``ktdp.inter_tile_reduce`` does), use
+            # that exact per-core total — it reflects what the transport
+            # actually moved, including any per-tile sync subset.  The
+            # operand-based fallback is for legacy/test paths only.
+            nbytes = self._comm_size(result)
             bw = self.config.ring_bytes_per_cycle
             cycles = nbytes / bw if bw > 0 else 0.0
-            if op_type == "ktdp.reduce":
-                rounds = max(1, math.ceil(math.log2(self.config.num_cores)))
-                cycles *= rounds
             return ("comm", cycles, 0.0, nbytes)
 
         # Unknown category
@@ -371,12 +370,32 @@ class LatencyTracker:
         return (1, 1, 1)
 
     @staticmethod
-    def _comm_size(operands: List[Any]) -> int:
-        """Estimate bytes transferred by a communication operation."""
-        for v in operands:
-            if isinstance(v, Tile):
-                return v.data.nbytes
-        return 0
+    def _comm_size(result: Any) -> int:
+        """Bytes transferred by a communication operation.
+
+        Comm ops must stamp the per-core wire total onto the result
+        ``Tile.comm_bytes`` from inside the handler.
+        ``ktdp.inter_tile_reduce`` does this by reading
+        ``RingReduceBackend.bytes_moved`` after ``yield from`` returns
+        and assigning to ``final.comm_bytes``.  Future delivery ops
+        (``inter_tile_consume``, ``inter_tile_reduce_scatter``) follow
+        the same pattern.
+
+        Raises if the carrier is missing — it's a contract violation,
+        not a fallback case.
+        """
+        if not isinstance(result, Tile):
+            raise RuntimeError(
+                f"_comm_size: comm op result must be a Tile, got "
+                f"{type(result).__name__}"
+            )
+        if result.comm_bytes is None:
+            raise RuntimeError(
+                "_comm_size: Tile result on comm path must populate "
+                "comm_bytes; got None.  Comm-op handlers must stamp "
+                "comm_bytes from the transport backend's send total."
+            )
+        return result.comm_bytes
 
 
 # ---------------------------------------------------------------------------

--- a/ktir_cpu/mlir_frontend/parser.py
+++ b/ktir_cpu/mlir_frontend/parser.py
@@ -156,6 +156,7 @@ def _no_attrs(mlir_op, attributes, result_type, operands):
 
 MLIRTypeAdapter.install(
     "func.return",
+    "linalg.add",
     "linalg.fill",
     "linalg.matmul",
     "linalg.batch_matmul",

--- a/ktir_cpu/ops/comm_ops.py
+++ b/ktir_cpu/ops/comm_ops.py
@@ -20,7 +20,9 @@ dialect handlers in ``ktir_cpu.dialects``.
 """
 
 from abc import ABC, abstractmethod
-from typing import Callable, Dict, Generator, List, Type, Union
+from dataclasses import dataclass
+from typing import Callable, Dict, FrozenSet, Generator, List, Optional, Tuple, Type, Union
+from ..affine import AffineSet
 from ..ir_types import Tile
 from ..grid import CoreContext, RecvRequest
 from ..memory import LXScratchpad, SpyreMemoryHierarchy
@@ -69,6 +71,96 @@ class InstantTransferBackend(TransferBackend):
 
 
 # ---------------------------------------------------------------------------
+# CommPlan — logical input to a ReduceBackend
+# ---------------------------------------------------------------------------
+# The dialect handler builds a CommPlan from the IR's affine sets at
+# consume-op entry; the backend reads it to know who participates and
+# (when set) which producers each consumer depends on.  Pure logical:
+# no ring order, no neighbour relation, no schedule, no topology —
+# those are the backend's concern.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CommPlan:
+    """Logical structure of one inter-tile op: who produces, who
+    consumes, who depends on whom.
+
+    Built fresh by the consume handler at op entry from the future's
+    parsed sets and the consume op's own attributes; passed to
+    ``ReduceBackend.run``; discarded when ``run`` returns.
+
+    Fields:
+      ``producers``: tile ids producing partials in this group.
+      ``consumers``: tile ids that should hold the result.
+      ``deps``: optional ``producer_dependency_per_consumer`` resolved
+          to ``{consumer_id: frozenset[producer_id]}``.  ``None`` =
+          full-barrier mode (every consumer depends on every producer).
+    """
+    producers: Tuple[int, ...]
+    consumers: Tuple[int, ...]
+    deps: Optional[Dict[int, FrozenSet[int]]] = None
+
+    def is_producer(self, core_id: int) -> bool:
+        return core_id in self.producers
+
+    def is_consumer(self, core_id: int) -> bool:
+        return core_id in self.consumers
+
+    def producers_for(self, consumer_id: int) -> FrozenSet[int]:
+        """Producers this consumer depends on.
+
+        Full-barrier (``deps`` is ``None``) → every producer.
+        Per-tile sync (``deps`` set) → the declared subset for this
+        consumer; raises ``KeyError`` if the consumer is missing
+        from the deps map (caller bug — every consumer must appear).
+        """
+        if self.deps is None:
+            return frozenset(self.producers)
+        return self.deps[consumer_id]
+
+    @classmethod
+    def for_reduce(
+        cls,
+        *,
+        producer_set: AffineSet,
+        consumer_set: AffineSet,
+        group_idx: int,
+        num_cores: int,
+        dep_set: Optional[AffineSet] = None,
+    ) -> "CommPlan":
+        """Build a CommPlan for an ``inter_tile_reduce`` op.
+
+        Enumerates ``producer_set`` and ``consumer_set`` over the
+        ``num_cores`` workgroup at the bound ``group_idx``.  When
+        ``dep_set`` is given, evaluates it as ``(p)[c, g]`` (or
+        ``(p)[c]`` when group-independent) for each consumer to
+        populate ``deps``.
+        """
+        producers = tuple(
+            i for i in range(num_cores)
+            if producer_set.contains([i], [group_idx])
+        )
+        consumers = tuple(
+            i for i in range(num_cores)
+            if consumer_set.contains([i], [group_idx])
+        )
+        deps: Optional[Dict[int, FrozenSet[int]]] = None
+        if dep_set is not None:
+            # producer_dependency_per_consumer is parameterised either
+            # ``(p)[c]`` (group-independent: one symbol) or ``(p)[c, g]``
+            # (group-aware: two symbols).  Both shapes pass through
+            # ``contains`` cleanly with the right symbol vector.
+            deps = {}
+            for c in consumers:
+                syms = [c, group_idx] if dep_set.n_syms >= 2 else [c]
+                deps[c] = frozenset(
+                    p for p in producers if dep_set.contains([p], syms)
+                )
+        return cls(producers=producers, consumers=consumers, deps=deps)
+
+
+# ---------------------------------------------------------------------------
 # Reduce backends
 # ---------------------------------------------------------------------------
 # A ReduceBackend owns the full reduce protocol — messaging, compute,
@@ -86,23 +178,24 @@ class InstantTransferBackend(TransferBackend):
 class ReduceBackend(ABC):
     """Abstract reduce algorithm — owns messaging, compute, completion.
 
-    ``run`` is called once per participating core. It may be a
+    ``run`` is called once per core in the workgroup.  It may be a
     generator (yields ``RecvRequest`` at each blocking point) or a
     plain function (synchronous algorithms, e.g. LX-scratchpad
     reduce). The scheduler treats both shapes uniformly via
     ``inspect.isgenerator``.
 
-    Returns the reduced tile for *this* core. Cores not in
-    ``core_group`` should return *tile* unchanged without
-    communicating.
+    Returns the reduced tile for *this* core if it is a consumer;
+    ``None`` otherwise.  ``CommPlan`` is a *mask*: non-producers
+    contribute ``identity`` so the fold stays well-defined;
+    non-consumers run the protocol but discard the result.
 
     Bandwidth accounting — the ``comm_bytes`` contract
     ----------------------------------------------------
     Subclasses MUST populate ``self.bytes_moved`` during ``run`` with
     the total bytes this core sent over the transport, then stamp it
-    onto ``result.comm_bytes`` before returning.  The latency tracker
-    reads ``comm_bytes`` from the result in ``_comm_size`` to charge
-    ring bandwidth.  End-to-end:
+    onto ``result.comm_bytes`` before returning (when returning a
+    Tile).  The latency tracker reads ``comm_bytes`` from the result
+    in ``_comm_size`` to charge ring bandwidth.  End-to-end:
 
         backend.run            : self.bytes_moved += tile.size_bytes()
                                  ...
@@ -111,10 +204,10 @@ class ReduceBackend(ABC):
         latency._comm_size     : return result.comm_bytes
 
     The dialect handler does not touch ``bytes_moved`` or
-    ``comm_bytes`` — the field is published by the backend that filled
-    it.  Backend instances are constructed fresh per op (one per core
-    per produce op via ``TileFuture``), so the counter starts at 0
-    and accumulates across the rounds of a single ``run``.
+    ``comm_bytes`` — the field is published by the backend that
+    filled it.  Backend instances are constructed fresh per call
+    (one per core per consume op), so the counter starts at 0 and
+    accumulates across the rounds of a single ``run``.
     """
 
     # Default bandwidth counter — subclasses overwrite during ``run``.
@@ -126,43 +219,50 @@ class ReduceBackend(ABC):
         self,
         context: CoreContext,
         tile: Tile,
-        core_group: List[int],
+        plan: "CommPlan",
         reduce_fn: Callable[[Tile, Tile], Tile],
-    ) -> Union[Tile, Generator[RecvRequest, Tile, Tile]]:
+        identity: Tile,
+    ) -> Union[Tile, None, Generator[RecvRequest, Tile, Union[Tile, None]]]:
         ...
 
 
 class RingReduceBackend(ReduceBackend):
-    """Ring reduction across *core_group* — one core's view.
+    """Ring reduction over the whole workgroup — one core's view.
 
-    Generator. Yields ``RecvRequest`` exactly ``len(core_group) - 1``
-    times. After all rounds every participating core holds the full
-    reduction (sum, max, …) of every starting tile in the group.
+    Generator. Every core in the workgroup runs the protocol; the
+    ring spans all ``ctx.num_cores`` cores in id order.  Yields
+    ``RecvRequest`` exactly ``num_cores - 1`` times.
 
-    Algorithm
-    ---------
-    Cores in *core_group* are arranged into a logical ring in list
-    order: each core sends to ``(my_idx + 1) % N`` and receives from
-    ``(my_idx - 1) % N``. The local core runs ``N-1`` rounds and
-    maintains two values:
+    ``CommPlan`` masks contributions and outputs:
 
-    - ``result``     — the accumulator, folded in via ``reduce_fn``.
+    - **Non-producers** inject ``identity`` so the fold remains
+      well-defined.  They still execute the protocol — they have to,
+      because they're on the wire — but their seed is the identity
+      tensor instead of a real partial.
+    - **Non-consumers** run the protocol but ``return None``; the
+      interpreter's SSA-bind logic skips storing ``None`` results,
+      matching the spec's "results are undefined for non-participants"
+      rule.
+
+    Layout: naive ``range(n)`` ring in core-id order.  Each core's
+    neighbour is ``(my_idx ± 1) % n``.  A different layout
+    (e.g. coordinated with sibling groups, or a snake through a 2-D
+    mesh) would be a different ``ReduceBackend`` subclass.
+
+    Algorithm — reduce-then-forward
+    -------------------------------
+    Each core maintains two values:
+
+    - ``result``     — the accumulator, folded via ``reduce_fn``.
     - ``to_forward`` — the tile to send next round.
 
-    In round 1, ``to_forward`` is the local starting tile. In every
-    subsequent round, ``to_forward`` is the tile we received the
-    previous round — we pass it onward unchanged. Each starting
-    tile thus travels exactly ``N-1`` hops around the ring, visiting
-    every other core once, and is folded into each visited core's
-    accumulator. After ``N-1`` rounds, every core's accumulator has
-    seen all ``N`` starting tiles, so every core holds the full
-    reduction.
-
-    This is the standard reduce-then-forward ring algorithm — not a
-    scan, and not all-to-all. Sending the *received* tile (rather
-    than the accumulator) is what keeps each value visiting every
-    core exactly once; sending the accumulator instead causes
-    double-counting.
+    Round 1's ``to_forward`` is the local seed (real partial for
+    producers, ``identity`` for non-producers).  Every subsequent
+    round forwards the tile *received* the previous round, unchanged.
+    Each starting tile thus travels exactly ``N - 1`` hops, visiting
+    every other core once, folded into each visited core's
+    accumulator.  Sending the accumulator instead would
+    double-count.
 
     Example: 4 cores, sum, starting values [1, 2, 3, 4]::
 
@@ -172,8 +272,7 @@ class RingReduceBackend(ReduceBackend):
           core 2:  recv 2 (from 1); send 3 to 3; acc = 3+2 = 5
           core 3:  recv 3 (from 2); send 4 to 0; acc = 4+3 = 7
         round 2:
-          core 0:  recv 3 (the tile that was at 3 last round);
-                   forward 4 to 1; acc = 5+3 = 8
+          core 0:  recv 3; forward 4 to 1; acc = 5+3 = 8
           core 1:  recv 4; forward 1 to 2; acc = 3+4 = 7
           core 2:  recv 1; forward 2 to 3; acc = 5+1 = 6
           core 3:  recv 2; forward 3 to 0; acc = 7+2 = 9
@@ -182,9 +281,6 @@ class RingReduceBackend(ReduceBackend):
           core 1:  recv 3; acc = 7+3 = 10
           core 2:  recv 4; acc = 6+4 = 10
           core 3:  recv 1; acc = 9+1 = 10
-
-    Cores not in *core_group* return *tile* unchanged without
-    communicating.
     """
 
     def __init__(self):
@@ -195,30 +291,56 @@ class RingReduceBackend(ReduceBackend):
         # re-assigning to self.
         self.bytes_moved = 0
 
-    def run(self, context, tile, core_group, reduce_fn):
-        if context.core_id not in core_group:
-            return tile
+    def run(self, context, tile, plan, reduce_fn, identity):
+        n = context.num_cores
+        next_core = (context.core_id + 1) % n
+        prev_core = (context.core_id - 1) % n
 
-        n_cores = len(core_group)
-        my_idx = core_group.index(context.core_id)
-        next_core = core_group[(my_idx + 1) % n_cores]
-        prev_core = core_group[(my_idx - 1) % n_cores]
+        # Seed.
+        # Producers start with their partial; non-producer consumers
+        # start with identity so the first fold gives the right
+        # answer.  ``to_forward`` is what this core injects onto the
+        # wire — its content matters only when the *receiving* core
+        # treats this core as an in-plan producer; otherwise the
+        # receiver discards it.  We default to ``tile`` for
+        # producers and ``identity`` for non-producers; the latter is
+        # arbitrary (any tile of the right shape works) but keeps the
+        # wire payload predictable.
+        is_prod = plan.is_producer(context.core_id)
+        seed = tile if is_prod else identity
+        result = seed.copy()       # accumulator
+        to_forward = seed.copy()   # tile to send next round (round 1: local)
 
-        result = tile.copy()       # accumulator
-        to_forward = tile.copy()   # tile to send next round (round 1: local)
-
-        for _ in range(n_cores - 1):
+        # Ring runs over the whole workgroup in lock-step: every core
+        # sends and receives every round, regardless of whether it's
+        # in ``plan.producers``.  The fold is plan-aware — only tiles
+        # originating from in-plan producers are folded into the
+        # accumulator.  Out-of-plan tiles still flow through
+        # (preserving lock-step) but are discarded at fold time.
+        #
+        # Origin tracking: the tile this core receives in round k from
+        # ``prev_core`` was originally produced by core
+        # ``(my_id - k) mod n`` in the ring's id-order layout.  Each
+        # subsequent round, the same tile is forwarded one hop further,
+        # so we just step the origin index.
+        my_id = context.core_id
+        for k in range(1, n):
+            origin = (my_id - k) % n
             self.bytes_moved += to_forward.size_bytes()
             context.send_to(next_core, to_forward)
             received = yield RecvRequest(src=prev_core)
-            result = reduce_fn(result, received)
+            if plan.is_producer(origin):
+                result = reduce_fn(result, received)
             to_forward = received  # pass received tile onward unchanged
 
+        # Mask: non-consumers run the ring but discard the result.
+        # The interpreter's SSA-bind ``if result is not None`` guard
+        # then skips storing anything for this core.
+        if not plan.is_consumer(context.core_id):
+            return None
+
         # Stamp the per-core wire total onto the result Tile so the
-        # latency tracker can read it via ``Tile.comm_bytes``.  Owning
-        # the field-set here (rather than the dialect handler) keeps
-        # the contract local: the backend that *fills* ``bytes_moved``
-        # is the one that *publishes* it.
+        # latency tracker can read it via ``Tile.comm_bytes``.
         result.comm_bytes = self.bytes_moved
         return result
 

--- a/ktir_cpu/ops/comm_ops.py
+++ b/ktir_cpu/ops/comm_ops.py
@@ -99,21 +99,22 @@ class ReduceBackend(ABC):
     Bandwidth accounting — the ``comm_bytes`` contract
     ----------------------------------------------------
     Subclasses MUST populate ``self.bytes_moved`` during ``run`` with
-    the total bytes this core sent over the transport.  The dialect
-    handler reads it once ``run`` completes and stamps the value onto
-    ``Tile.comm_bytes`` on the result; the latency tracker reads
-    ``comm_bytes`` from the result in ``_comm_size`` to charge ring
-    bandwidth.  End-to-end:
+    the total bytes this core sent over the transport, then stamp it
+    onto ``result.comm_bytes`` before returning.  The latency tracker
+    reads ``comm_bytes`` from the result in ``_comm_size`` to charge
+    ring bandwidth.  End-to-end:
 
         backend.run            : self.bytes_moved += tile.size_bytes()
-        dialect handler        : final.comm_bytes = backend.bytes_moved
+                                 ...
+                                 result.comm_bytes = self.bytes_moved
+                                 return result
         latency._comm_size     : return result.comm_bytes
 
-    The value is meaningful only after ``run`` returns; reading it
-    before is undefined.  Backend instances are constructed fresh per
-    op (one per core per produce op via ``TileFuture``), so the
-    counter starts at 0 and accumulates across the rounds of a single
-    ``run``.
+    The dialect handler does not touch ``bytes_moved`` or
+    ``comm_bytes`` — the field is published by the backend that filled
+    it.  Backend instances are constructed fresh per op (one per core
+    per produce op via ``TileFuture``), so the counter starts at 0
+    and accumulates across the rounds of a single ``run``.
     """
 
     # Default bandwidth counter — subclasses overwrite during ``run``.
@@ -213,6 +214,12 @@ class RingReduceBackend(ReduceBackend):
             result = reduce_fn(result, received)
             to_forward = received  # pass received tile onward unchanged
 
+        # Stamp the per-core wire total onto the result Tile so the
+        # latency tracker can read it via ``Tile.comm_bytes``.  Owning
+        # the field-set here (rather than the dialect handler) keeps
+        # the contract local: the backend that *fills* ``bytes_moved``
+        # is the one that *publishes* it.
+        result.comm_bytes = self.bytes_moved
         return result
 
 

--- a/ktir_cpu/ops/comm_ops.py
+++ b/ktir_cpu/ops/comm_ops.py
@@ -95,7 +95,30 @@ class ReduceBackend(ABC):
     Returns the reduced tile for *this* core. Cores not in
     ``core_group`` should return *tile* unchanged without
     communicating.
+
+    Bandwidth accounting — the ``comm_bytes`` contract
+    ----------------------------------------------------
+    Subclasses MUST populate ``self.bytes_moved`` during ``run`` with
+    the total bytes this core sent over the transport.  The dialect
+    handler reads it once ``run`` completes and stamps the value onto
+    ``Tile.comm_bytes`` on the result; the latency tracker reads
+    ``comm_bytes`` from the result in ``_comm_size`` to charge ring
+    bandwidth.  End-to-end:
+
+        backend.run            : self.bytes_moved += tile.size_bytes()
+        dialect handler        : final.comm_bytes = backend.bytes_moved
+        latency._comm_size     : return result.comm_bytes
+
+    The value is meaningful only after ``run`` returns; reading it
+    before is undefined.  Backend instances are constructed fresh per
+    op (one per core per produce op via ``TileFuture``), so the
+    counter starts at 0 and accumulates across the rounds of a single
+    ``run``.
     """
+
+    # Default bandwidth counter — subclasses overwrite during ``run``.
+    # Declared at class level so the contract is visible on the base.
+    bytes_moved: int = 0
 
     @abstractmethod
     def run(
@@ -103,6 +126,7 @@ class ReduceBackend(ABC):
         context: CoreContext,
         tile: Tile,
         core_group: List[int],
+        reduce_fn: Callable[[Tile, Tile], Tile],
     ) -> Union[Tile, Generator[RecvRequest, Tile, Tile]]:
         ...
 
@@ -162,10 +186,15 @@ class RingReduceBackend(ReduceBackend):
     communicating.
     """
 
-    def __init__(self, reduce_fn: Callable[[Tile, Tile], Tile]):
-        self.reduce_fn = reduce_fn
+    def __init__(self):
+        # Per-instance bandwidth counter.  The base class declares
+        # ``bytes_moved: int = 0`` at class level, but we re-init on
+        # the instance to avoid the class-level slot being shared
+        # across instances if a subclass ever mutates without
+        # re-assigning to self.
+        self.bytes_moved = 0
 
-    def run(self, context, tile, core_group):
+    def run(self, context, tile, core_group, reduce_fn):
         if context.core_id not in core_group:
             return tile
 
@@ -178,9 +207,10 @@ class RingReduceBackend(ReduceBackend):
         to_forward = tile.copy()   # tile to send next round (round 1: local)
 
         for _ in range(n_cores - 1):
+            self.bytes_moved += to_forward.size_bytes()
             context.send_to(next_core, to_forward)
             received = yield RecvRequest(src=prev_core)
-            result = self.reduce_fn(result, received)
+            result = reduce_fn(result, received)
             to_forward = received  # pass received tile onward unchanged
 
         return result

--- a/ktir_cpu/parser_utils.py
+++ b/ktir_cpu/parser_utils.py
@@ -200,9 +200,11 @@ def parse_attr_block(op_text: str, aliases: Optional[Dict] = None,
             continue
         pos += eq_m.end()
 
-        # Extract raw value string
+        # Extract raw value string; skip entry if value is absent
         raw, consumed = _extract_attr_value(block[pos:], aliases)
         pos += consumed
+        if not raw:
+            continue
 
         result[key] = _coerce_attr_value(raw)
 
@@ -238,6 +240,33 @@ def parse_attr_list(op_text: str, aliases: Optional[Dict] = None,
     return result
 
 
+def _scan_angle_bracketed(text: str, start: int) -> int:
+    """Return the index one past the closing ``>`` of an angle-bracketed span.
+
+    *start* must point at the opening ``<``.  Skips ``>=`` (constraint
+    operator) and ``->`` (affine_map arrow) so they are not mistaken for
+    closing brackets.  Returns ``len(text)`` if no matching ``>`` is found.
+    """
+    depth = 0
+    i = start
+    while i < len(text):
+        ch = text[i]
+        if ch == '>' and i + 1 < len(text) and text[i + 1] == '=':
+            i += 2
+            continue
+        if ch == '-' and i + 1 < len(text) and text[i + 1] == '>':
+            i += 2
+            continue
+        if ch == '<':
+            depth += 1
+        elif ch == '>':
+            depth -= 1
+            if depth == 0:
+                return i + 1
+        i += 1
+    return len(text)
+
+
 def extract_named_attr(op_text: str, key: str,
                        aliases: Optional[Dict] = None) -> Optional[str]:
     """Extract a single bare ``key = value`` attribute from ``op_text``.
@@ -265,24 +294,8 @@ def extract_named_attr(op_text: str, key: str,
     # keyword<...> values — count <> depth, skip >= and ->
     kw_m = re.match(r'[\w.]+<', rest)
     if kw_m:
-        i = kw_m.end() - 1
-        depth = 0
-        while i < len(rest):
-            ch = rest[i]
-            if ch == '>' and i + 1 < len(rest) and rest[i + 1] == '=':
-                i += 2
-                continue
-            if ch == '-' and i + 1 < len(rest) and rest[i + 1] == '>':
-                i += 2
-                continue
-            if ch == '<':
-                depth += 1
-            elif ch == '>':
-                depth -= 1
-                if depth == 0:
-                    return rest[:i + 1]
-            i += 1
-        return rest
+        end = _scan_angle_bracketed(rest, kw_m.end() - 1)
+        return rest[:end]
 
     # Plain token up to next comma / newline / brace / colon / arrow.
     end = re.search(r'[,\n}]|\s+:|\s*->', rest)
@@ -311,26 +324,8 @@ def _extract_attr_value(text: str, aliases: Optional[Dict]) -> tuple:
     # keyword<...> values — count <> depth, skip >= and ->
     kw_m = re.match(r'[\w.]+<', stripped)
     if kw_m:
-        i = kw_m.end() - 1  # index of opening '<'
-        depth = 0
-        while i < len(stripped):
-            ch = stripped[i]
-            # >= is a constraint operator, not a closing bracket
-            if ch == '>' and i + 1 < len(stripped) and stripped[i + 1] == '=':
-                i += 2
-                continue
-            # -> is the affine_map result arrow, not a bracket pair
-            if ch == '-' and i + 1 < len(stripped) and stripped[i + 1] == '>':
-                i += 2
-                continue
-            if ch == '<':
-                depth += 1
-            elif ch == '>':
-                depth -= 1
-                if depth == 0:
-                    return stripped[:i + 1], skip + i + 1
-            i += 1
-        return stripped, skip + len(stripped)
+        end = _scan_angle_bracketed(stripped, kw_m.end() - 1)
+        return stripped[:end], skip + end
 
     # Plain token up to next comma or closing brace
     end = re.search(r'[,}]', stripped)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -296,6 +296,23 @@ EXAMPLE_PARAMS: dict[str, list[dict]] = {
             "n_cols": 128,
         },
     ],
+    "ring_reduce_multi_group": [
+        {
+            "path": "latency/ring_reduce_multi_group.mlir",
+            # 16-core workgroup partitioned into 4 groups of 4; each
+            # group does an in-group all-reduce; the first core of
+            # each group (pid % 4 == 0) writes back to a per-group
+            # output row.
+            # grid = [16, 1, 1] → 16 cores; n_cols = 128.
+            # HBM stick layout:
+            #   sticks [0..31]  → 16 input rows × 2 sticks each (4096 bytes)
+            #   sticks [32..39] → 4 output rows × 2 sticks each (1024 bytes)
+            "execute_kwargs": {"in_ptr": 0, "out_ptr": 32},
+            "n_cols": 128,
+            "n_groups": 4,
+            "group_size": 4,
+        },
+    ],
 }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -286,12 +286,13 @@ EXAMPLE_PARAMS: dict[str, list[dict]] = {
     "ring_reduce": [
         {
             "path": "ktir/ring_reduce.mlir",
-            # 4-core ring reduce: ktdp.reduce (reduce_to_core<0>, sum, grid_axis<0>)
-            # grid = [4, 1, 1] → 4 cores; n_cols = 128 (from construct_memory_view sizes)
-            # HBM layout: in_ptr=0 (4×128×2=1024 bytes), out_ptr=1024 (128×2=256 bytes)
-            # xfail: parser support for #ktdp.reduce_kind / reduce_mode / grid_axis
-            # attributes not yet upstream (torch-spyre/ktir-mlir-frontend#21).
-            "execute_kwargs": {"in_ptr": 0, "out_ptr": 1024},
+            # 4-core all-reduce sum via ktdp.inter_tile_produce +
+            # ktdp.inter_tile_reduce; only core 0 writes back.
+            # grid = [4, 1, 1] → 4 cores; n_cols = 128 (from construct_memory_view sizes).
+            # HBM stick layout (1 stick = 128 bytes = 64 f16):
+            #   sticks [0..7]  → 4 input rows × 2 sticks each (1024 bytes total)
+            #   sticks [8..9]  → 1 output row × 2 sticks (256 bytes)
+            "execute_kwargs": {"in_ptr": 0, "out_ptr": 8},
             "n_cols": 128,
         },
     ],

--- a/tests/mlir_frontend/test_registry_consistency.py
+++ b/tests/mlir_frontend/test_registry_consistency.py
@@ -54,10 +54,19 @@ FRONTEND_UNSUPPORTED = {
     # to reconcile to the real op form or remove — NOT frontend gaps to fill.
     "arith.convertf": "not a real upstream arith op — unknown to the MLIR "
                       "parser; reconcile to a real cast op or remove.",
-    "ktdp.reduce": "non-spec op (not in the ktdp dialect). Reconcile to the "
-                   "real cross-core reduce form or remove. See issue #88.",
     "ktdp.coreid": "non-spec op (not in the ktdp dialect). Reconcile to the "
                    "real core-identity form or remove. See issue #88.",
+
+    # Real spec ops missing a frontend adapter handler — pending
+    # ktir-mlir-frontend#23 (inter-tile communication ops).
+    "ktdp.inter_tile_produce": "🧪 experimental op; no frontend adapter yet. "
+                               "Blocked on ktir-mlir-frontend#23.",
+    "ktdp.inter_tile_reduce": "🧪 experimental op; no frontend adapter yet. "
+                              "Blocked on ktir-mlir-frontend#23.",
+    "ktdp.yield_partial": "🧪 experimental terminator; no frontend adapter yet. "
+                          "Blocked on ktir-mlir-frontend#23.",
+    "ktdp.yield_reduced": "🧪 experimental terminator; no frontend adapter yet. "
+                          "Blocked on ktir-mlir-frontend#23.",
 
     # Real spec op missing only a frontend adapter handler (distinct from the
     # non-spec ops above).

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -566,6 +566,9 @@ class TestRingReduceExecution:
     (``ktdp.inter_tile_produce`` + ``ktdp.inter_tile_reduce``) — every
     core ends up holding the all-reduced sum, but only core 0 writes it
     back to HBM (gated by ``scf.if %is_writer``).
+
+    The latency-tracker breakdown for the same kernel lives in
+    ``tests/test_latency.py::TestRingReduceLatency``.
     """
 
     @pytest.mark.parametrize("path,func_name,entry", get_test_params("ring_reduce"))

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -559,14 +559,14 @@ class TestSdpaExecution(InterpreterTestMixin):
         np.testing.assert_allclose(result, expected, rtol=1e-2, atol=1e-2)
 
 
-@pytest.mark.xfail(
-    reason=(
-        "Requires parser support for #ktdp.reduce_kind / reduce_mode / grid_axis "
-        "attributes (torch-spyre/ktir-mlir-frontend#21)."
-    )
-)
 class TestRingReduceExecution:
-    """End-to-end execution of ring_reduce.mlir (xfail until parser updated)."""
+    """End-to-end execution of ring_reduce.mlir.
+
+    Exercises the new inter-tile communication ops
+    (``ktdp.inter_tile_produce`` + ``ktdp.inter_tile_reduce``) — every
+    core ends up holding the all-reduced sum, but only core 0 writes it
+    back to HBM (gated by ``scf.if %is_writer``).
+    """
 
     @pytest.mark.parametrize("path,func_name,entry", get_test_params("ring_reduce"))
     def test_ring_reduce_sum(self, path, func_name, entry):
@@ -584,11 +584,15 @@ class TestRingReduceExecution:
         interp = KTIRInterpreter()
         interp.load(path)
 
+        # ``in_ptr`` and ``out_ptr`` are HBM stick indices (matching the
+        # convention ``KTIRInterpreter.execute_function`` uses for ndarray
+        # kwargs).  Seed / read directly with them — no element-to-stick
+        # translation needed.
         _orig = interp._prepare_execution
 
         def _prepare_and_seed(grid_shape):
             _orig(grid_shape)
-            interp.memory.hbm.write(in_ptr, rows.flatten())
+            interp.memory.hbm.write(in_ptr,  rows.flatten())
             interp.memory.hbm.write(out_ptr, np.zeros(n_cols, dtype=np.float16))
 
         interp._prepare_execution = _prepare_and_seed

--- a/tests/test_grid_scheduler.py
+++ b/tests/test_grid_scheduler.py
@@ -184,16 +184,16 @@ def _sum_tiles(a: Tile, b: Tile) -> Tile:
 
 @register_reduce_backend("test.reduce", RingReduceBackend)
 def _h_reduce(op: Operation, ctx) -> Any:
-    """test.reduce — wraps CommOps.reduce with the registered backend.
+    """test.reduce — wraps RingReduceBackend.run with the registered backend.
 
-    Returns the generator produced by ``RingReduceBackend.run`` (via
-    ``CommOps.reduce``). The scheduler drives ``N-1`` ``RecvRequest``
-    yields per core; the final accumulator is bound to ``op.result``.
+    Returns the generator produced by ``RingReduceBackend.run``. The
+    scheduler drives ``N-1`` ``RecvRequest`` yields per core; the final
+    accumulator is bound to ``op.result``.
     """
     tile = ctx.get_value(op.operands[0])
     group = op.attributes["group"]
     backend_cls = get_reduce_backend(op.op_type)
-    return CommOps.reduce(ctx, tile, group, backend_cls(_sum_tiles))
+    return backend_cls().run(ctx, tile, group, _sum_tiles)
 
 
 _STUB_HANDLERS: Dict[str, Callable[[Operation, Any], Any]] = {
@@ -456,7 +456,7 @@ def test_ring_reduce(spec, execute_fn):
 # deadlock cases automatically.
 # ---------------------------------------------------------------------------
 
-def _broken_recv_only(self, ctx, tile, group):
+def _broken_recv_only(self, ctx, tile, group, reduce_fn):
     """Recv from the previous neighbor, never send. Every participating
     core blocks on round 1 → flat mutual-recv deadlock.
     """
@@ -469,7 +469,7 @@ def _broken_recv_only(self, ctx, tile, group):
     return tile
 
 
-def _broken_wrong_dest(self, ctx, tile, group):
+def _broken_wrong_dest(self, ctx, tile, group, reduce_fn):
     """Send to (idx+2) % n while recv-ing from (idx-1) % n. Every core's
     send lands in a queue no one reads from; every core's recv waits
     on a queue no one writes to. Deadlock at round 1.
@@ -485,7 +485,7 @@ def _broken_wrong_dest(self, ctx, tile, group):
     return tile
 
 
-def _broken_extra_recv(self, ctx, tile, group):
+def _broken_extra_recv(self, ctx, tile, group, reduce_fn):
     """Run N-1 ring rounds correctly, then dangle one extra recv. The
     final recv has no matching send → deadlock after the algorithm
     has otherwise made progress.
@@ -501,7 +501,7 @@ def _broken_extra_recv(self, ctx, tile, group):
     for _ in range(n - 1):
         ctx.send_to(next_core, to_forward)
         received = yield RecvRequest(src=prev_core)
-        result = self.reduce_fn(result, received)
+        result = reduce_fn(result, received)
         to_forward = received
     # Dangling recv — no one sent for this round.
     yield RecvRequest(src=prev_core)

--- a/tests/test_grid_scheduler.py
+++ b/tests/test_grid_scheduler.py
@@ -129,6 +129,7 @@ from ktir_cpu.ir_types import Operation, Tile
 from ktir_cpu.memory import SpyreMemoryHierarchy
 from ktir_cpu.ops.comm_ops import (
     CommOps,
+    CommPlan,
     RingReduceBackend,
     get_reduce_backend,
     register_reduce_backend,
@@ -186,14 +187,19 @@ def _sum_tiles(a: Tile, b: Tile) -> Tile:
 def _h_reduce(op: Operation, ctx) -> Any:
     """test.reduce — wraps RingReduceBackend.run with the registered backend.
 
-    Returns the generator produced by ``RingReduceBackend.run``. The
-    scheduler drives ``N-1`` ``RecvRequest`` yields per core; the final
-    accumulator is bound to ``op.result``.
+    Builds a ``CommPlan`` from the ``group`` attribute (treated as both
+    the producer set and the consumer set — synthetic all-reduce
+    semantics) and an identity tile of zeros matching the input shape.
+    Returns the generator produced by ``RingReduceBackend.run``; the
+    scheduler drives the per-round ``RecvRequest`` yields and the
+    final accumulator is bound to ``op.result``.
     """
     tile = ctx.get_value(op.operands[0])
-    group = op.attributes["group"]
+    group = tuple(op.attributes["group"])
+    plan = CommPlan(producers=group, consumers=group)
+    identity = Tile(np.zeros_like(tile.data), tile.dtype, tile.shape)
     backend_cls = get_reduce_backend(op.op_type)
-    return backend_cls().run(ctx, tile, group, _sum_tiles)
+    return backend_cls().run(ctx, tile, plan, _sum_tiles, identity)
 
 
 _STUB_HANDLERS: Dict[str, Callable[[Operation, Any], Any]] = {
@@ -456,46 +462,42 @@ def test_ring_reduce(spec, execute_fn):
 # deadlock cases automatically.
 # ---------------------------------------------------------------------------
 
-def _broken_recv_only(self, ctx, tile, group, reduce_fn):
-    """Recv from the previous neighbor, never send. Every participating
-    core blocks on round 1 → flat mutual-recv deadlock.
+def _broken_recv_only(self, ctx, tile, plan, reduce_fn, identity):
+    """Recv from the previous neighbor, never send. Every core in
+    the workgroup blocks on round 1 → flat mutual-recv deadlock.
+
+    Ring spans the whole workgroup; ``plan`` is informational only
+    in the broken stubs (the bug is in send/recv pairing, not in
+    the fold).
     """
-    if ctx.core_id not in group:
-        return tile
-    n = len(group)
-    my_idx = group.index(ctx.core_id)
-    prev = group[(my_idx - 1) % n]
+    n = ctx.num_cores
+    prev = (ctx.core_id - 1) % n
     yield RecvRequest(src=prev)
     return tile
 
 
-def _broken_wrong_dest(self, ctx, tile, group, reduce_fn):
-    """Send to (idx+2) % n while recv-ing from (idx-1) % n. Every core's
-    send lands in a queue no one reads from; every core's recv waits
-    on a queue no one writes to. Deadlock at round 1.
+def _broken_wrong_dest(self, ctx, tile, plan, reduce_fn, identity):
+    """Send to ``(my_id + 2) % n`` while recv-ing from
+    ``(my_id - 1) % n``. Every core's send lands in a queue no one
+    reads from; every core's recv waits on a queue no one writes to.
+    Deadlock at round 1.
     """
-    if ctx.core_id not in group:
-        return tile
-    n = len(group)
-    my_idx = group.index(ctx.core_id)
-    wrong_dst = group[(my_idx + 2) % n]
-    prev = group[(my_idx - 1) % n]
+    n = ctx.num_cores
+    wrong_dst = (ctx.core_id + 2) % n
+    prev = (ctx.core_id - 1) % n
     ctx.send_to(wrong_dst, tile)
     yield RecvRequest(src=prev)
     return tile
 
 
-def _broken_extra_recv(self, ctx, tile, group, reduce_fn):
+def _broken_extra_recv(self, ctx, tile, plan, reduce_fn, identity):
     """Run N-1 ring rounds correctly, then dangle one extra recv. The
     final recv has no matching send → deadlock after the algorithm
     has otherwise made progress.
     """
-    if ctx.core_id not in group:
-        return tile
-    n = len(group)
-    my_idx = group.index(ctx.core_id)
-    next_core = group[(my_idx + 1) % n]
-    prev_core = group[(my_idx - 1) % n]
+    n = ctx.num_cores
+    next_core = (ctx.core_id + 1) % n
+    prev_core = (ctx.core_id - 1) % n
     result = tile.copy()
     to_forward = tile.copy()
     for _ in range(n - 1):

--- a/tests/test_latency.py
+++ b/tests/test_latency.py
@@ -96,15 +96,11 @@ def _run_vector_reduce(path, func_name, entry, cfg, trace=False):
     """Run a vector reduce (per-core tile) and return report."""
     interp = KTIRInterpreter(latency_config=cfg, trace_latency=trace)
     interp.load(path)
-    # Build tensor args using the interpreter's declared arg names so we
-    # match the parser's normalization (arg0, arg1, ...).
     arg_names = interp.arg_names(func_name)
     sizes = interp.tensor_input_output_sizes(func_name)
 
-    # Use the first argument as the input tensor for the reduce example.
     arg0 = arg_names[0]
     shape = sizes[arg0]["shape"]
-    # shape may be a tuple like (1, 4)
     rng = np.random.default_rng(42)
     inp = rng.standard_normal(tuple(shape)).astype(np.float16)
 
@@ -115,6 +111,41 @@ def _run_vector_reduce(path, func_name, entry, cfg, trace=False):
     kwargs = {**scalars, **{arg0: inp}}
     interp.execute_function(func_name, **kwargs)
     return interp.get_latency_report()
+
+
+def _run_ring_reduce(path, func_name, entry, cfg, trace=False):
+    """Run ring_reduce on its 4-core grid and return ``(report, rows, n_cols)``.
+
+    Differs from the other ``_run_*`` helpers because ``ring_reduce.mlir``
+    takes raw stick-index pointers (``in_ptr`` / ``out_ptr``) rather than
+    ndarray kwargs.  We patch ``_prepare_execution`` to seed the input
+    rows after HBM allocation; this mirrors
+    ``test_examples.py::TestRingReduceExecution::test_ring_reduce_sum``.
+    Returning ``rows`` and ``n_cols`` lets callers compute the expected
+    ring-traffic byte count without re-deriving it.
+    """
+    meta = parse_example(path, func_name)
+    num_cores = math.prod(meta.grid)
+    n_cols = entry["n_cols"]
+    in_ptr = entry["execute_kwargs"]["in_ptr"]
+    out_ptr = entry["execute_kwargs"]["out_ptr"]
+
+    rng = np.random.default_rng(42)
+    rows = rng.uniform(1.0, 2.0, size=(num_cores, n_cols)).astype(np.float16)
+
+    interp = KTIRInterpreter(latency_config=cfg, trace_latency=trace)
+    interp.load(path)
+
+    _orig = interp._prepare_execution
+
+    def _prepare_and_seed(grid_shape):
+        _orig(grid_shape)
+        interp.memory.hbm.write(in_ptr,  rows.flatten())
+        interp.memory.hbm.write(out_ptr, np.zeros(n_cols, dtype=np.float16))
+
+    interp._prepare_execution = _prepare_and_seed
+    interp.execute_function(func_name, **entry["execute_kwargs"])
+    return interp.get_latency_report(), rows, n_cols
 
 
 # ---------------------------------------------------------------------------
@@ -1726,3 +1757,223 @@ class TestIndirectAccessLatency:
             f"load idx sticks={load_idx_sticks}, "
             f"store idx sticks={store_idx_sticks}, expected both to be 4"
         )
+
+
+# ---------------------------------------------------------------------------
+# Ring reduce latency — comm-dominated path
+# ---------------------------------------------------------------------------
+# 🧪 Experimental — tracks ktir-mlir-frontend#23.  Validates the
+# inter-tile + scheduler + latency pipeline: ring bytes accumulated by
+# RingReduceBackend land on Tile.comm_bytes and flow into the per-core
+# LatencyReport.  Correctness counterpart:
+# tests/test_examples.py::TestRingReduceExecution.
+
+class TestRingReduceLatency:
+    """Per-core latency report from the 4-core ring reduce in
+    ``examples/ktir/ring_reduce.mlir``.
+
+    Scope of validity
+    -----------------
+    This test pins ``comm_cycles = ring_bytes / ring_bytes_per_cycle``
+    for the kernel as written.  That formula is exact **only** under two
+    conditions, both of which hold here:
+
+    1. **Single group, contiguous cores.**  The kernel uses
+       ``producer_tiles_per_group = (i)[g] : (i - 4*g >= 0,
+       -i + 4*g + 3 >= 0)`` with ``groups = (g) : (g == 0)``, so the
+       producer set for the single group is ``{0, 1, 2, 3}`` — exactly
+       the four physical cores in core-id order.  ``RingReduceBackend``
+       lays the ring out in that order, so ``send_to(next_core, ...)``
+       is always a 1-hop transfer to the *immediate* neighbor:
+       0 → 1 → 2 → 3 → 0.
+
+    2. **No per-hop overhead in the latency model today.**  ``LC.COMM``
+       in ``latency.py`` charges ``bytes / ring_bytes_per_cycle`` and
+       nothing else.  No constant per-hop latency, no multi-hop scaling.
+
+    For any pattern where the producer set's logical order does **not**
+    match physical wire order — e.g. multi-group with strided membership
+    like ``{g, g+8, g+16, g+24}``, butterfly mirror, or one-to-many
+    broadcast — the model would underestimate and this test's cycle
+    assertion would no longer reflect the real cost.  The structural
+    assertions (per-core counts, category buckets, store-only-on-core-0)
+    remain valid regardless.  A multi-group latency test will need to
+    pin per-hop costs once that part of the model is added.
+
+    Ring layout — 4 cores, 3 rounds
+    -------------------------------
+    Each arrow ``→`` is one ``send_to`` of one ``1x128 f16`` payload
+    (256 bytes) to the *immediate* core-id neighbor.  The wire wraps
+    3 → 0.  Each core does ``N - 1 = 3`` rounds.  After round 3 every
+    core's accumulator has folded in every starting tile exactly once,
+    so all four cores hold ``t0 + t1 + t2 + t3``.
+
+    Each cell shows ``acc | fwd``: the accumulator value on that core
+    *after* the round's reduce, and the tile that core will *forward*
+    in the next round (= the tile it just received this round).
+    ``send`` annotations on the arrows show the round-1 payloads.
+
+                        round 1               round 2          round 3
+
+      core 0  start:t0  ┌── send t0 ─→┐    ┌── send t3 ─→┐    ┌── send t2 ─→┐
+                        │ recv t3      │    │ recv t2      │    │ recv t1      │
+                        │ acc=t0+t3    │    │ acc=t0+t3+t2 │    │ acc=Σt       │
+                        │ fwd=t3       │    │ fwd=t2       │    │              │
+                        └──────────────┘    └──────────────┘    └──────────────┘
+
+      core 1  start:t1  ┌── send t1 ─→┐    ┌── send t0 ─→┐    ┌── send t3 ─→┐
+                        │ recv t0      │    │ recv t3      │    │ recv t2      │
+                        │ acc=t1+t0    │    │ acc=t1+t0+t3 │    │ acc=Σt       │
+                        │ fwd=t0       │    │ fwd=t3       │    │              │
+                        └──────────────┘    └──────────────┘    └──────────────┘
+
+      core 2  start:t2  ┌── send t2 ─→┐    ┌── send t1 ─→┐    ┌── send t0 ─→┐
+                        │ recv t1      │    │ recv t0      │    │ recv t3      │
+                        │ acc=t2+t1    │    │ acc=t2+t1+t0 │    │ acc=Σt       │
+                        │ fwd=t1       │    │ fwd=t0       │    │              │
+                        └──────────────┘    └──────────────┘    └──────────────┘
+
+      core 3  start:t3  ┌── send t3 ─→┐    ┌── send t2 ─→┐    ┌── send t1 ─→┐
+                        │ recv t2      │    │ recv t1      │    │ recv t0      │
+                        │ acc=t3+t2    │    │ acc=t3+t2+t1 │    │ acc=Σt       │
+                        │ fwd=t2       │    │ fwd=t1       │    │              │
+                        └──────────────┘    └──────────────┘    └──────────────┘
+
+    Wire usage per core: 3 sends × 256 bytes = 768 bytes/core, all over
+    1-hop neighbor edges.  That's the byte total ``RingReduceBackend``
+    accumulates into ``self.bytes_moved`` and the consume handler stamps
+    onto ``Tile.comm_bytes``.
+
+    Per-core trace (each core, in order)
+    ------------------------------------
+    With ``HardwareConfig()`` defaults — ``simd_elements_per_cycle = 64``,
+    ``hbm_bandwidth_tb_s = 1.0``, ``ring_bandwidth_tb_s = 4.0``,
+    ``num_cores = 32`` — and a ``1 x 128 f16`` partial (256 bytes,
+    occupying 2 HBM sticks)::
+
+      arith.constant                  zero    cycles=0.0
+      arith.constant                  zero    cycles=0.0
+      ktdp.get_compute_tile_id        zero    cycles=0.0
+      arith.muli                      compute cycles=0.0   (scalar index)
+      arith.addi                      compute cycles=0.0   (scalar index)
+      ktdp.construct_memory_view      zero    cycles=0.0
+      ktdp.construct_access_tile      zero    cycles=0.0
+      ktdp.load                       memory  cycles=8.192 (256 bytes / 31.25 B/cyc)
+      ktdp.yield_partial              zero    cycles=0.0
+      ktdp.inter_tile_produce         zero    cycles=0.0   (no LC.COMM)
+      arith.constant                  zero    cycles=0.0
+      tensor.empty                    zero    cycles=0.0
+      linalg.fill                     zero    cycles=0.0
+      tensor.empty                    zero    cycles=0.0
+      linalg.add                      compute cycles=2.0   (128 elems / 64 simd)
+      ktdp.yield_reduced              zero    cycles=0.0
+      tensor.empty                    zero    cycles=0.0
+      linalg.add                      compute cycles=2.0   <- combiner round 2
+      ktdp.yield_reduced              zero    cycles=0.0
+      tensor.empty                    zero    cycles=0.0
+      linalg.add                      compute cycles=2.0   <- combiner round 3
+      ktdp.yield_reduced              zero    cycles=0.0
+      ktdp.inter_tile_reduce          comm    cycles=0.192 (768 bytes / 4000 B/cyc)
+      arith.cmpi                      compute cycles=0.015625 (1 elem / 64 simd)
+      [core 0 only:  tensor.expand_shape  zero    cycles=0.0]
+      [core 0 only:  ktdp.construct_memory_view  zero    cycles=0.0]
+      [core 0 only:  ktdp.construct_access_tile  zero    cycles=0.0]
+      [core 0 only:  ktdp.store              memory  cycles=8.192 (256 bytes)]
+      scf.if                          zero    cycles=0.0
+      return                          zero    cycles=0.0
+
+    The ring reduce contributes ``(N_ring - 1) * partial_bytes = 3 * 256
+    = 768`` bytes per core.  The combiner region (``linalg.add``) runs
+    ``N_ring - 1 = 3`` times on each core, once per ring round (the
+    backend's ``reduce_fn`` invocation; see
+    ``RingReduceBackend.run`` in ``ktir_cpu/ops/comm_ops.py``).
+
+    Per-core totals
+    ---------------
+    - All cores: ``compute = 2.0 * 3 + 0.015625 = 6.015625`` cycles,
+      ``comm = 0.192`` cycles.
+    - Cores 1, 2, 3: ``memory = 8.192`` cycles (one ``ktdp.load``).
+    - Core 0:       ``memory = 16.384`` cycles (``ktdp.load`` +
+      ``ktdp.store``).
+    - ``rep.kernel_cycles = max(total_cycles)`` is on core 0, since it
+      carries the extra HBM store.
+    """
+
+    @pytest.mark.parametrize("path,func_name,entry", get_test_params("ring_reduce"))
+    def test_ring_reduce_per_core_breakdown(self, path, func_name, entry):
+        cfg = HardwareConfig()
+        rep, rows, n_cols = _run_ring_reduce(
+            path, func_name, entry, cfg, trace=True
+        )
+
+        assert rep is not None, (
+            "latency report should be present when latency_config is set"
+        )
+
+        N_ring = rows.shape[0]                  # 4 producers per group
+        partial_bytes = n_cols * 2              # 1 x 128 f16 = 256 bytes
+        per_core_ring_bytes = (N_ring - 1) * partial_bytes
+        expected_comm_cycles = per_core_ring_bytes / cfg.ring_bytes_per_cycle
+
+        # Every core should have a counters record.
+        assert set(rep.counters.keys()) == set(range(N_ring))
+
+        # ---- Per-core invariants ----
+        for core_id, cc in rep.counters.items():
+            ops = [t.op_type for t in cc.trace]
+
+            # Each core runs the produce + reduce pair exactly once.
+            assert ops.count("ktdp.inter_tile_produce") == 1
+            assert ops.count("ktdp.inter_tile_reduce") == 1
+
+            # Produce is a metadata-only op now (no LC.COMM): cycles=0.
+            produce_entry = next(
+                t for t in cc.trace if t.op_type == "ktdp.inter_tile_produce"
+            )
+            assert produce_entry.cycles == 0
+            assert produce_entry.category == "zero"
+
+            # Reduce is the comm-charged op.  Bytes stamped onto
+            # Tile.comm_bytes by RingReduceBackend flow into the
+            # tracker via _comm_size; cycles = bytes /
+            # ring_bytes_per_cycle, with no log2(num_cores) multiplier
+            # (dropped in the per-message accounting redesign).
+            reduce_entry = next(
+                t for t in cc.trace if t.op_type == "ktdp.inter_tile_reduce"
+            )
+            assert reduce_entry.category == "comm"
+            assert reduce_entry.cycles == pytest.approx(expected_comm_cycles)
+
+            # Total per-core comm equals exactly the reduce charge —
+            # no other op in the trace contributes to the comm bucket.
+            assert cc.comm_cycles == pytest.approx(expected_comm_cycles)
+
+            # Cumulative comm bytes for this core (the only comm op is
+            # the reduce, so total_bytes - HBM-side load/store bytes
+            # equals the ring's per-core wire load).  We pin the comm
+            # bytes via the cycle assertion above; this asserts the
+            # aggregate counter agrees: ring bytes contribute exactly
+            # ``per_core_ring_bytes`` to ``total_bytes``.
+            # Note ``total_bytes`` also includes HBM bytes from
+            # ``ktdp.load`` / ``ktdp.store``, so we can't pin it on its
+            # own — we just assert it's at least the ring bytes.
+            assert cc.total_bytes >= per_core_ring_bytes
+
+            # Each core loads its own row from HBM exactly once.
+            assert ops.count("ktdp.load") == 1
+
+        # ---- Cross-core invariants ----
+        # Only core 0 writes back (gated by ``scf.if %is_writer``).
+        store_cores = [
+            cid for cid, cc in rep.counters.items()
+            if any(t.op_type == "ktdp.store" for t in cc.trace)
+        ]
+        assert store_cores == [0], (
+            f"expected only core 0 to ktdp.store, got {store_cores}"
+        )
+
+        # Kernel wall-clock = max of per-core total cycles.  Core 0
+        # carries the extra HBM store, so it must be the heaviest.
+        per_core_total = {cid: cc.total_cycles for cid, cc in rep.counters.items()}
+        assert rep.kernel_cycles == max(per_core_total.values())
+        assert per_core_total[0] >= max(per_core_total[c] for c in (1, 2, 3))

--- a/tests/test_latency.py
+++ b/tests/test_latency.py
@@ -148,6 +148,48 @@ def _run_ring_reduce(path, func_name, entry, cfg, trace=False):
     return interp.get_latency_report(), rows, n_cols
 
 
+def _run_ring_reduce_multi_group(path, func_name, entry, cfg, trace=False):
+    """Run the multi-group ring_reduce on its 16-core grid and return
+    ``(report, rows, n_cols, n_groups, group_size)``.
+
+    Mirrors ``_run_ring_reduce`` but for the 16-core, 4-group kernel
+    in ``examples/latency/ring_reduce_multi_group.mlir``.  Every core
+    holds its own 1×128 partial; the kernel runs four concurrent
+    in-group all-reduces and writes one output row per group.
+    """
+    meta = parse_example(path, func_name)
+    num_cores = math.prod(meta.grid)
+    n_cols = entry["n_cols"]
+    n_groups = entry["n_groups"]
+    group_size = entry["group_size"]
+    in_ptr = entry["execute_kwargs"]["in_ptr"]
+    out_ptr = entry["execute_kwargs"]["out_ptr"]
+
+    rng = np.random.default_rng(42)
+    rows = rng.uniform(1.0, 2.0, size=(num_cores, n_cols)).astype(np.float16)
+
+    interp = KTIRInterpreter(latency_config=cfg, trace_latency=trace)
+    interp.load(path)
+
+    _orig = interp._prepare_execution
+
+    def _prepare_and_seed(grid_shape):
+        _orig(grid_shape)
+        interp.memory.hbm.write(in_ptr,  rows.flatten())
+        interp.memory.hbm.write(out_ptr, np.zeros(n_groups * n_cols, dtype=np.float16))
+
+    interp._prepare_execution = _prepare_and_seed
+    interp.execute_function(func_name, **entry["execute_kwargs"])
+    return (
+        interp.get_latency_report(),
+        rows,
+        n_cols,
+        n_groups,
+        group_size,
+        interp.memory.hbm.read(out_ptr, n_groups * n_cols, "f16").reshape(n_groups, n_cols),
+    )
+
+
 # ---------------------------------------------------------------------------
 # Vector add latency — memory-dominated
 # ---------------------------------------------------------------------------
@@ -1977,3 +2019,94 @@ class TestRingReduceLatency:
         per_core_total = {cid: cc.total_cycles for cid, cc in rep.counters.items()}
         assert rep.kernel_cycles == max(per_core_total.values())
         assert per_core_total[0] >= max(per_core_total[c] for c in (1, 2, 3))
+
+
+# ---------------------------------------------------------------------------
+# Multi-group ring reduce — comm-dominated, 4 groups of 4 on a 16-core grid
+# ---------------------------------------------------------------------------
+# 🧪 Experimental — tracks ktir-mlir-frontend#23.  Validates two
+# things the single-group test cannot:
+#   1. Correctness of the plan-aware fold in ``RingReduceBackend.run``
+#      — every group's accumulator must contain only its own four
+#      tiles, even though the ring spans the whole 16-core
+#      workgroup.  Out-of-plan tiles flow through but are discarded
+#      at fold time; misbehaviour here would smear values across
+#      groups.
+#   2. Per-core ring bytes scale with ``ctx.num_cores``, not group
+#      size — the ring is over the whole workgroup, so a 16-core
+#      workgroup with 4 groups of 4 sends ``num_cores - 1 = 15``
+#      messages per core, not ``group_size - 1 = 3``.
+
+class TestRingReduceMultiGroupLatency:
+    """4 concurrent groups of 4 cores on a 16-core workgroup.
+
+    Hardware-config defaults: ``ring_bandwidth_tb_s = 4.0``,
+    ``ring_bytes_per_cycle = 4000``.  Workgroup geometry:
+
+    - 16 cores, 4 groups of 4: group ``g`` is ``{4g, 4g+1, 4g+2, 4g+3}``.
+    - Each core holds a ``tensor<1x128xf16>`` partial (256 bytes).
+    - Per-core ring traffic = ``(num_cores - 1) * partial_bytes`` =
+      ``15 * 256 = 3840`` bytes.
+    - Per-core comm cycles = ``3840 / 4000 = 0.96``.
+
+    Note the difference from the single-group test: the ring's size
+    is ``num_cores - 1``, *not* ``group_size - 1``.  Multi-group does
+    not shrink the per-op ring; it just narrows the fold via the
+    plan.
+    """
+
+    @pytest.mark.parametrize(
+        "path,func_name,entry",
+        get_test_params("ring_reduce_multi_group"),
+    )
+    def test_multi_group_correctness_and_bytes(self, path, func_name, entry):
+        cfg = HardwareConfig()
+        rep, rows, n_cols, n_groups, group_size, output = (
+            _run_ring_reduce_multi_group(path, func_name, entry, cfg, trace=True)
+        )
+
+        num_cores = n_groups * group_size
+        partial_bytes = n_cols * 2          # 1 x 128 f16 = 256 bytes
+        per_core_ring_bytes = (num_cores - 1) * partial_bytes
+        expected_comm_cycles = per_core_ring_bytes / cfg.ring_bytes_per_cycle
+
+        # ---- Correctness: each group's writer holds the in-group sum ----
+        # ``output[g]`` was written by core ``4*g``; expected value is
+        # the sum of rows[4g..4g+3].  If the plan-aware fold slipped
+        # and folded out-of-group tiles, this assertion would catch it.
+        for g in range(n_groups):
+            expected = rows[g * group_size:(g + 1) * group_size].sum(axis=0)
+            np.testing.assert_allclose(
+                output[g], expected, rtol=1e-2,
+                err_msg=f"group {g}: output does not match in-group sum",
+            )
+
+        # ---- Latency: every core's comm bucket = (num_cores-1) * partial_bytes ----
+        # Includes non-writer cores (most of the 16) — they all run the
+        # ring; only the comm bucket varies, not store traffic.
+        assert set(rep.counters.keys()) == set(range(num_cores))
+        for core_id, cc in rep.counters.items():
+            assert cc.comm_cycles == pytest.approx(expected_comm_cycles), (
+                f"core {core_id}: comm_cycles {cc.comm_cycles} "
+                f"!= expected {expected_comm_cycles}"
+            )
+
+            ops = [t.op_type for t in cc.trace]
+            assert ops.count("ktdp.inter_tile_produce") == 1
+            assert ops.count("ktdp.inter_tile_reduce") == 1
+
+            reduce_entry = next(
+                t for t in cc.trace if t.op_type == "ktdp.inter_tile_reduce"
+            )
+            assert reduce_entry.category == "comm"
+            assert reduce_entry.cycles == pytest.approx(expected_comm_cycles)
+
+        # ---- Cross-core invariants: only group writers store ----
+        store_cores = sorted(
+            cid for cid, cc in rep.counters.items()
+            if any(t.op_type == "ktdp.store" for t in cc.trace)
+        )
+        expected_writers = [g * group_size for g in range(n_groups)]
+        assert store_cores == expected_writers, (
+            f"expected writers {expected_writers}, got {store_cores}"
+        )


### PR DESCRIPTION
cc: @tnakaike @Prasanth-Chatarasi @lchu6 @mudhakar 

Stacked on:
  1. [ktir-cpu#70](https://github.com/torch-spyre/ktir-cpu/pull/70)
     `affine-eq-node` — `==` as a first-class AST node.
  2. [ktir-cpu#71](https://github.com/torch-spyre/ktir-cpu/pull/71)
     `parser-utils-flush-fix` — three parser-side helpers
     (`parse.py` two-stage flush, `parser_utils.extract_named_attr`,
     `parser_ast.enumerate_membership_keys`).

Merge order: #70 → #71 → this PR.  Until #70 and #71 land on `main`,
the diff against `main` includes their commits; review against
`#71` is the focused view.

Spec: [ktir-mlir-frontend#23](https://github.com/torch-spyre/ktir-mlir-frontend/pull/23)
(🧪 unmerged — surface may shift)

## Summary

Implement the **reduce path** of the four-op design: `ktdp.inter_tile_produce` + `ktdp.inter_tile_reduce`. Runs a 4-core all-reduce end-to-end with per-core ring-bandwidth accounting. All new ops are 🧪 experimental.

**In:** two ops + `yield_partial`/`yield_reduced` terminators, `!ktdp.tile_future<T_p>` (N=1), per-core `TileFuture`, `CommPlan` (producers/consumers/deps; plan-aware fold), end-to-end bandwidth pipeline (`bytes_moved` → `Tile.comm_bytes` → `LatencyReport`), rewritten `ring_reduce.mlir`, two latency tests.

**Out (deferred):** `inter_tile_consume`, `inter_tile_reduce_scatter`, `producer_dependency_per_consumer` runtime (full-barrier semantics for now), N>1 partials, spec-invariant verifier checks.

## Latency traces and scores

`HardwareConfig()` defaults: `clock_ghz = 1.0`,
`hbm_bandwidth_tb_s = 1.0` (per-core: 31.25 B/cyc on the 32-chip
default), `ring_bandwidth_tb_s = 4.0` (4000 B/cyc),
`simd_elements_per_cycle = 64`.  Both kernels load a
`tensor<1x128xf16>` row per core (256 bytes = `8.192` HBM cycles).

**Combiner work is charged per fold, on the core that runs it.**
`reduce_fn` (the user's combiner region) executes inside
`RingReduceBackend.run` once per *in-plan* round — not once per ring
round.  Each call routes through ``execute_region → _execute_op →
record_op``, so every `linalg.add` (`128/64 = 2.0` cycles), every
`tensor.empty`, and every `arith.cmpi` lands in *that core's*
``compute_cycles`` bucket.  Out-of-plan rounds still send / receive
on the wire (`bytes_moved` accumulates), but the fold is skipped, so
no compute charge accrues for them.  The single-`scf.if` writer adds
`8.192` HBM cycles on writer cores only.

### Single-group, 4 cores (`examples/ktir/ring_reduce.mlir`)

```
kernel_cycles: 22.5916           ← max core (= core 0, the writer)
core 0:  total=22.5916  compute=6.0156  memory=16.3840  comm=0.1920   (writer)
core 1:  total=14.3996  compute=6.0156  memory= 8.1920  comm=0.1920
core 2:  total=14.3996  compute=6.0156  memory= 8.1920  comm=0.1920
core 3:  total=14.3996  compute=6.0156  memory= 8.1920  comm=0.1920
```

`comm = 0.192 = (4 − 1) × 256 / 4000`.  Three messages per core,
one per ring round.

### Multi-group, 16 cores in 4 groups of 4 (`examples/latency/ring_reduce_multi_group.mlir`)

```
kernel_cycles: 23.3596           ← max core (any of the four group writers)
core  0 (writer    ): total=23.3596  compute=6.0156  memory=16.3840  comm=0.9600
core  1 (non-writer): total=15.1676  compute=6.0156  memory= 8.1920  comm=0.9600
core  4 (writer    ): total=23.3596  compute=6.0156  memory=16.3840  comm=0.9600
core  5 (non-writer): total=15.1676  compute=6.0156  memory= 8.1920  comm=0.9600
core  8 (writer    ): total=23.3596  compute=6.0156  memory=16.3840  comm=0.9600
core 12 (writer    ): total=23.3596  compute=6.0156  memory=16.3840  comm=0.9600
```

`comm = 0.96 = (16 − 1) × 256 / 4000`.  **Five times** the
single-group value — exactly the ratio `(num_cores − 1)` scales
to.  The four group writers all share `kernel_cycles = 23.3596`;
core 0 has no special status now that the workgroup partitions
the writer responsibility evenly.

The writer/non-writer total-cycle gap is `8.1920` — the extra HBM
store on writers, identical between the two kernels.

## Architecture

Design lives in
[`docs/cross_core_scheduling.md`](docs/cross_core_scheduling.md)
§"Inter-tile communication" — that's the canonical reference.  The
shape, in one breath:

> `TileFuture` is per-core, holding this core's partial.  The
> consume handler builds a `CommPlan` (producers, consumers,
> optional `producer_dependency_per_consumer`) and dispatches to a
> `ReduceBackend`.  The backend's ring spans the **whole
> workgroup** — every core sends and receives every round — and the
> plan acts as a *fold mask*: only tiles originating from
> `plan.producers` get folded into a consumer's accumulator,
> non-producers seed with `identity`, and non-consumers return
> `None`.  Per-core `bytes_moved` lands on `Tile.comm_bytes`; the
> latency tracker reads it to charge ring bandwidth.  Read the doc
> for diagrams.

Two non-obvious bits worth surfacing here:

- **`_wrap_latency_counter` (interpreter).** Comm handlers return a
  generator; `record_op` fires *after* the generator returns its
  real value (with `comm_bytes` set), not at handler entry.  Wrap
  is opt-in — only when the latency tracker is on.

- **Workgroup size injection.** `CoreContext.attach_scheduler`
  takes a `num_cores` kwarg and exposes it via `ctx.num_cores`.
  Backends size their protocols from this (the live IR-grid count),
  not from `HardwareConfig.num_cores` (the chip-spec constant —
  see "Known issue" below).

## Cleanups

Behaviour-preserving refactor alongside the architecture work.

- **`attach_reshape` + backend-stamps-`comm_bytes`.**  Handler's
  inline `_reshape` + `_gen` closures move into `ktdp_helpers.py`
  as `reshape_tile_to_target` and `attach_reshape`.  Backend stamps
  `result.comm_bytes = self.bytes_moved` itself, keeping the
  fill / publish on the same side of the contract.  Consume-handler
  tail:
  ```python
  plan = CommPlan.for_reduce(...)
  backend = _select_reduce_backend(plan, op.attributes)
  target_shape = op.attributes.get("_result_shape")
  raw = backend.run(context, local_tile, plan, reduce_fn, identity)
  return attach_reshape(raw, target_shape)
  ```

## Tests

`826 passed, 1 skipped, 6 xfailed`. New:
- `test_examples.py::TestRingReduceExecution::test_ring_reduce_sum`
- `test_latency.py::TestRingReduceLatency::test_ring_reduce_per_core_breakdown`
- `test_latency.py::TestRingReduceMultiGroupLatency::test_multi_group_correctness_and_bytes`

## Follow-ups

COMMENT: compact this

- **Track [ktir-mlir-frontend#23](https://github.com/torch-spyre/ktir-mlir-frontend/pull/23).**
  The four-op spec is upstream-unmerged; reconcile any op / attr
  drift before merging this on `main`.  The 🧪 decoration in
  `ktdp_ops.py` and `gap_analysis.md` calls it out.
- **Spec-invariant verification.** Three checks are deferred until
  the upstream spec stabilises (see the "Verification — deferred"
  block in `ktir_cpu/dialects/ktdp_ops.py`):
  - **A2.** ``groups`` match between produce and consume.  Bounded
    enumeration over ``ctx.num_cores`` — no polyhedral set-difference
    machinery needed.
  - **B1.** ``producer_dependency_per_consumer ⊆
    producer_tiles_per_group`` (subset).  Post-check on
    ``CommPlan.for_reduce``.
  - **B2.** Every producer is named by some consumer's deps
    (coverage).  Same place as B1.

  The single-use invariant on ``%fut`` (§2.3) is *not* on the list:
  the per-core ``TileFuture`` instance is the def-use edge for our
  purposes, so the simulator can't double-consume even silently —
  see ``TileFuture``'s docstring and
  ``docs/cross_core_scheduling.md`` §"Def-use is simulated by
  TileFuture, not walked".
- **Broadcast / reduce-scatter delivery ops.** Substrate in place;
  each needs its own handler (and a `BroadcastBackend` for consume).
- **Per-tile sync runtime.**
  `producer_dependency_per_consumer` is parsed and resolved into
  `CommPlan.deps`; the v1 ring backend ignores it (every fold uses
  the full producer set).  A future smarter ring or
  `PointToPointReduceBackend` would honour `plan.producers_for(c)`
  to short-circuit unnecessary folds.
- **Disambiguate the two `num_cores` facts.**  There are two
  `num_cores`-style facts in the simulator and the names collide:
  - **`GridExecutor.num_cores`** — live workgroup size from the
    IR's `grid` attribute.  Always available.  Reachable via
    `ctx.num_cores` (injected by `attach_scheduler`).  Used by
    `RingReduceBackend.run` to size the ring.
  - **`HardwareConfig.num_cores`** — chip-spec constant
    (default 32).  Only present with latency tracking on.
    Parameterises
    `hbm_bytes_per_cycle_per_core = total_hbm_bw / num_cores`.

  These are different facts: an IR `grid = [4]` running on a
  32-core chip is still bandwidth-shared across 32 cores' worth of
  HBM ports.  The current code is correct
  (`RingReduceBackend.run` reads `ctx.num_cores`, latency
  `_estimate` reads `HardwareConfig.num_cores`), but the name
  overlap is easy to mix up at call sites.  Rename
  `HardwareConfig.num_cores` to something hardware-flavoured
  (`hw_num_cores`, `chip_cores`, …) so the workgroup-vs-chip
  distinction is visible.
