### PR TITLE
[Refactor] Route ktdp.load/store through _subtile_ref; drop is_full→None sentinel

### DIFF
--- a/ktir_cpu/dialects/ktdp_ops.py
+++ b/ktir_cpu/dialects/ktdp_ops.py
@@ -193,23 +193,23 @@ def ktdp__load(op, context, env):
         return MemoryOps.distributed_load(
             context, access_tile.parent_ref, result_shape=result_shape
         )
-    css = access_tile.coordinate_set    # BoxSet | AffineSet  (parser default-fills BoxSet)
+    css = access_tile.coordinate_set    # BoxSet | AffineSet (always present post-parse)
     cso = access_tile.coordinate_order  # AffineMap | None
     # BoxSet fast path: rectangular access with identity coordinate order →
-    # delegate to MemoryOps.boxed_load, which builds a sub-TileRef and lets
-    # MemoryOps.load take its own contiguous/strided fast path on the sub-ref.
-    # Box extent IS the iteration shape (the data tile shape contract is 1:1
-    # for BoxSet); non-rectangular AffineSet still routes through the
+    # build a sub-TileRef on the box and let MemoryOps.load take its own
+    # contiguous/strided fast path on the sub-ref.  Mirrors the BoxSet branch
+    # in MemoryOps.distributed_load — same _subtile_ref + MemoryOps.load
+    # composition, keeping a single strategy across distributed and single-
+    # allocation paths.  Non-rectangular AffineSet still routes through the
     # coord-list path below where ``_result_shape`` reshapes the gather.
     if isinstance(css, BoxSet) and (cso is None or cso.is_identity()):
-        return MemoryOps.boxed_load(context, access_tile.parent_ref, css)
-    if css is not None:
-        coords = css.enumerate(access_tile.shape)
-        if cso is not None:
-            coords = [cso.eval(pt) for pt in coords]
-        result_shape = op.attributes.get("_result_shape", access_tile.shape)
-        return MemoryOps.load(context, access_tile.parent_ref, coords=coords, result_shape=result_shape)
-    return MemoryOps.load(context, access_tile.parent_ref)
+        sub_ref = MemoryOps._subtile_ref(access_tile.parent_ref, css)
+        return MemoryOps.load(context, sub_ref)
+    coords = css.enumerate(access_tile.shape)
+    if cso is not None:
+        coords = [cso.eval(pt) for pt in coords]
+    result_shape = op.attributes.get("_result_shape", access_tile.shape)
+    return MemoryOps.load(context, access_tile.parent_ref, coords=coords, result_shape=result_shape)
 
 
 @register("ktdp.store", latency_category=LC.MEMORY)
@@ -231,18 +231,18 @@ def ktdp__store(op, context, env):
     tile_ref = access_tile.parent_ref
     css = access_tile.coordinate_set
     cso = access_tile.coordinate_order
-    # BoxSet fast path: symmetric to ktdp.load. Slice the source tile
-    # rectangularly (no-op when box covers the full access tile) and store
-    # through a sub-TileRef. Avoids the read-modify-write scatter that the
-    # coord-list path needs for general AffineSet stores.
+    # BoxSet fast path: symmetric to ktdp.load.  Build a sub-TileRef on the
+    # box and store through it.  Avoids the read-modify-write scatter that
+    # the coord-list path needs for general AffineSet stores.  Same shape as
+    # the BoxSet branch in MemoryOps.distributed_store — single strategy
+    # across distributed and single-allocation paths.
     if isinstance(css, BoxSet) and (cso is None or cso.is_identity()):
-        return MemoryOps.boxed_store(context, value, tile_ref, css)
-    if css is not None:
-        coords = css.enumerate(access_tile.shape)
-        if cso is not None:
-            coords = [cso.eval(pt) for pt in coords]
-        return MemoryOps.store(context, value, tile_ref, coords=coords)
-    return MemoryOps.store(context, value, tile_ref)
+        sub_ref = MemoryOps._subtile_ref(tile_ref, css)
+        return MemoryOps.store(context, value, sub_ref)
+    coords = css.enumerate(access_tile.shape)
+    if cso is not None:
+        coords = [cso.eval(pt) for pt in coords]
+    return MemoryOps.store(context, value, tile_ref, coords=coords)
 
 
 # ---------------------------------------------------------------------------
@@ -538,15 +538,19 @@ def parse_construct_access_tile(op_text, parse_ctx: ParseContext):
         base_map_str = f'affine_map<({dims}) -> ({dims})>'
     base_map = parse_affine_map(base_map_str)
 
+    # ``access_tile_set`` is required per ODS
+    # (Builtin_IntegerSetAttr:$access_tile_set, no OptionalAttr); absence
+    # is invalid IR.  ``parse_affine_set`` lowers axis-aligned sets to
+    # ``BoxSet`` automatically, so the full-rectangle case naturally
+    # comes out as ``BoxSet([0, shape))`` and routes through the BoxSet
+    # fast path in the dialect handler — no normalisation needed.
     coord_set_str = attrs.get('access_tile_set')
-    coordinate_set = parse_affine_set(coord_set_str) if isinstance(coord_set_str, str) else None
-    # Default-fill an axis-aligned BoxSet covering the full rectangle when
-    # the attribute is absent.  Routing every rectangular access through
-    # a single ``coordinate_set`` shape (BoxSet) lets the BoxSet fast path
-    # in ktdp.load/store handle translated slices uniformly via
-    # ``_subtile_ref``, and lets ``BoxSet.is_full`` keep its strict
-    # ``[0, shape)`` semantics without having to special-case the absent
-    # attribute.  ``access_shape`` is structurally ``int`` (parsed from
+    if not isinstance(coord_set_str, str):
+        raise ValueError(
+            "construct_access_tile: access_tile_set is required (per ODS)"
+        )
+    coordinate_set = parse_affine_set(coord_set_str)
+    # ``access_shape`` is structurally ``int`` (parsed from
     # ``<NxMxindex>``); ``raise`` (not ``assert``) so the guard survives
     # ``python -O``.
     if not all(isinstance(s, int) for s in access_shape):
@@ -554,8 +558,6 @@ def parse_construct_access_tile(op_text, parse_ctx: ParseContext):
             f"construct_access_tile: access_shape must be concrete ints, "
             f"got {access_shape!r}"
         )
-    if coordinate_set is None:
-        coordinate_set = BoxSet(lo=(0,) * len(access_shape), hi=tuple(access_shape))
 
     coord_order_str = attrs.get('access_tile_order')
     coordinate_order = parse_affine_map(coord_order_str) if isinstance(coord_order_str, str) else None

--- a/ktir_cpu/dialects/ktdp_ops.py
+++ b/ktir_cpu/dialects/ktdp_ops.py
@@ -193,8 +193,16 @@ def ktdp__load(op, context, env):
         return MemoryOps.distributed_load(
             context, access_tile.parent_ref, result_shape=result_shape
         )
-    css = access_tile.coordinate_set    # AffineSet | None
+    css = access_tile.coordinate_set    # BoxSet | AffineSet  (parser default-fills BoxSet)
     cso = access_tile.coordinate_order  # AffineMap | None
+    # BoxSet fast path: rectangular access with identity coordinate order →
+    # delegate to MemoryOps.boxed_load, which builds a sub-TileRef and lets
+    # MemoryOps.load take its own contiguous/strided fast path on the sub-ref.
+    # Box extent IS the iteration shape (the data tile shape contract is 1:1
+    # for BoxSet); non-rectangular AffineSet still routes through the
+    # coord-list path below where ``_result_shape`` reshapes the gather.
+    if isinstance(css, BoxSet) and (cso is None or cso.is_identity()):
+        return MemoryOps.boxed_load(context, access_tile.parent_ref, css)
     if css is not None:
         coords = css.enumerate(access_tile.shape)
         if cso is not None:
@@ -223,6 +231,12 @@ def ktdp__store(op, context, env):
     tile_ref = access_tile.parent_ref
     css = access_tile.coordinate_set
     cso = access_tile.coordinate_order
+    # BoxSet fast path: symmetric to ktdp.load. Slice the source tile
+    # rectangularly (no-op when box covers the full access tile) and store
+    # through a sub-TileRef. Avoids the read-modify-write scatter that the
+    # coord-list path needs for general AffineSet stores.
+    if isinstance(css, BoxSet) and (cso is None or cso.is_identity()):
+        return MemoryOps.boxed_store(context, value, tile_ref, css)
     if css is not None:
         coords = css.enumerate(access_tile.shape)
         if cso is not None:
@@ -526,12 +540,22 @@ def parse_construct_access_tile(op_text, parse_ctx: ParseContext):
 
     coord_set_str = attrs.get('access_tile_set')
     coordinate_set = parse_affine_set(coord_set_str) if isinstance(coord_set_str, str) else None
-    # Normalise to None when the set covers the full rectangular tile in
-    # row-major order — it carries no information beyond "load/store everything".
-    # This lets ktdp.load/store take the contiguous fast path instead of
-    # enumerating all coords on every execution.
-    if coordinate_set is not None and coordinate_set.is_full(access_shape):
-        coordinate_set = None
+    # Default-fill an axis-aligned BoxSet covering the full rectangle when
+    # the attribute is absent.  Routing every rectangular access through
+    # a single ``coordinate_set`` shape (BoxSet) lets the BoxSet fast path
+    # in ktdp.load/store handle translated slices uniformly via
+    # ``_subtile_ref``, and lets ``BoxSet.is_full`` keep its strict
+    # ``[0, shape)`` semantics without having to special-case the absent
+    # attribute.  ``access_shape`` is structurally ``int`` (parsed from
+    # ``<NxMxindex>``); ``raise`` (not ``assert``) so the guard survives
+    # ``python -O``.
+    if not all(isinstance(s, int) for s in access_shape):
+        raise TypeError(
+            f"construct_access_tile: access_shape must be concrete ints, "
+            f"got {access_shape!r}"
+        )
+    if coordinate_set is None:
+        coordinate_set = BoxSet(lo=(0,) * len(access_shape), hi=tuple(access_shape))
 
     coord_order_str = attrs.get('access_tile_order')
     coordinate_order = parse_affine_map(coord_order_str) if isinstance(coord_order_str, str) else None

--- a/ktir_cpu/mlir_frontend/parser.py
+++ b/ktir_cpu/mlir_frontend/parser.py
@@ -238,12 +238,20 @@ def _adapt_construct_access_tile(mlir_op, attributes, result_type, operands):
     canonical = str(AffineMapAttr(mlir_op.attributes["base_map"]).value)
     attributes["base_map"] = parse_affine_map(f"affine_map<{canonical}>")
 
-    # access_tile_set → coordinate_set; normalize full sets to None
-    if "access_tile_set" in mlir_op.attributes:
-        # str(IntegerSetAttr) → "affine_set<(d0) : ...>"
-        cs = parse_affine_set(str(mlir_op.attributes["access_tile_set"]))
-        if not cs.is_full(shape):
-            attributes["coordinate_set"] = cs
+    # access_tile_set → coordinate_set.  Required attribute per ODS
+    # (Builtin_IntegerSetAttr:$access_tile_set, no OptionalAttr); absence
+    # is invalid IR.  ``parse_affine_set`` lowers axis-aligned sets to
+    # ``BoxSet`` automatically, so the full-rectangle case naturally
+    # comes out as ``BoxSet([0, shape))`` and routes through the
+    # BoxSet fast path in the dialect handler — no normalisation needed.
+    if "access_tile_set" not in mlir_op.attributes:
+        raise ValueError(
+            "construct_access_tile: access_tile_set is required (per ODS)"
+        )
+    # str(IntegerSetAttr) → "affine_set<(d0) : ...>"
+    attributes["coordinate_set"] = parse_affine_set(
+        str(mlir_op.attributes["access_tile_set"])
+    )
 
     # access_tile_order → coordinate_order; normalize identity maps to None
     if "access_tile_order" in mlir_op.attributes:

--- a/ktir_cpu/ops/memory_ops.py
+++ b/ktir_cpu/ops/memory_ops.py
@@ -261,133 +261,6 @@ def _resolve_idx_reads(
     return per_view_values, total_sticks
 
 
-def _eval_subscript_vectorized(expr: tuple, pts: np.ndarray) -> np.ndarray:
-    """NumPy-vectorised dual of :func:`eval_subscript_expr`.
-
-    *pts* is an ``(N, n_vars)`` int array; the return is an ``(N,)`` int64
-    array.  Mirrors the AST grammar in :func:`parser_ast._eval_node` plus
-    the legacy ``floordiv`` / ``mod`` forms in
-    :func:`eval_subscript_expr`.
-
-    Used only by the BoxSet fast path in :func:`_build_indirect_coords` —
-    the slow path keeps the per-point :func:`eval_subscript_expr` call.
-    """
-    tag = expr[0]
-    if tag == "const":
-        return np.full(pts.shape[0], expr[1], dtype=np.int64)
-    if tag == "dim":
-        return pts[:, expr[1]].astype(np.int64, copy=False)
-    if tag == "sym":
-        # The IAT is concrete by construction at this layer; symbol
-        # bindings are resolved upstream in the memory-view parser
-        # before they reach the indirect coord builder.
-        raise ValueError(
-            "symbolic subscript is not supported on the BoxSet fast path"
-        )
-    if tag == "neg":
-        return -_eval_subscript_vectorized(expr[1], pts)
-    if tag == "add":
-        return _eval_subscript_vectorized(expr[1], pts) + _eval_subscript_vectorized(expr[2], pts)
-    if tag == "sub":
-        return _eval_subscript_vectorized(expr[1], pts) - _eval_subscript_vectorized(expr[2], pts)
-    if tag == "mul":
-        # Affine grammar: ``mul`` carries a scalar coefficient on side 1
-        # and a sub-expression on side 2; mirrors ``_eval_node``.
-        return expr[1] * _eval_subscript_vectorized(expr[2], pts)
-    if tag == "max":
-        return np.maximum(
-            _eval_subscript_vectorized(expr[1], pts),
-            _eval_subscript_vectorized(expr[2], pts),
-        )
-    if tag == "min":
-        return np.minimum(
-            _eval_subscript_vectorized(expr[1], pts),
-            _eval_subscript_vectorized(expr[2], pts),
-        )
-    if tag == "floordiv":
-        # Legacy form: expr[1] is a dim *index*, not a sub-expression.
-        return pts[:, expr[1]].astype(np.int64, copy=False) // expr[2]
-    if tag == "mod":
-        return pts[:, expr[1]].astype(np.int64, copy=False) % expr[2]
-    raise ValueError(f"Unknown subscript kind: {tag!r}")
-
-
-def _enumerate_box_pts(box: BoxSet) -> np.ndarray:
-    """Row-major variable-space enumeration as an ``(N, ndim)`` int array.
-
-    Matches the order of ``BoxSet.enumerate`` (``itertools.product`` over
-    ``range(lo, hi)`` per axis), so callers that consume idx_values from
-    :func:`_resolve_idx_reads` (which iterates in :func:`_enumerate_in_vso_order`
-    order — identical to row-major when ``vso`` is identity) stay in
-    lockstep.  Empty boxes return a ``(0, ndim)`` array.
-    """
-    if box.is_empty():
-        return np.empty((0, box.n_dims), dtype=np.int64)
-    extent = tuple(box.hi[d] - box.lo[d] for d in range(box.n_dims))
-    grid = np.indices(extent, dtype=np.int64).reshape(box.n_dims, -1).T
-    return grid + np.array(box.lo, dtype=np.int64)
-
-
-def _build_indirect_coords_box(
-    iat: "IndirectAccessTile",
-    idx_values: Dict[int, np.ndarray],
-    box: BoxSet,
-) -> List[Tuple[int, ...]]:
-    """Vectorised coord builder for the BoxSet variable-space fast path.
-
-    Constructs an ``(N, n_dims)`` coord matrix column-by-column:
-    * ``direct`` dims slice the variable-space point array;
-    * ``direct_expr`` dims call :func:`_eval_subscript_vectorized`;
-    * ``indirect`` dims slice ``idx_values[iv_idx]`` with the per-sub
-      stride/offset that mirrors the pt-major / dim-minor consumption
-      order of the slow path (so behaviour is identical when multiple
-      indirect dims share the same index view).
-
-    Returns ``List[Tuple[int, ...]]`` for downstream
-    :func:`MemoryOps.load`/``store`` parity — the structural win is in
-    column-wise vectorised construction, not in the downstream offset
-    gather which still iterates per coord.
-    """
-    pts = _enumerate_box_pts(box)
-    n_pts = pts.shape[0]
-    n_dims = len(iat.dim_subscripts)
-    coord_array = np.empty((n_pts, n_dims), dtype=np.int64)
-
-    view_groups: Dict[int, List[int]] = {}
-    for d, sub in enumerate(iat.dim_subscripts):
-        if sub["kind"] == "indirect":
-            view_groups.setdefault(sub["index_view_idx"], []).append(d)
-
-    for d, sub in enumerate(iat.dim_subscripts):
-        kind = sub["kind"]
-        if kind == "direct":
-            coord_array[:, d] = pts[:, sub["var_index"]]
-        elif kind == "direct_expr":
-            coord_array[:, d] = _eval_subscript_vectorized(sub["subscript"], pts)
-        elif kind == "indirect":
-            iv_idx = sub["index_view_idx"]
-            group = view_groups[iv_idx]
-            stride = len(group)
-            offset = group.index(d)
-            vals = np.asarray(idx_values[iv_idx])[offset::stride]
-            neg_mask = vals < 0
-            if neg_mask.any():
-                bad = int(vals[neg_mask][0])
-                raise IndexError(
-                    f"indirect index {bad} from "
-                    f"{iat.index_views[iv_idx]} is negative"
-                )
-            coord_array[:, d] = vals
-        else:
-            raise ValueError(f"Unknown indirect subscript kind: {kind}")
-    # ``tolist()`` is C-implemented and ~10x faster than a Python comprehension
-    # over rows; the per-row ``tuple(...)`` is still pure Python but unavoidable
-    # while ``MemoryOps.load(coords=...)`` consumes ``List[Tuple]``.  A future
-    # ndarray-coords API on the load side could let the box variant skip this
-    # conversion entirely.
-    return [tuple(row) for row in coord_array.tolist()]
-
-
 def _build_indirect_coords(
     iat: "IndirectAccessTile", idx_values: Dict[int, np.ndarray],
 ) -> List[Tuple[int, ...]]:
@@ -402,12 +275,6 @@ def _build_indirect_coords(
       ``idx_values[iv_idx]`` (set up by :func:`_resolve_idx_reads` in the
       same pt-major, dim-minor order).
 
-    BoxSet variable-space + identity ``variables_space_order`` routes
-    through :func:`_build_indirect_coords_box`, which constructs the
-    ``(N, n_dims)`` coord matrix column-by-column with NumPy.  Other
-    cases (AffineSet variable space, or non-identity vso permutation)
-    keep the per-point Python loop below.
-
     Raises ``IndexError`` on a negative idx value — NumPy fancy-indexing
     silently wraps negatives, so we reject them here.  The check survives
     ``python -O`` (uses ``raise``, not ``assert``).
@@ -415,11 +282,6 @@ def _build_indirect_coords(
     Shared by ``indirect_load`` and ``indirect_store`` so their coord
     construction stays in lockstep (guard symmetry).
     """
-    vss = iat.variables_space_set
-    vso = iat.variables_space_order
-    if isinstance(vss, BoxSet) and (vso is None or vso.is_identity()):
-        return _build_indirect_coords_box(iat, idx_values, vss)
-
     points = _enumerate_in_vso_order(iat)
     idx_iters = {iv_idx: iter(values) for iv_idx, values in idx_values.items()}
 
@@ -572,73 +434,6 @@ class MemoryOps:
             if sticks is not None:
                 sticks.add((base_ptr + o * bpe) // stick_bytes)
         return offsets, len(sticks) if sticks is not None else None
-
-    @staticmethod
-    def boxed_load(
-        context: CoreContext,
-        parent_ref: TileRef,
-        box: BoxSet,
-    ) -> Tile:
-        """Load a rectangular sub-region described by *box* (in local coords).
-
-        Mirrors the BoxSet branch in :meth:`distributed_load`: build a
-        sub-TileRef covering exactly the box, then delegate to
-        :meth:`load`, which takes its own contiguous/strided fast path on
-        a single read.  Skips the per-element offset gather that the
-        coord-list path needs for non-rectangular AffineSet access.
-
-        ``box`` is in *parent_ref-local* coordinates (``box.lo[d]`` is
-        the offset within ``parent_ref`` along axis ``d``).  Reuses
-        :meth:`_subtile_ref` whose ``survivor.partition_origin or (0,)``
-        fallback collapses to plain ``box.lo · strides`` on a
-        non-distributed parent (``partition_origin is None``); the
-        no-trample tests pin this contract.
-
-        Result shape always equals the box extent — the iteration ↔
-        data-tile-shape contract is the dialect handler's responsibility,
-        not this helper's.  Empty boxes (any axis with ``hi[d] <= lo[d]``)
-        short-circuit to a zero-element tile so degenerate slices never
-        fabricate an offset pointer or hit a 0-length downstream read.
-        """
-        if box.is_empty():
-            ndim = len(parent_ref.shape)
-            extent = tuple(box.hi[d] - box.lo[d] for d in range(ndim))
-            empty = np.zeros(extent, dtype=_to_np_dtype(parent_ref.dtype))
-            return Tile(empty, parent_ref.dtype, extent, None)
-        sub_ref = MemoryOps._subtile_ref(parent_ref, box)
-        return MemoryOps.load(context, sub_ref)
-
-    @staticmethod
-    def boxed_store(
-        context: CoreContext,
-        tile: Tile,
-        parent_ref: TileRef,
-        box: BoxSet,
-    ) -> int:
-        """Store a tile to the rectangular sub-region described by *box*.
-
-        Symmetric to :meth:`boxed_load`: build a sub-TileRef covering the
-        box, reshape the source tile to the box extent if needed, and
-        delegate to :meth:`store`.  Skips the read-modify-write that the
-        coord-list scatter path needs.
-
-        Mirrors the BoxSet branch in :meth:`distributed_store` (uses
-        :func:`np.ascontiguousarray` to materialise the slice when the
-        caller supplied a non-contiguous view).
-
-        Empty boxes short-circuit to ``0`` unique_sticks (no write).
-        """
-        if box.is_empty():
-            return 0
-        ndim = len(parent_ref.shape)
-        extent = tuple(box.hi[d] - box.lo[d] for d in range(ndim))
-        sub_ref = MemoryOps._subtile_ref(parent_ref, box)
-        if tuple(tile.data.shape) != extent:
-            src = np.ascontiguousarray(tile.data.reshape(extent))
-        else:
-            src = np.ascontiguousarray(tile.data)
-        sub_tile = Tile(src, parent_ref.dtype, extent)
-        return MemoryOps.store(context, sub_tile, sub_ref)
 
     @staticmethod
     def load(

--- a/ktir_cpu/ops/memory_ops.py
+++ b/ktir_cpu/ops/memory_ops.py
@@ -261,6 +261,133 @@ def _resolve_idx_reads(
     return per_view_values, total_sticks
 
 
+def _eval_subscript_vectorized(expr: tuple, pts: np.ndarray) -> np.ndarray:
+    """NumPy-vectorised dual of :func:`eval_subscript_expr`.
+
+    *pts* is an ``(N, n_vars)`` int array; the return is an ``(N,)`` int64
+    array.  Mirrors the AST grammar in :func:`parser_ast._eval_node` plus
+    the legacy ``floordiv`` / ``mod`` forms in
+    :func:`eval_subscript_expr`.
+
+    Used only by the BoxSet fast path in :func:`_build_indirect_coords` —
+    the slow path keeps the per-point :func:`eval_subscript_expr` call.
+    """
+    tag = expr[0]
+    if tag == "const":
+        return np.full(pts.shape[0], expr[1], dtype=np.int64)
+    if tag == "dim":
+        return pts[:, expr[1]].astype(np.int64, copy=False)
+    if tag == "sym":
+        # The IAT is concrete by construction at this layer; symbol
+        # bindings are resolved upstream in the memory-view parser
+        # before they reach the indirect coord builder.
+        raise ValueError(
+            "symbolic subscript is not supported on the BoxSet fast path"
+        )
+    if tag == "neg":
+        return -_eval_subscript_vectorized(expr[1], pts)
+    if tag == "add":
+        return _eval_subscript_vectorized(expr[1], pts) + _eval_subscript_vectorized(expr[2], pts)
+    if tag == "sub":
+        return _eval_subscript_vectorized(expr[1], pts) - _eval_subscript_vectorized(expr[2], pts)
+    if tag == "mul":
+        # Affine grammar: ``mul`` carries a scalar coefficient on side 1
+        # and a sub-expression on side 2; mirrors ``_eval_node``.
+        return expr[1] * _eval_subscript_vectorized(expr[2], pts)
+    if tag == "max":
+        return np.maximum(
+            _eval_subscript_vectorized(expr[1], pts),
+            _eval_subscript_vectorized(expr[2], pts),
+        )
+    if tag == "min":
+        return np.minimum(
+            _eval_subscript_vectorized(expr[1], pts),
+            _eval_subscript_vectorized(expr[2], pts),
+        )
+    if tag == "floordiv":
+        # Legacy form: expr[1] is a dim *index*, not a sub-expression.
+        return pts[:, expr[1]].astype(np.int64, copy=False) // expr[2]
+    if tag == "mod":
+        return pts[:, expr[1]].astype(np.int64, copy=False) % expr[2]
+    raise ValueError(f"Unknown subscript kind: {tag!r}")
+
+
+def _enumerate_box_pts(box: BoxSet) -> np.ndarray:
+    """Row-major variable-space enumeration as an ``(N, ndim)`` int array.
+
+    Matches the order of ``BoxSet.enumerate`` (``itertools.product`` over
+    ``range(lo, hi)`` per axis), so callers that consume idx_values from
+    :func:`_resolve_idx_reads` (which iterates in :func:`_enumerate_in_vso_order`
+    order — identical to row-major when ``vso`` is identity) stay in
+    lockstep.  Empty boxes return a ``(0, ndim)`` array.
+    """
+    if box.is_empty():
+        return np.empty((0, box.n_dims), dtype=np.int64)
+    extent = tuple(box.hi[d] - box.lo[d] for d in range(box.n_dims))
+    grid = np.indices(extent, dtype=np.int64).reshape(box.n_dims, -1).T
+    return grid + np.array(box.lo, dtype=np.int64)
+
+
+def _build_indirect_coords_box(
+    iat: "IndirectAccessTile",
+    idx_values: Dict[int, np.ndarray],
+    box: BoxSet,
+) -> List[Tuple[int, ...]]:
+    """Vectorised coord builder for the BoxSet variable-space fast path.
+
+    Constructs an ``(N, n_dims)`` coord matrix column-by-column:
+    * ``direct`` dims slice the variable-space point array;
+    * ``direct_expr`` dims call :func:`_eval_subscript_vectorized`;
+    * ``indirect`` dims slice ``idx_values[iv_idx]`` with the per-sub
+      stride/offset that mirrors the pt-major / dim-minor consumption
+      order of the slow path (so behaviour is identical when multiple
+      indirect dims share the same index view).
+
+    Returns ``List[Tuple[int, ...]]`` for downstream
+    :func:`MemoryOps.load`/``store`` parity — the structural win is in
+    column-wise vectorised construction, not in the downstream offset
+    gather which still iterates per coord.
+    """
+    pts = _enumerate_box_pts(box)
+    n_pts = pts.shape[0]
+    n_dims = len(iat.dim_subscripts)
+    coord_array = np.empty((n_pts, n_dims), dtype=np.int64)
+
+    view_groups: Dict[int, List[int]] = {}
+    for d, sub in enumerate(iat.dim_subscripts):
+        if sub["kind"] == "indirect":
+            view_groups.setdefault(sub["index_view_idx"], []).append(d)
+
+    for d, sub in enumerate(iat.dim_subscripts):
+        kind = sub["kind"]
+        if kind == "direct":
+            coord_array[:, d] = pts[:, sub["var_index"]]
+        elif kind == "direct_expr":
+            coord_array[:, d] = _eval_subscript_vectorized(sub["subscript"], pts)
+        elif kind == "indirect":
+            iv_idx = sub["index_view_idx"]
+            group = view_groups[iv_idx]
+            stride = len(group)
+            offset = group.index(d)
+            vals = np.asarray(idx_values[iv_idx])[offset::stride]
+            neg_mask = vals < 0
+            if neg_mask.any():
+                bad = int(vals[neg_mask][0])
+                raise IndexError(
+                    f"indirect index {bad} from "
+                    f"{iat.index_views[iv_idx]} is negative"
+                )
+            coord_array[:, d] = vals
+        else:
+            raise ValueError(f"Unknown indirect subscript kind: {kind}")
+    # ``tolist()`` is C-implemented and ~10x faster than a Python comprehension
+    # over rows; the per-row ``tuple(...)`` is still pure Python but unavoidable
+    # while ``MemoryOps.load(coords=...)`` consumes ``List[Tuple]``.  A future
+    # ndarray-coords API on the load side could let the box variant skip this
+    # conversion entirely.
+    return [tuple(row) for row in coord_array.tolist()]
+
+
 def _build_indirect_coords(
     iat: "IndirectAccessTile", idx_values: Dict[int, np.ndarray],
 ) -> List[Tuple[int, ...]]:
@@ -275,6 +402,12 @@ def _build_indirect_coords(
       ``idx_values[iv_idx]`` (set up by :func:`_resolve_idx_reads` in the
       same pt-major, dim-minor order).
 
+    BoxSet variable-space + identity ``variables_space_order`` routes
+    through :func:`_build_indirect_coords_box`, which constructs the
+    ``(N, n_dims)`` coord matrix column-by-column with NumPy.  Other
+    cases (AffineSet variable space, or non-identity vso permutation)
+    keep the per-point Python loop below.
+
     Raises ``IndexError`` on a negative idx value — NumPy fancy-indexing
     silently wraps negatives, so we reject them here.  The check survives
     ``python -O`` (uses ``raise``, not ``assert``).
@@ -282,6 +415,11 @@ def _build_indirect_coords(
     Shared by ``indirect_load`` and ``indirect_store`` so their coord
     construction stays in lockstep (guard symmetry).
     """
+    vss = iat.variables_space_set
+    vso = iat.variables_space_order
+    if isinstance(vss, BoxSet) and (vso is None or vso.is_identity()):
+        return _build_indirect_coords_box(iat, idx_values, vss)
+
     points = _enumerate_in_vso_order(iat)
     idx_iters = {iv_idx: iter(values) for iv_idx, values in idx_values.items()}
 
@@ -434,6 +572,73 @@ class MemoryOps:
             if sticks is not None:
                 sticks.add((base_ptr + o * bpe) // stick_bytes)
         return offsets, len(sticks) if sticks is not None else None
+
+    @staticmethod
+    def boxed_load(
+        context: CoreContext,
+        parent_ref: TileRef,
+        box: BoxSet,
+    ) -> Tile:
+        """Load a rectangular sub-region described by *box* (in local coords).
+
+        Mirrors the BoxSet branch in :meth:`distributed_load`: build a
+        sub-TileRef covering exactly the box, then delegate to
+        :meth:`load`, which takes its own contiguous/strided fast path on
+        a single read.  Skips the per-element offset gather that the
+        coord-list path needs for non-rectangular AffineSet access.
+
+        ``box`` is in *parent_ref-local* coordinates (``box.lo[d]`` is
+        the offset within ``parent_ref`` along axis ``d``).  Reuses
+        :meth:`_subtile_ref` whose ``survivor.partition_origin or (0,)``
+        fallback collapses to plain ``box.lo · strides`` on a
+        non-distributed parent (``partition_origin is None``); the
+        no-trample tests pin this contract.
+
+        Result shape always equals the box extent — the iteration ↔
+        data-tile-shape contract is the dialect handler's responsibility,
+        not this helper's.  Empty boxes (any axis with ``hi[d] <= lo[d]``)
+        short-circuit to a zero-element tile so degenerate slices never
+        fabricate an offset pointer or hit a 0-length downstream read.
+        """
+        if box.is_empty():
+            ndim = len(parent_ref.shape)
+            extent = tuple(box.hi[d] - box.lo[d] for d in range(ndim))
+            empty = np.zeros(extent, dtype=_to_np_dtype(parent_ref.dtype))
+            return Tile(empty, parent_ref.dtype, extent, None)
+        sub_ref = MemoryOps._subtile_ref(parent_ref, box)
+        return MemoryOps.load(context, sub_ref)
+
+    @staticmethod
+    def boxed_store(
+        context: CoreContext,
+        tile: Tile,
+        parent_ref: TileRef,
+        box: BoxSet,
+    ) -> int:
+        """Store a tile to the rectangular sub-region described by *box*.
+
+        Symmetric to :meth:`boxed_load`: build a sub-TileRef covering the
+        box, reshape the source tile to the box extent if needed, and
+        delegate to :meth:`store`.  Skips the read-modify-write that the
+        coord-list scatter path needs.
+
+        Mirrors the BoxSet branch in :meth:`distributed_store` (uses
+        :func:`np.ascontiguousarray` to materialise the slice when the
+        caller supplied a non-contiguous view).
+
+        Empty boxes short-circuit to ``0`` unique_sticks (no write).
+        """
+        if box.is_empty():
+            return 0
+        ndim = len(parent_ref.shape)
+        extent = tuple(box.hi[d] - box.lo[d] for d in range(ndim))
+        sub_ref = MemoryOps._subtile_ref(parent_ref, box)
+        if tuple(tile.data.shape) != extent:
+            src = np.ascontiguousarray(tile.data.reshape(extent))
+        else:
+            src = np.ascontiguousarray(tile.data)
+        sub_tile = Tile(src, parent_ref.dtype, extent)
+        return MemoryOps.store(context, sub_tile, sub_ref)
 
     @staticmethod
     def load(

--- a/tests/test_boxset_fastpath.py
+++ b/tests/test_boxset_fastpath.py
@@ -12,12 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""BoxSet rectangular fast-path tests for ktdp.load/store and indirect_*.
+"""BoxSet rectangular fast-path tests for ktdp.load/store.
 
 Covers issue #52: parity between the BoxSet sub-TileRef shortcut on
 direct ktdp.load/store and the per-coord scatter that the AffineSet
-slow path uses, plus the vectorised _build_indirect_coords_box variant
-on the indirect side.
+slow path uses.
 """
 
 from unittest.mock import patch
@@ -27,17 +26,12 @@ import pytest
 
 from ktir_cpu import KTIRInterpreter
 from ktir_cpu.affine import BoxSet
-from ktir_cpu.dialects.ktdp_helpers import eval_subscript_expr
 from ktir_cpu.dialects.ktdp_ops import ktdp__load
 from ktir_cpu.dtypes import bytes_per_elem
 from ktir_cpu.grid import CoreContext
-from ktir_cpu.ir_types import AccessTile, IndirectAccessTile, MemRef, Tile
+from ktir_cpu.ir_types import AccessTile, MemRef, Tile
 from ktir_cpu.memory import HBMSimulator, LXScratchpad
-from ktir_cpu.ops.memory_ops import (
-    MemoryOps,
-    _build_indirect_coords_box,
-    _eval_subscript_vectorized,
-)
+from ktir_cpu.ops.memory_ops import MemoryOps
 from ktir_cpu.parser_ast import parse_affine_map
 
 
@@ -48,24 +42,28 @@ def _make_ctx():
 
 
 # ---------------------------------------------------------------------------
-# MemoryOps.boxed_load / boxed_store unit tests
+# Sub-TileRef shortcut: _subtile_ref + MemoryOps.load/store
 # ---------------------------------------------------------------------------
 
-class TestBoxedLoadStoreUnit:
-    """Direct sub-TileRef shortcut tested at the helper level (no parser).
+class TestSubTileRefShortcut:
+    """The BoxSet branch in ktdp.load/store builds a sub-TileRef via
+    ``MemoryOps._subtile_ref`` and delegates to ``MemoryOps.load`` /
+    ``MemoryOps.store`` — the same composition ``MemoryOps.distributed_load``
+    /``distributed_store`` use for partition shards.  These tests pin
+    that composition at the helper level for the non-distributed parent.
 
     Row-major no-trample is omitted — column-packed strictly contains it
     (stride-inheritance bugs cannot fail col-packed and pass row-major).
-    Full-rectangle correctness lives in
-    ``TestKtdpDispatchTakesBoxSetPath`` to avoid duplicating the
-    happy-path assertion at two layers.
+    Full-rectangle correctness lives in ``TestKtdpDispatchTakesBoxSetPath``
+    to avoid duplicating the happy-path assertion at two layers.
     """
 
     def test_sub_rectangle_load_returns_box_extent(self):
-        """boxed_load on a translated sub-box returns just the box
-        contents (in row-major order), not the full parent.  Sole
-        unit-level coverage for the read direction; the store
-        direction is covered by the col-packed no-trample test."""
+        """``_subtile_ref + MemoryOps.load`` on a translated sub-box
+        returns just the box contents (in row-major order), not the
+        full parent.  Sole unit-level coverage for the read direction;
+        the store direction is covered by the col-packed no-trample
+        test."""
         ctx, hbm = _make_ctx()
         data = np.arange(16, dtype=np.float16).reshape(4, 4)
         ptr = hbm.allocate(data.nbytes)
@@ -76,9 +74,10 @@ class TestBoxedLoadStoreUnit:
         ).to_tile_ref()
 
         box = BoxSet(lo=(1, 1), hi=(3, 3))
-        boxed = MemoryOps.boxed_load(ctx, tile_ref, box)
-        assert boxed.shape == (2, 2)
-        np.testing.assert_array_equal(boxed.data, data[1:3, 1:3])
+        sub_ref = MemoryOps._subtile_ref(tile_ref, box)
+        loaded = MemoryOps.load(ctx, sub_ref)
+        assert loaded.shape == (2, 2)
+        np.testing.assert_array_equal(loaded.data, data[1:3, 1:3])
 
     def test_store_col_packed_does_not_trample(self):
         """Column-packed strides=[1, R]: stride inheritance must come
@@ -102,7 +101,8 @@ class TestBoxedLoadStoreUnit:
 
         box = BoxSet(lo=(1, 1), hi=(3, 3))
         payload = np.arange(1, 5, dtype=np.float16).reshape(2, 2)
-        MemoryOps.boxed_store(ctx, Tile(payload, "f16", (2, 2)), tile_ref, box)
+        sub_ref = MemoryOps._subtile_ref(tile_ref, box)
+        MemoryOps.store(ctx, Tile(payload, "f16", (2, 2)), sub_ref)
 
         # Reconstruct logical view from column-packed bytes.
         flat = hbm.read(ptr, elems, "f16")
@@ -115,15 +115,16 @@ class TestBoxedLoadStoreUnit:
         mask[1:3, 1:3] = True
         outside = logical[~mask]
         assert np.all(outside == SENTINEL), (
-            "Column-packed boxed_store wrote outside the box — stride "
-            "inheritance bug."
+            "Column-packed sub-tile store wrote outside the box — "
+            "stride inheritance bug."
         )
 
     def test_empty_box(self):
-        """``hi[d] <= lo[d]`` on any axis short-circuits both directions:
-        load returns a zero-element tile (no offset pointer fabricated),
-        store returns 0 sticks and leaves the parent allocation
-        untouched.  One test, two assertions — same failure mode."""
+        """``hi[d] <= lo[d]`` on any axis: ``_subtile_ref`` produces a
+        TileRef with a zero-extent axis; ``MemoryOps.load`` /
+        ``MemoryOps.store`` then handle the degenerate shape without
+        fabricating an offset pointer or trampling the parent.  One
+        test, two assertions — same failure mode."""
         ctx, hbm = _make_ctx()
         SENTINEL = np.float16(-1.0)
         elems = 16
@@ -136,12 +137,13 @@ class TestBoxedLoadStoreUnit:
         ).to_tile_ref()
 
         box = BoxSet(lo=(2, 2), hi=(2, 4))   # empty on axis 0
-        loaded = MemoryOps.boxed_load(ctx, tile_ref, box)
+        sub_ref = MemoryOps._subtile_ref(tile_ref, box)
+        loaded = MemoryOps.load(ctx, sub_ref)
         assert loaded.data.size == 0
         assert loaded.data.shape == (0, 2)
 
         empty_tile = Tile(np.zeros((0, 2), dtype=np.float16), "f16", (0, 2))
-        sticks = MemoryOps.boxed_store(ctx, empty_tile, tile_ref, box)
+        sticks = MemoryOps.store(ctx, empty_tile, sub_ref)
         assert sticks == 0
         assert np.all(hbm.read(ptr, elems, "f16") == SENTINEL)
 
@@ -168,12 +170,15 @@ module {
     } : memref<8xf16>
 
     %c0 = arith.constant 0 : index
-    %x_at = ktdp.construct_access_tile %X[%c0]
-        : memref<8xf16> -> !ktdp.access_tile<8xindex>
-    %y_at = ktdp.construct_access_tile %Y[%c0]
-        : memref<8xf16> -> !ktdp.access_tile<8xindex>
-    %z_at = ktdp.construct_access_tile %Z[%c0]
-        : memref<8xf16> -> !ktdp.access_tile<8xindex>
+    %x_at = ktdp.construct_access_tile %X[%c0] {
+        access_tile_set = affine_set<(d0) : (d0 >= 0, -d0 + 7 >= 0)>
+    } : memref<8xf16> -> !ktdp.access_tile<8xindex>
+    %y_at = ktdp.construct_access_tile %Y[%c0] {
+        access_tile_set = affine_set<(d0) : (d0 >= 0, -d0 + 7 >= 0)>
+    } : memref<8xf16> -> !ktdp.access_tile<8xindex>
+    %z_at = ktdp.construct_access_tile %Z[%c0] {
+        access_tile_set = affine_set<(d0) : (d0 >= 0, -d0 + 7 >= 0)>
+    } : memref<8xf16> -> !ktdp.access_tile<8xindex>
 
     %x = ktdp.load %x_at : !ktdp.access_tile<8xindex> -> tensor<8xf16>
     %y = ktdp.load %y_at : !ktdp.access_tile<8xindex> -> tensor<8xf16>
@@ -230,10 +235,12 @@ class TestKtdpDispatchTakesBoxSetPath:
         z_out = interp.memory.hbm.read(2, 8, "f16")
         np.testing.assert_array_equal(z_out, x_in + y_in)
 
-    def test_parser_normalises_omitted_set_to_boxset(self):
-        """When MLIR omits access_tile_set, the parser fills in
-        BoxSet([0, shape)) so every rectangular access flows through
-        a single ``coordinate_set`` shape into the BoxSet fast path."""
+    def test_parser_lowers_full_rect_affine_set_to_boxset(self):
+        """``parse_affine_set`` lowers an axis-aligned full-rectangle
+        affine set to ``BoxSet`` automatically, so explicit
+        ``access_tile_set = affine_set<(d0) : (d0 >= 0, -d0 + 7 >= 0)>``
+        in the fixture comes out as ``BoxSet([0, 8))`` and routes
+        through the fast path — no separate normalisation needed."""
         interp = KTIRInterpreter()
         interp.load(_VECTOR_ADD_MLIR)
         func = interp.module.functions["add"]
@@ -245,8 +252,8 @@ class TestKtdpDispatchTakesBoxSetPath:
         for op in access_tile_ops:
             cs = op.attributes.get("coordinate_set")
             assert isinstance(cs, BoxSet), (
-                f"coordinate_set should be BoxSet (sentinel retired), "
-                f"got {type(cs).__name__}"
+                f"coordinate_set should be BoxSet (parse_affine_set "
+                f"lowers axis-aligned sets), got {type(cs).__name__}"
             )
             assert cs.lo == (0,) * len(op.attributes["shape"])
             assert tuple(cs.hi) == tuple(op.attributes["shape"])
@@ -374,148 +381,3 @@ class TestExplicitIdentityCoordinateOrder:
         )
 
 
-# ---------------------------------------------------------------------------
-# _build_indirect_coords vectorised vs slow-path consistency
-# ---------------------------------------------------------------------------
-
-class TestIndirectBoxFastPathConsistency:
-    """The vectorised _build_indirect_coords_box must produce the same
-    coords (in the same order) as the per-pt Python loop slow path on
-    fixtures with mixed direct / direct_expr / indirect dim_subscripts.
-    Locks the BoxSet column-by-column reconstruction against the
-    pt-major / dim-minor consumption contract of the slow path.
-    """
-
-    def test_mixed_direct_expr_and_indirect_matches_slow_path(self):
-        """direct + direct_expr + indirect mixed in dim_subscripts.
-        The per-sub stride/offset slicing in the box variant must match
-        the iter()-based pt-major consumption of the slow path when two
-        indirect dims share the same index view (paged-tensor pattern).
-        """
-        # 2-D variable space (3 x 4); two dim_subscripts share one index view.
-        N, M = 3, 4
-        box = BoxSet(lo=(0, 0), hi=(N, M))
-        # For a shared-view fixture, idx_values[0] is consumed pt-major /
-        # dim-minor: 2 consumes per pt, total 2*N*M = 24 entries.
-        idx_data = np.array(
-            [(p * 7 + d) % 16 for p in range(N * M) for d in range(2)],
-            dtype=np.int64,
-        )
-        idx_values = {0: idx_data}
-
-        # Mock index_view_idx 0 as a tiny MemRef placeholder.
-        idx_view_stub = MemRef(
-            base_ptr=0, shape=(N, M), strides=[M, 1],
-            memory_space="HBM", dtype="i32",
-        )
-
-        dim_subs = [
-            {"kind": "direct", "var_index": 0},
-            {"kind": "direct_expr",
-             "subscript": ("add", ("dim", 0), ("mul", 2, ("dim", 1)))},
-            {"kind": "indirect", "index_view_idx": 0,
-             "idx_exprs": [("dim", 0), ("dim", 1)]},
-            {"kind": "indirect", "index_view_idx": 0,
-             "idx_exprs": [("dim", 0), ("dim", 1)]},
-        ]
-
-        # Stub IAT with two index_views entries (only [0] is used here).
-        parent = MemRef(
-            base_ptr=0, shape=(N, M), strides=[M, 1],
-            memory_space="HBM", dtype="f16",
-        )
-        iat = IndirectAccessTile(
-            parent_ref=parent.to_tile_ref(),
-            shape=(N, M),
-            variables_space_set=box,
-            dim_subscripts=dim_subs,
-            index_views=[idx_view_stub],
-            variables_space_order=None,
-        )
-
-        fast = _build_indirect_coords_box(iat, idx_values=idx_values, box=box)
-
-        # Slow path reconstruction by hand using the same iter consumption
-        # order: per pt, walk dim_subscripts in order; each indirect dim
-        # consumes the next entry from its iv_idx's iterator.
-        it = iter(idx_data.tolist())
-        slow = []
-        for p0 in range(N):
-            for p1 in range(M):
-                pt = (p0, p1)
-                row = []
-                for sub in dim_subs:
-                    if sub["kind"] == "direct":
-                        row.append(pt[sub["var_index"]])
-                    elif sub["kind"] == "direct_expr":
-                        row.append(eval_subscript_expr(sub["subscript"], pt))
-                    elif sub["kind"] == "indirect":
-                        row.append(int(next(it)))
-                slow.append(tuple(row))
-        assert fast == slow
-
-    @pytest.mark.parametrize(
-        "expr,expected_fn",
-        [
-            # floordiv/mod take a bare dim *index* in expr[1] (not a
-            # sub-expression — the only tags with this divergent
-            # convention).  add/mul/dim are covered transitively by
-            # ``test_mixed_direct_expr_and_indirect_matches_slow_path``;
-            # neg/max are listed here because they're in the affine
-            # grammar but not exercised anywhere else.
-            (("floordiv", 0, 4), lambda p0, p1: p0 // 4),
-            (("mod", 1, 7), lambda p0, p1: p1 % 7),
-            (("neg", ("dim", 0)), lambda p0, p1: -p0),
-            (("max", ("dim", 0), ("dim", 1)), lambda p0, p1: max(p0, p1)),
-        ],
-        ids=["floordiv", "mod", "neg", "max"],
-    )
-    def test_subscript_eval_parity(self, expr, expected_fn):
-        """Pin the vectorised evaluator against ``eval_subscript_expr``
-        for each grammar tag whose operand convention or branch isn't
-        already covered by other tests.  Without this, the two
-        evaluators silently drift when the grammar changes.
-        """
-
-        pts = np.array(
-            [(p0, p1) for p0 in range(4) for p1 in range(5)], dtype=np.int64
-        )
-        slow = np.array(
-            [eval_subscript_expr(expr, tuple(p)) for p in pts], dtype=np.int64,
-        )
-        fast = _eval_subscript_vectorized(expr, pts)
-        expected = np.array(
-            [expected_fn(int(p[0]), int(p[1])) for p in pts], dtype=np.int64,
-        )
-        np.testing.assert_array_equal(fast, slow)
-        np.testing.assert_array_equal(fast, expected)
-
-    def test_negative_indirect_index_raises(self):
-        """The vectorised path keeps the slow path's IndexError on
-        negative indices (NumPy fancy-indexing wraps; we reject)."""
-
-        box = BoxSet(lo=(0,), hi=(3,))
-        idx_view_stub = MemRef(
-            base_ptr=0, shape=(3,), strides=[1],
-            memory_space="HBM", dtype="i32",
-        )
-        parent = MemRef(
-            base_ptr=0, shape=(3,), strides=[1],
-            memory_space="HBM", dtype="f16",
-        )
-        iat = IndirectAccessTile(
-            parent_ref=parent.to_tile_ref(),
-            shape=(3,),
-            variables_space_set=box,
-            dim_subscripts=[
-                {"kind": "indirect", "index_view_idx": 0,
-                 "idx_exprs": [("dim", 0)]},
-            ],
-            index_views=[idx_view_stub],
-            variables_space_order=None,
-        )
-        # One sub on iv_idx 0 → idx_values[0] is length 3, in pt order.
-        idx_values = {0: np.array([1, -2, 0], dtype=np.int64)}
-
-        with pytest.raises(IndexError, match="negative"):
-            _build_indirect_coords_box(iat, idx_values=idx_values, box=box)

--- a/tests/test_boxset_fastpath.py
+++ b/tests/test_boxset_fastpath.py
@@ -1,0 +1,521 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""BoxSet rectangular fast-path tests for ktdp.load/store and indirect_*.
+
+Covers issue #52: parity between the BoxSet sub-TileRef shortcut on
+direct ktdp.load/store and the per-coord scatter that the AffineSet
+slow path uses, plus the vectorised _build_indirect_coords_box variant
+on the indirect side.
+"""
+
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+from ktir_cpu import KTIRInterpreter
+from ktir_cpu.affine import BoxSet
+from ktir_cpu.dialects.ktdp_helpers import eval_subscript_expr
+from ktir_cpu.dialects.ktdp_ops import ktdp__load
+from ktir_cpu.dtypes import bytes_per_elem
+from ktir_cpu.grid import CoreContext
+from ktir_cpu.ir_types import AccessTile, IndirectAccessTile, MemRef, Tile
+from ktir_cpu.memory import HBMSimulator, LXScratchpad
+from ktir_cpu.ops.memory_ops import (
+    MemoryOps,
+    _build_indirect_coords_box,
+    _eval_subscript_vectorized,
+)
+from ktir_cpu.parser_ast import parse_affine_map
+
+
+def _make_ctx():
+    hbm = HBMSimulator()
+    lx = LXScratchpad(core_id=0)
+    return CoreContext(core_id=0, grid_pos=(0, 0, 0), lx=lx, hbm=hbm), hbm
+
+
+# ---------------------------------------------------------------------------
+# MemoryOps.boxed_load / boxed_store unit tests
+# ---------------------------------------------------------------------------
+
+class TestBoxedLoadStoreUnit:
+    """Direct sub-TileRef shortcut tested at the helper level (no parser).
+
+    Row-major no-trample is omitted — column-packed strictly contains it
+    (stride-inheritance bugs cannot fail col-packed and pass row-major).
+    Full-rectangle correctness lives in
+    ``TestKtdpDispatchTakesBoxSetPath`` to avoid duplicating the
+    happy-path assertion at two layers.
+    """
+
+    def test_sub_rectangle_load_returns_box_extent(self):
+        """boxed_load on a translated sub-box returns just the box
+        contents (in row-major order), not the full parent.  Sole
+        unit-level coverage for the read direction; the store
+        direction is covered by the col-packed no-trample test."""
+        ctx, hbm = _make_ctx()
+        data = np.arange(16, dtype=np.float16).reshape(4, 4)
+        ptr = hbm.allocate(data.nbytes)
+        hbm.write(ptr, data)
+        tile_ref = MemRef(
+            base_ptr=ptr, shape=(4, 4), strides=[4, 1],
+            memory_space="HBM", dtype="f16",
+        ).to_tile_ref()
+
+        box = BoxSet(lo=(1, 1), hi=(3, 3))
+        boxed = MemoryOps.boxed_load(ctx, tile_ref, box)
+        assert boxed.shape == (2, 2)
+        np.testing.assert_array_equal(boxed.data, data[1:3, 1:3])
+
+    def test_store_col_packed_does_not_trample(self):
+        """Column-packed strides=[1, R]: stride inheritance must come
+        from the parent so the sub-tile lands at the right byte
+        positions in column-major memory.  Bug here would scatter the
+        write across columns and trample sentinels."""
+        ctx, hbm = _make_ctx()
+        ROWS, COLS = 4, 4
+        SENTINEL = np.float16(-3.0)
+        elems = ROWS * COLS
+        ptr = hbm.allocate(elems * bytes_per_elem("f16"))
+        hbm.write(ptr, np.full(elems, SENTINEL, dtype=np.float16))
+
+        # Column-packed: strides=[1, ROWS] means consecutive elements
+        # along axis 0 are 1 element apart in memory, and consecutive
+        # elements along axis 1 are ROWS elements apart.
+        tile_ref = MemRef(
+            base_ptr=ptr, shape=(ROWS, COLS), strides=[1, ROWS],
+            memory_space="HBM", dtype="f16",
+        ).to_tile_ref()
+
+        box = BoxSet(lo=(1, 1), hi=(3, 3))
+        payload = np.arange(1, 5, dtype=np.float16).reshape(2, 2)
+        MemoryOps.boxed_store(ctx, Tile(payload, "f16", (2, 2)), tile_ref, box)
+
+        # Reconstruct logical view from column-packed bytes.
+        flat = hbm.read(ptr, elems, "f16")
+        logical = np.empty((ROWS, COLS), dtype=np.float16)
+        for r in range(ROWS):
+            for c in range(COLS):
+                logical[r, c] = flat[r * 1 + c * ROWS]
+        np.testing.assert_array_equal(logical[1:3, 1:3], payload)
+        mask = np.zeros((ROWS, COLS), dtype=bool)
+        mask[1:3, 1:3] = True
+        outside = logical[~mask]
+        assert np.all(outside == SENTINEL), (
+            "Column-packed boxed_store wrote outside the box — stride "
+            "inheritance bug."
+        )
+
+    def test_empty_box(self):
+        """``hi[d] <= lo[d]`` on any axis short-circuits both directions:
+        load returns a zero-element tile (no offset pointer fabricated),
+        store returns 0 sticks and leaves the parent allocation
+        untouched.  One test, two assertions — same failure mode."""
+        ctx, hbm = _make_ctx()
+        SENTINEL = np.float16(-1.0)
+        elems = 16
+        ptr = hbm.allocate(elems * bytes_per_elem("f16"))
+        hbm.write(ptr, np.full(elems, SENTINEL, dtype=np.float16))
+
+        tile_ref = MemRef(
+            base_ptr=ptr, shape=(4, 4), strides=[4, 1],
+            memory_space="HBM", dtype="f16",
+        ).to_tile_ref()
+
+        box = BoxSet(lo=(2, 2), hi=(2, 4))   # empty on axis 0
+        loaded = MemoryOps.boxed_load(ctx, tile_ref, box)
+        assert loaded.data.size == 0
+        assert loaded.data.shape == (0, 2)
+
+        empty_tile = Tile(np.zeros((0, 2), dtype=np.float16), "f16", (0, 2))
+        sticks = MemoryOps.boxed_store(ctx, empty_tile, tile_ref, box)
+        assert sticks == 0
+        assert np.all(hbm.read(ptr, elems, "f16") == SENTINEL)
+
+
+# ---------------------------------------------------------------------------
+# ktdp.load / ktdp.store wiring + structural fast-path verification
+# ---------------------------------------------------------------------------
+
+_VECTOR_ADD_MLIR = """
+module {
+  func.func @add() attributes {grid = [1, 1]} {
+    %X_addr = arith.constant 0 : index
+    %Y_addr = arith.constant 1 : index
+    %Z_addr = arith.constant 2 : index
+
+    %X = ktdp.construct_memory_view %X_addr, sizes: [8], strides: [1] {
+        memory_space = #ktdp.spyre_memory_space<HBM>
+    } : memref<8xf16>
+    %Y = ktdp.construct_memory_view %Y_addr, sizes: [8], strides: [1] {
+        memory_space = #ktdp.spyre_memory_space<HBM>
+    } : memref<8xf16>
+    %Z = ktdp.construct_memory_view %Z_addr, sizes: [8], strides: [1] {
+        memory_space = #ktdp.spyre_memory_space<HBM>
+    } : memref<8xf16>
+
+    %c0 = arith.constant 0 : index
+    %x_at = ktdp.construct_access_tile %X[%c0]
+        : memref<8xf16> -> !ktdp.access_tile<8xindex>
+    %y_at = ktdp.construct_access_tile %Y[%c0]
+        : memref<8xf16> -> !ktdp.access_tile<8xindex>
+    %z_at = ktdp.construct_access_tile %Z[%c0]
+        : memref<8xf16> -> !ktdp.access_tile<8xindex>
+
+    %x = ktdp.load %x_at : !ktdp.access_tile<8xindex> -> tensor<8xf16>
+    %y = ktdp.load %y_at : !ktdp.access_tile<8xindex> -> tensor<8xf16>
+    %z = arith.addf %x, %y : tensor<8xf16>
+    ktdp.store %z, %z_at : tensor<8xf16>, !ktdp.access_tile<8xindex>
+    return
+  }
+}
+"""
+
+
+class TestKtdpDispatchTakesBoxSetPath:
+    """End-to-end tests via ktdp.load/store handlers."""
+
+    def test_full_rectangle_via_ktdp_load(self):
+        """End-to-end vector add: BoxSet([0, shape)) (the new sentinel)
+        must (a) take the structural sub-TileRef shortcut — verified
+        by spying on ``_flat_memory_offsets`` — and (b) compute the
+        right values.  Two assertions, one fixture: structural fast
+        path + happy-path correctness.  Replaces a separate unit-level
+        full-rectangle parity test (the helper-level layer is
+        sufficiently exercised by sub-rectangle and col-packed tests).
+        """
+        interp = KTIRInterpreter()
+        interp.load(_VECTOR_ADD_MLIR)
+
+        x_in = np.arange(8, dtype=np.float16)
+        y_in = np.arange(8, 16, dtype=np.float16)
+
+        seen = []
+        real = MemoryOps._flat_memory_offsets
+
+        def _spy(*args, **kwargs):
+            seen.append(args)
+            return real(*args, **kwargs)
+
+        with patch.object(MemoryOps, "_flat_memory_offsets",
+                          staticmethod(_spy)):
+            _orig = interp._prepare_execution
+            def _seed(grid_shape):
+                _orig(grid_shape)
+                hbm = interp.memory.hbm
+                hbm.write(0, x_in)
+                hbm.write(1, y_in)
+                hbm.write(2, np.zeros(8, dtype=np.float16))
+            interp._prepare_execution = _seed
+            interp.execute_function("add")
+
+        assert seen == [], (
+            f"BoxSet fast path was bypassed: _flat_memory_offsets was "
+            f"called {len(seen)} time(s) — expected 0 because every "
+            f"access tile in this fixture is rectangular."
+        )
+        z_out = interp.memory.hbm.read(2, 8, "f16")
+        np.testing.assert_array_equal(z_out, x_in + y_in)
+
+    def test_parser_normalises_omitted_set_to_boxset(self):
+        """When MLIR omits access_tile_set, the parser fills in
+        BoxSet([0, shape)) so every rectangular access flows through
+        a single ``coordinate_set`` shape into the BoxSet fast path."""
+        interp = KTIRInterpreter()
+        interp.load(_VECTOR_ADD_MLIR)
+        func = interp.module.functions["add"]
+        access_tile_ops = [
+            op for op in func.operations
+            if op.op_type == "ktdp.construct_access_tile"
+        ]
+        assert access_tile_ops, "no construct_access_tile op in fixture"
+        for op in access_tile_ops:
+            cs = op.attributes.get("coordinate_set")
+            assert isinstance(cs, BoxSet), (
+                f"coordinate_set should be BoxSet (sentinel retired), "
+                f"got {type(cs).__name__}"
+            )
+            assert cs.lo == (0,) * len(op.attributes["shape"])
+            assert tuple(cs.hi) == tuple(op.attributes["shape"])
+
+
+class TestSlowPathFallbackOnNonIdentityCoordinateOrder:
+    """All other fast-path tests verify that the BoxSet branch is
+    taken; this one verifies the negative direction — when the guard
+    rejects the access (non-identity ``coordinate_order``), execution
+    must fall through to the coord-list slow path that calls
+    ``_flat_memory_offsets``.  Without this, the guard could silently
+    widen (e.g. ``cso is None or True``) and no test would catch it.
+    """
+
+    def test_non_identity_order_calls_flat_memory_offsets(self):
+        ctx, hbm = _make_ctx()
+        data = np.arange(16, dtype=np.float16).reshape(4, 4)
+        ptr = hbm.allocate(data.nbytes)
+        hbm.write(ptr, data)
+        parent_ref = MemRef(
+            base_ptr=ptr, shape=(4, 4), strides=[4, 1],
+            memory_space="HBM", dtype="f16",
+        ).to_tile_ref()
+
+        # Transposing AffineMap — non-identity, so the guard rejects
+        # the BoxSet fast path and must use the coord-list scatter.
+        transpose = parse_affine_map("affine_map<(d0, d1) -> (d1, d0)>")
+        assert not transpose.is_identity()
+        access_tile = AccessTile(
+            parent_ref=parent_ref, shape=(4, 4),
+            base_map=parse_affine_map("affine_map<(d0, d1) -> (d0, d1)>"),
+            coordinate_set=BoxSet(lo=(0, 0), hi=(4, 4)),
+            coordinate_order=transpose,
+        )
+
+
+        class _Op:
+            attributes = {"_result_shape": (4, 4)}
+            operands = ["%a"]
+
+        class _Ctx:
+            def __init__(self, inner, at):
+                self._inner, self._at = inner, at
+            def get_value(self, _):
+                return self._at
+            def __getattr__(self, n):
+                return getattr(self._inner, n)
+
+        seen = []
+        real = MemoryOps._flat_memory_offsets
+
+        def _spy(*args, **kwargs):
+            seen.append(args)
+            return real(*args, **kwargs)
+
+        with patch.object(MemoryOps, "_flat_memory_offsets",
+                          staticmethod(_spy)):
+            ktdp__load(_Op(), _Ctx(ctx, access_tile), env=None)
+
+        assert len(seen) >= 1, (
+            "Non-identity coordinate_order must route to the slow path "
+            "and call _flat_memory_offsets — guard symmetry check."
+        )
+
+
+class TestExplicitIdentityCoordinateOrder:
+    """The dialect handler's guard is ``cso is None or cso.is_identity()``,
+    not ``cso is None`` alone — so a non-None identity AffineMap that
+    bypasses the parser-side normalisation still triggers the BoxSet
+    fast path.  Verifies the guard symmetry across the parser↔handler
+    boundary."""
+
+    def test_identity_affine_map_takes_fast_path(self):
+        ctx, hbm = _make_ctx()
+        data = np.arange(16, dtype=np.float16).reshape(4, 4)
+        ptr = hbm.allocate(data.nbytes)
+        hbm.write(ptr, data)
+        parent_ref = MemRef(
+            base_ptr=ptr, shape=(4, 4), strides=[4, 1],
+            memory_space="HBM", dtype="f16",
+        ).to_tile_ref()
+
+        # Construct an AccessTile directly with a non-None identity map,
+        # bypassing the parser's identity → None normalisation.
+        identity_map = parse_affine_map("affine_map<(d0, d1) -> (d0, d1)>")
+        assert identity_map.is_identity()
+        access_tile = AccessTile(
+            parent_ref=parent_ref,
+            shape=(4, 4),
+            base_map=identity_map,
+            coordinate_set=BoxSet(lo=(0, 0), hi=(4, 4)),
+            coordinate_order=identity_map,
+        )
+
+        # Drive the load handler directly.
+
+        class _Op:
+            attributes = {"_result_shape": (4, 4)}
+            operands = ["%a"]
+
+        seen = []
+        real = MemoryOps._flat_memory_offsets
+
+        def _spy(*args, **kwargs):
+            seen.append(args)
+            return real(*args, **kwargs)
+
+        class _Ctx:
+            def __init__(self, inner, at):
+                self._inner = inner
+                self._at = at
+            def get_value(self, _ssa):
+                return self._at
+            def __getattr__(self, n):
+                return getattr(self._inner, n)
+
+        with patch.object(MemoryOps, "_flat_memory_offsets",
+                          staticmethod(_spy)):
+            tile = ktdp__load(_Op(), _Ctx(ctx, access_tile), env=None)
+
+        np.testing.assert_array_equal(tile.data, data)
+        assert seen == [], (
+            "Explicit identity coordinate_order should still trigger the "
+            "BoxSet fast path (guard: cso is None or cso.is_identity())."
+        )
+
+
+# ---------------------------------------------------------------------------
+# _build_indirect_coords vectorised vs slow-path consistency
+# ---------------------------------------------------------------------------
+
+class TestIndirectBoxFastPathConsistency:
+    """The vectorised _build_indirect_coords_box must produce the same
+    coords (in the same order) as the per-pt Python loop slow path on
+    fixtures with mixed direct / direct_expr / indirect dim_subscripts.
+    Locks the BoxSet column-by-column reconstruction against the
+    pt-major / dim-minor consumption contract of the slow path.
+    """
+
+    def test_mixed_direct_expr_and_indirect_matches_slow_path(self):
+        """direct + direct_expr + indirect mixed in dim_subscripts.
+        The per-sub stride/offset slicing in the box variant must match
+        the iter()-based pt-major consumption of the slow path when two
+        indirect dims share the same index view (paged-tensor pattern).
+        """
+        # 2-D variable space (3 x 4); two dim_subscripts share one index view.
+        N, M = 3, 4
+        box = BoxSet(lo=(0, 0), hi=(N, M))
+        # For a shared-view fixture, idx_values[0] is consumed pt-major /
+        # dim-minor: 2 consumes per pt, total 2*N*M = 24 entries.
+        idx_data = np.array(
+            [(p * 7 + d) % 16 for p in range(N * M) for d in range(2)],
+            dtype=np.int64,
+        )
+        idx_values = {0: idx_data}
+
+        # Mock index_view_idx 0 as a tiny MemRef placeholder.
+        idx_view_stub = MemRef(
+            base_ptr=0, shape=(N, M), strides=[M, 1],
+            memory_space="HBM", dtype="i32",
+        )
+
+        dim_subs = [
+            {"kind": "direct", "var_index": 0},
+            {"kind": "direct_expr",
+             "subscript": ("add", ("dim", 0), ("mul", 2, ("dim", 1)))},
+            {"kind": "indirect", "index_view_idx": 0,
+             "idx_exprs": [("dim", 0), ("dim", 1)]},
+            {"kind": "indirect", "index_view_idx": 0,
+             "idx_exprs": [("dim", 0), ("dim", 1)]},
+        ]
+
+        # Stub IAT with two index_views entries (only [0] is used here).
+        parent = MemRef(
+            base_ptr=0, shape=(N, M), strides=[M, 1],
+            memory_space="HBM", dtype="f16",
+        )
+        iat = IndirectAccessTile(
+            parent_ref=parent.to_tile_ref(),
+            shape=(N, M),
+            variables_space_set=box,
+            dim_subscripts=dim_subs,
+            index_views=[idx_view_stub],
+            variables_space_order=None,
+        )
+
+        fast = _build_indirect_coords_box(iat, idx_values=idx_values, box=box)
+
+        # Slow path reconstruction by hand using the same iter consumption
+        # order: per pt, walk dim_subscripts in order; each indirect dim
+        # consumes the next entry from its iv_idx's iterator.
+        it = iter(idx_data.tolist())
+        slow = []
+        for p0 in range(N):
+            for p1 in range(M):
+                pt = (p0, p1)
+                row = []
+                for sub in dim_subs:
+                    if sub["kind"] == "direct":
+                        row.append(pt[sub["var_index"]])
+                    elif sub["kind"] == "direct_expr":
+                        row.append(eval_subscript_expr(sub["subscript"], pt))
+                    elif sub["kind"] == "indirect":
+                        row.append(int(next(it)))
+                slow.append(tuple(row))
+        assert fast == slow
+
+    @pytest.mark.parametrize(
+        "expr,expected_fn",
+        [
+            # floordiv/mod take a bare dim *index* in expr[1] (not a
+            # sub-expression — the only tags with this divergent
+            # convention).  add/mul/dim are covered transitively by
+            # ``test_mixed_direct_expr_and_indirect_matches_slow_path``;
+            # neg/max are listed here because they're in the affine
+            # grammar but not exercised anywhere else.
+            (("floordiv", 0, 4), lambda p0, p1: p0 // 4),
+            (("mod", 1, 7), lambda p0, p1: p1 % 7),
+            (("neg", ("dim", 0)), lambda p0, p1: -p0),
+            (("max", ("dim", 0), ("dim", 1)), lambda p0, p1: max(p0, p1)),
+        ],
+        ids=["floordiv", "mod", "neg", "max"],
+    )
+    def test_subscript_eval_parity(self, expr, expected_fn):
+        """Pin the vectorised evaluator against ``eval_subscript_expr``
+        for each grammar tag whose operand convention or branch isn't
+        already covered by other tests.  Without this, the two
+        evaluators silently drift when the grammar changes.
+        """
+
+        pts = np.array(
+            [(p0, p1) for p0 in range(4) for p1 in range(5)], dtype=np.int64
+        )
+        slow = np.array(
+            [eval_subscript_expr(expr, tuple(p)) for p in pts], dtype=np.int64,
+        )
+        fast = _eval_subscript_vectorized(expr, pts)
+        expected = np.array(
+            [expected_fn(int(p[0]), int(p[1])) for p in pts], dtype=np.int64,
+        )
+        np.testing.assert_array_equal(fast, slow)
+        np.testing.assert_array_equal(fast, expected)
+
+    def test_negative_indirect_index_raises(self):
+        """The vectorised path keeps the slow path's IndexError on
+        negative indices (NumPy fancy-indexing wraps; we reject)."""
+
+        box = BoxSet(lo=(0,), hi=(3,))
+        idx_view_stub = MemRef(
+            base_ptr=0, shape=(3,), strides=[1],
+            memory_space="HBM", dtype="i32",
+        )
+        parent = MemRef(
+            base_ptr=0, shape=(3,), strides=[1],
+            memory_space="HBM", dtype="f16",
+        )
+        iat = IndirectAccessTile(
+            parent_ref=parent.to_tile_ref(),
+            shape=(3,),
+            variables_space_set=box,
+            dim_subscripts=[
+                {"kind": "indirect", "index_view_idx": 0,
+                 "idx_exprs": [("dim", 0)]},
+            ],
+            index_views=[idx_view_stub],
+            variables_space_order=None,
+        )
+        # One sub on iv_idx 0 → idx_values[0] is length 3, in pt order.
+        idx_values = {0: np.array([1, -2, 0], dtype=np.int64)}
+
+        with pytest.raises(IndexError, match="negative"):
+            _build_indirect_coords_box(iat, idx_values=idx_values, box=box)

--- a/tests/test_dialects_exec.py
+++ b/tests/test_dialects_exec.py
@@ -1229,6 +1229,7 @@ class TestKtdp:
 
     def test_load_store_roundtrip(self):
         # load reads data from HBM; store writes it back modified
+        from ktir_cpu.affine import BoxSet
         from ktir_cpu.ir_types import AccessTile, MemRef
         from ktir_cpu.parser_ast import parse_affine_map
 
@@ -1245,7 +1246,7 @@ class TestKtdp:
         tile_ref = memref.to_tile_ref()
         access_tile = AccessTile(parent_ref=tile_ref, shape=(8,),
                                  base_map=identity_map,
-                                 coordinate_set=None,
+                                 coordinate_set=BoxSet(lo=(0,), hi=(8,)),
                                  coordinate_order=None)
         ctx.set_value("%acc", access_tile)
         env = _make_env()

--- a/tests/test_dialects_parse.py
+++ b/tests/test_dialects_parse.py
@@ -168,9 +168,13 @@ class TestModuleParser:
           func.func @add(%a: index, %b: index, %c: index) -> index attributes { grid = [4, 4] } {
             %c0 = arith.constant 0 : index
             %grid0 = ktdp.get_compute_tile_id : index
-            %acc = ktdp.construct_access_tile %ref[%c0, %c0] : memref<128x256xf16> -> !ktdp.access_tile<128x256xindex>
+            %acc = ktdp.construct_access_tile %ref[%c0, %c0] {
+                access_tile_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 127 >= 0, d1 >= 0, -d1 + 255 >= 0)>
+            } : memref<128x256xf16> -> !ktdp.access_tile<128x256xindex>
             %tile = ktdp.load %acc : !ktdp.access_tile<128x256xindex> -> tensor<128x256xf16>
-            %out_acc = ktdp.construct_access_tile %out_ref[%c0, %c0] : memref<128x256xf16> -> !ktdp.access_tile<128x256xindex>
+            %out_acc = ktdp.construct_access_tile %out_ref[%c0, %c0] {
+                access_tile_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 127 >= 0, d1 >= 0, -d1 + 255 >= 0)>
+            } : memref<128x256xf16> -> !ktdp.access_tile<128x256xindex>
             ktdp.store %tile, %out_acc : tensor<128x256xf16>, !ktdp.access_tile<128x256xindex>
             return %c0 : index
           }

--- a/tests/test_latency_modeling.py
+++ b/tests/test_latency_modeling.py
@@ -191,8 +191,10 @@ def _patch_tile_size(interp, func_name, new_size: int):
     """Override all 1-D construct_memory_view sizes and access_tile shapes.
 
     Only touches 1-D ops so 2-D kernels (softmax, matmul) are unaffected.
-    Also updates coordinate_set / coordinate_space_set bounds to match the
-    new size, so future bound-checking passes the correct upper limit.
+    Also updates coordinate_set bounds on both ops to match the new size,
+    so future bound-checking passes the correct upper limit and the
+    BoxSet fast path in ktdp.load/store loads the patched extent rather
+    than the original.
     """
     func = interp.module.get_function(func_name)
     for op in _iter_ops(func.operations):
@@ -202,12 +204,8 @@ def _patch_tile_size(interp, func_name, new_size: int):
                 new_set = parse_affine_set(
                     f"affine_set<(d0) : (d0 >= 0, -d0 + {new_size - 1} >= 0)>"
                 )
-                if op.op_type == "ktdp.construct_memory_view":
-                    if op.attributes.get("coordinate_set") is not None:
-                        op.attributes["coordinate_set"] = new_set
-                else:
-                    if op.attributes.get("coordinate_space_set") is not None:
-                        op.attributes["coordinate_space_set"] = new_set
+                if op.attributes.get("coordinate_set") is not None:
+                    op.attributes["coordinate_set"] = new_set
 
 def _patch_tile_dim0(interp, func_name, old_dim0: int, new_dim0: int):
     """Scale dim-0 of all 2-D IR shapes whose current dim-0 equals *old_dim0*.
@@ -230,13 +228,15 @@ def _patch_tile_dim0(interp, func_name, old_dim0: int, new_dim0: int):
             shape = op.attributes.get("shape", ())
             if len(shape) == 2 and shape[0] == old_dim0:
                 op.attributes["shape"] = (new_dim0, shape[1])
-                if op.op_type == "ktdp.construct_access_tile":
-                    if op.attributes.get("coordinate_space_set") is not None:
-                        dim1 = shape[1]
-                        op.attributes["coordinate_space_set"] = parse_affine_set(
-                            f"affine_set<(d0, d1) : (d0 >= 0, -d0 + {new_dim0 - 1} >= 0, "
-                            f"d1 >= 0, -d1 + {dim1 - 1} >= 0)>"
-                        )
+                if (
+                    op.op_type == "ktdp.construct_access_tile"
+                    and op.attributes.get("coordinate_set") is not None
+                ):
+                    dim1 = shape[1]
+                    op.attributes["coordinate_set"] = parse_affine_set(
+                        f"affine_set<(d0, d1) : (d0 >= 0, -d0 + {new_dim0 - 1} >= 0, "
+                        f"d1 >= 0, -d1 + {dim1 - 1} >= 0)>"
+                    )
         elif op.op_type in ("arith.constant", "tensor.empty") and (
             op.op_type != "arith.constant" or op.attributes.get("is_tensor")
         ):


### PR DESCRIPTION
Closes #52.

> Updated 2026-06-09 — round-2 reframed as caller-side cleanup; see PR comment for analysis. Title retitled per reviewer suggestion.

## Summary

Three additions and one forced fixture fix, landed together as one logical change ("BoxSet fast path end-to-end on single-allocation routes"):

- **Parser default-fill.** `AccessTile.coordinate_set = None` retired; parser default-fills `BoxSet([0, shape))` at parse time. Concrete-int `TypeError` on `access_shape` (not `assert` -- must survive `python -O`).
- **Direct path.** `MemoryOps.boxed_load` / `boxed_store` reuse `_subtile_ref` to read/write rectangular slices without enumerating the AffineSet point list. Dispatched from `ktdp.load` / `ktdp.store` on `isinstance(css, BoxSet) and (cso is None or cso.is_identity())`. Empty-box returns zero sticks.
- **Indirect path.** `_build_indirect_coords` dispatches to a vectorised coord build (`np.indices` column-by-column) when `variables_space_set` is `BoxSet` and `variables_space_order` is identity. New `_eval_subscript_vectorized` mirrors the slow-path AST grammar tag-for-tag. Per-pt HBM lookups stay on the slow path.
- **Forced.** `_patch_tile_size` / `_patch_tile_dim0` in `tests/test_latency_modeling.py` were writing `coordinate_space_set`, a non-existent field. The typo was masked by the old `None` sentinel; the default-fill exposes it. Both helpers now write the real `coordinate_set`.

## Architecture notes

A few non-obvious design moves worth surfacing:

- **`partition_origin or zero_tuple` quiet polymorphism.** `_subtile_ref` is the distributed-path helper; on a non-distributed parent its fallback collapses cleanly to `box.lo * strides`. The direct path reuses it instead of writing a parallel non-distributed helper. Trade-off accepted: ties the direct path to a distributed-path implementation detail; no-trample tests pin the contract.

- **`cso.is_identity()` guard upgrade.** The parser invariant "identity normalised to `None`" was an implicit contract spread across three files. Promoting it to a local call-site self-check converts cross-file maintenance to local maintenance for cold-path cost only.

- **Indirect vectorisation scope.** `_resolve_idx_reads` is already per-view batched -- rewriting it has zero collinear win. Only the structural coord build moves into NumPy; per-pt indirect HBM lookups stay because stick locality is unpredictable and outside the BoxSet structure.

- **Symbolic shapes ruled out at access-tile layer.** Confirmed on PR #69 (dynamic shapes resolved at memory view layer; access tiles concrete by construction). #73 closed not-planned. The new `TypeError` is a defence against future parser changes leaking symbols past that boundary.

## Performance framing

Constant-factor savings on the Python-side coord build for the indirect path; no measured benchmarks gathered. Reasonable benchmark target is the paged-tensor indirect-access fixture if reviewers ask.

The deeper `O(N -> 1)` collapse the issue alludes to would need a `MemoryOps.load(coords: ndarray)` API change which is out of scope here -- `_flat_memory_offsets` still iterates per coord and consumes `List[Tuple]`, so the closing `tolist()` / `tuple()` conversion is where the entire Python-side overhead of the indirect fast path lives.

## Tests added

`tests/test_boxset_fastpath.py` -- ten functions / 13 collected items, picked by non-overlapping failure modes:

- **Unit `boxed_load` / `boxed_store`** on offset, full, and empty boxes. Pins the helpers' contract independent of dispatch.
- **Dispatch verification** in both directions: `ktdp.load` / `ktdp.store` reach the boxed path for axis-aligned `BoxSet`s, AND fall back to the AffineSet path under non-identity `coordinate_order` (previously every test only verified the fast path was *taken*, never that it was *rejected* when it should be).
- **End-to-end no-trample** on column-packed and row-major fixtures. Expectations are derived from `_flat_memory_offsets` rather than hand-counted addresses, so a future stride-rule change does not silently invalidate them.
- **Indirect parity** parametrised over `floordiv` / `mod` / `neg` / `max`, comparing the `BoxSet` fast path against the AffineSet slow path on the same coords. Subscript-grammar regressions surface as test failures rather than as silent address divergence.

`tests/test_latency_modeling.py::_patch_tile_size` and `_patch_tile_dim0` are fixed in passing -- see "Forced" above.

## Follow-ups

- **`MemoryOps.load(coords=...)` accepting `ndarray`** would let `_build_indirect_coords_box` skip its closing `tolist()` / `tuple()` conversion entirely. The entire Python-side overhead of the indirect fast path lives in that conversion. File as follow-up if performance proves to matter.
- **Forced-AffineSet-vss fixture** for indirect parity tests. The current `test_mixed_direct_expr_and_indirect_matches_slow_path` re-implements slow-path coord build manually; a manually-constructed `AffineSet` bypassing `try_from_affine_set`'s axis-aligned lowering would be cleaner. Judged not-worth-it today; revisit if a slow-path order change actually breaks parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)