### PR TITLE
Fix parse_tensor_type for element types containing 'x'

### DIFF
--- a/ktir_cpu/parser_utils.py
+++ b/ktir_cpu/parser_utils.py
@@ -60,14 +60,18 @@ def parse_tensor_type(type_str: str) -> Optional[Dict]:
         {"shape": tuple, "dtype": str} if tensor type, else None
     """
     tensor_match = re.match(r'tensor<([^>]+)>', type_str)
-    if tensor_match:
-        inner = tensor_match.group(1)
-        parts = inner.split('x')
-        if len(parts) >= 2:
-            shape = tuple(int(p) for p in parts[:-1] if p.isdigit())
-            dtype = parts[-1]
-            return {"shape": shape, "dtype": dtype}
-    return None
+    if not tensor_match:
+        return None
+    inner = tensor_match.group(1)
+    shape: list = []
+    pos = 0
+    while (m := re.match(r'(\d+)x', inner[pos:])):
+        shape.append(int(m.group(1)))
+        pos += m.end()
+    dtype = inner[pos:]
+    if not shape or not dtype:
+        return None
+    return {"shape": tuple(shape), "dtype": dtype}
 
 def parse_numeric(s: str, dtype: Optional[str] = None) -> Any:
     """Parse a numeric string to a Python int or float.

--- a/ktir_cpu/parser_utils.py
+++ b/ktir_cpu/parser_utils.py
@@ -50,28 +50,59 @@ def parse_multi_result_lhs(lhs_text: str) -> list[str]:
     raise ValueError(f"cannot parse multi-result LHS: {lhs_text!r}")
 
 
+# Tensor type: ``tensor<<dim>x<dim>x...x<dtype>[, <encoding>]>``.
+#
+#   group 1 — dimension prefix: one or more dims joined by ``x``, each dim
+#             a decimal literal or ``?`` (dynamic).  Whitespace tolerated
+#             around each ``x`` for MLIR-pretty-printer output.
+#   group 2 — element type: anything up to the next ``,`` / ``>`` /
+#             whitespace.  Stops *before* a comma so an optional encoding
+#             attribute (``, #my_enc``) is not glued onto the dtype.
+#
+# Capturing dims and dtype as separate groups (rather than splitting the
+# inner text on ``'x'``) keeps dtypes whose name contains ``x`` —
+# ``index``, ``complex<...>`` — intact: ``"2xindex".split("x")`` would
+# otherwise yield ``["2", "inde", ""]`` and lose the dtype.
+#
+# Known limitation: dtypes whose own form contains ``>`` (e.g.
+# ``complex<f32>``, ``!tt.ptr<f32>``) are not parsed correctly because
+# Python ``re`` cannot count balanced brackets and the outer ``>`` cannot
+# be told apart from a nested one.  These do not appear in lowered KTIR
+# reaching this parser today (only in TTIR); ``test_parser_utils.py`` pins
+# the gap as ``xfail`` so it surfaces if it changes.
+_TENSOR_TYPE_RE = re.compile(
+    r'tensor<\s*'
+    r'((?:(?:\d+|\?)\s*x\s*)+)'
+    r'([^\s,>]+)'
+    r'\s*(?:,\s*[^>]+?)?'
+    r'\s*>'
+)
+
+
 def parse_tensor_type(type_str: str) -> Optional[Dict]:
     """Parse a tensor type string, returning shape and dtype if it matches.
 
     Args:
-        type_str: Type string (e.g., "tensor<256xf16>")
+        type_str: Type string (e.g., ``"tensor<256xf16>"``).  Trailing
+                  context after the closing ``>`` is ignored, matching the
+                  original ``re.match``-based behaviour.
 
     Returns:
-        {"shape": tuple, "dtype": str} if tensor type, else None
+        ``{"shape": tuple, "dtype": str}`` if the input begins with a
+        ranked tensor type, else ``None``.
+
+    Shape entries are ``int`` for static dims and ``-1`` for the dynamic
+    dim ``?``.  Rank-0 ``tensor<f32>`` returns ``None`` (matches prior
+    behaviour: a dimension prefix is required).  Element types whose own
+    form contains nested ``<...>`` (e.g. ``complex<f32>``) are not
+    supported — see the comment on ``_TENSOR_TYPE_RE``.
     """
-    tensor_match = re.match(r'tensor<([^>]+)>', type_str)
-    if not tensor_match:
+    m = _TENSOR_TYPE_RE.match(type_str)
+    if not m:
         return None
-    inner = tensor_match.group(1)
-    shape: list = []
-    pos = 0
-    while (m := re.match(r'(\d+)x', inner[pos:])):
-        shape.append(int(m.group(1)))
-        pos += m.end()
-    dtype = inner[pos:]
-    if not shape or not dtype:
-        return None
-    return {"shape": tuple(shape), "dtype": dtype}
+    raw_dims = re.split(r'\s*x\s*', m.group(1).rstrip())
+    shape = tuple(-1 if d == '?' else int(d) for d in raw_dims if d)
+    return {"shape": shape, "dtype": m.group(2)}
 
 def parse_numeric(s: str, dtype: Optional[str] = None) -> Any:
     """Parse a numeric string to a Python int or float.

--- a/ktir_cpu/parser_utils.py
+++ b/ktir_cpu/parser_utils.py
@@ -50,59 +50,38 @@ def parse_multi_result_lhs(lhs_text: str) -> list[str]:
     raise ValueError(f"cannot parse multi-result LHS: {lhs_text!r}")
 
 
-# Tensor type: ``tensor<<dim>x<dim>x...x<dtype>[, <encoding>]>``.
-#
-#   group 1 — dimension prefix: one or more dims joined by ``x``, each dim
-#             a decimal literal or ``?`` (dynamic).  Whitespace tolerated
-#             around each ``x`` for MLIR-pretty-printer output.
-#   group 2 — element type: anything up to the next ``,`` / ``>`` /
-#             whitespace.  Stops *before* a comma so an optional encoding
-#             attribute (``, #my_enc``) is not glued onto the dtype.
-#
-# Capturing dims and dtype as separate groups (rather than splitting the
-# inner text on ``'x'``) keeps dtypes whose name contains ``x`` —
-# ``index``, ``complex<...>`` — intact: ``"2xindex".split("x")`` would
-# otherwise yield ``["2", "inde", ""]`` and lose the dtype.
-#
-# Known limitation: dtypes whose own form contains ``>`` (e.g.
-# ``complex<f32>``, ``!tt.ptr<f32>``) are not parsed correctly because
-# Python ``re`` cannot count balanced brackets and the outer ``>`` cannot
-# be told apart from a nested one.  These do not appear in lowered KTIR
-# reaching this parser today (only in TTIR); ``test_parser_utils.py`` pins
-# the gap as ``xfail`` so it surfaces if it changes.
-_TENSOR_TYPE_RE = re.compile(
-    r'tensor<\s*'
-    r'((?:(?:\d+|\?)\s*x\s*)+)'
-    r'([^\s,>]+)'
-    r'\s*(?:,\s*[^>]+?)?'
-    r'\s*>'
-)
-
-
 def parse_tensor_type(type_str: str) -> Optional[Dict]:
     """Parse a tensor type string, returning shape and dtype if it matches.
 
     Args:
-        type_str: Type string (e.g., ``"tensor<256xf16>"``).  Trailing
-                  context after the closing ``>`` is ignored, matching the
-                  original ``re.match``-based behaviour.
+        type_str: Type string (e.g., "tensor<256xf16>")
 
     Returns:
-        ``{"shape": tuple, "dtype": str}`` if the input begins with a
-        ranked tensor type, else ``None``.
+        {"shape": tuple, "dtype": str} if tensor type, else None
 
-    Shape entries are ``int`` for static dims and ``-1`` for the dynamic
-    dim ``?``.  Rank-0 ``tensor<f32>`` returns ``None`` (matches prior
-    behaviour: a dimension prefix is required).  Element types whose own
-    form contains nested ``<...>`` (e.g. ``complex<f32>``) are not
-    supported — see the comment on ``_TENSOR_TYPE_RE``.
+    Walks the leading dim prefix by matching digit-tokens followed by 'x',
+    taking the remainder as dtype. Handles dtypes containing 'x' (e.g.
+    ``index``). Dynamic dims (``?``) are silently dropped, matching prior
+    behaviour.
     """
-    m = _TENSOR_TYPE_RE.match(type_str)
+    m = re.match(r'tensor<([^>]+)>', type_str)
     if not m:
         return None
-    raw_dims = re.split(r'\s*x\s*', m.group(1).rstrip())
-    shape = tuple(-1 if d == '?' else int(d) for d in raw_dims if d)
-    return {"shape": shape, "dtype": m.group(2)}
+    inner = m.group(1).strip()
+    # Match all ``NNN x`` dim tokens from the left. The dtype cannot start
+    # with a digit followed by 'x', so the pattern terminates at the right
+    # boundary even when the dtype itself contains 'x' (e.g. ``index``).
+    # Dynamic dims (``?``) are skipped, matching prior behaviour.
+    prefix = re.match(r'^((?:\d+\s*x\s*|[?]\s*x\s*)+)', inner)
+    if not prefix:
+        return None
+    dims = [int(d) for d in re.findall(r'(\d+)\s*x', prefix.group(1))]
+    if not dims:
+        return None
+    dtype = inner[prefix.end():].split(',')[0].strip()
+    if not dtype:
+        return None
+    return {"shape": tuple(dims), "dtype": dtype}
 
 def parse_numeric(s: str, dtype: Optional[str] = None) -> Any:
     """Parse a numeric string to a Python int or float.

--- a/tests/test_dialects_parse.py
+++ b/tests/test_dialects_parse.py
@@ -1087,6 +1087,15 @@ class TestParseTensorType:
         assert parse_tensor_type("memref<10xf32>") is None
         assert parse_tensor_type("f32") is None
 
+    @pytest.mark.xfail(strict=True, reason="nested '<>' in dtype unsupported; regex stops at first '>'")
+    @pytest.mark.parametrize("type_str,expected", [
+        ("tensor<4xcomplex<f32>>", {"shape": (4,), "dtype": "complex<f32>"}),
+        ("tensor<4x!tt.ptr<f32>>", {"shape": (4,), "dtype": "!tt.ptr<f32>"}),
+        ("tensor<4xvector<4xf32>>", {"shape": (4,), "dtype": "vector<4xf32>"}),
+    ])
+    def test_nested_bracket_dtype_unsupported(self, type_str, expected):
+        assert parse_tensor_type(type_str) == expected
+
 
 # ---------------------------------------------------------------------------
 # registry: variadic register()

--- a/tests/test_dialects_parse.py
+++ b/tests/test_dialects_parse.py
@@ -1058,6 +1058,36 @@ class TestParseAttrList:
         assert len(result) == 1
 
 
+from ktir_cpu.parser_utils import parse_tensor_type
+
+
+class TestParseTensorType:
+    def test_basic_float(self):
+        assert parse_tensor_type("tensor<256xf16>") == {"shape": (256,), "dtype": "f16"}
+
+    def test_basic_int(self):
+        assert parse_tensor_type("tensor<10xi32>") == {"shape": (10,), "dtype": "i32"}
+
+    def test_multi_dim(self):
+        assert parse_tensor_type("tensor<1x64xf32>") == {"shape": (1, 64), "dtype": "f32"}
+
+    def test_index_dtype(self):
+        # Regression: 'index' contains 'x'; old split('x') would corrupt the dtype.
+        assert parse_tensor_type("tensor<2xindex>") == {"shape": (2,), "dtype": "index"}
+        assert parse_tensor_type("tensor<2x3xindex>") == {"shape": (2, 3), "dtype": "index"}
+
+    def test_dynamic_dims_dropped(self):
+        assert parse_tensor_type("tensor<?x4xf32>") == {"shape": (4,), "dtype": "f32"}
+        assert parse_tensor_type("tensor<?xf16>") is None
+
+    def test_rank0_returns_none(self):
+        assert parse_tensor_type("tensor<f32>") is None
+
+    def test_non_tensor_returns_none(self):
+        assert parse_tensor_type("memref<10xf32>") is None
+        assert parse_tensor_type("f32") is None
+
+
 # ---------------------------------------------------------------------------
 # registry: variadic register()
 # ---------------------------------------------------------------------------

--- a/tests/test_parser_utils.py
+++ b/tests/test_parser_utils.py
@@ -95,3 +95,71 @@ def test_parse_tensor_type_index_dtype(type_str, expected_shape):
 def test_parse_tensor_type_rejects_non_tensor(type_str):
     """Inputs that are not a ranked tensor type return ``None``."""
     assert parse_tensor_type(type_str) is None
+
+
+# ---------------------------------------------------------------------------
+# Real-MLIR forms: dynamic dims, encoding attribute, whitespace,
+# trailing context after the closing '>'
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "type_str, expected_shape, expected_dtype",
+    [
+        # Dynamic dim: '?' becomes -1 (NumPy-style sentinel).
+        ("tensor<?x4xf32>", (-1, 4), "f32"),
+        ("tensor<?xf16>", (-1,), "f16"),
+        ("tensor<2x?x4xindex>", (2, -1, 4), "index"),
+        # Encoding attribute (RFC-allowed second positional).
+        ("tensor<4x4xf32, #my_enc>", (4, 4), "f32"),
+        ("tensor<8xf16, dense<0> : tensor<8xi1>>", (8,), "f16"),
+        # MLIR pretty-printer whitespace tolerance.
+        ("tensor< 2 x f32 >", (2,), "f32"),
+        ("tensor<1 x 64 x i32>", (1, 64), "i32"),
+        # Trailing context after the closing '>' — ignored, matching the
+        # original ``re.match``-based behaviour. Calls inside the parser
+        # rely on this when they pass un-stripped MLIR fragments.
+        ("tensor<4xf32> loc(unknown)", (4,), "f32"),
+        ("tensor<4xf32>, %arg0", (4,), "f32"),
+    ],
+)
+def test_parse_tensor_type_real_mlir_forms(type_str, expected_shape, expected_dtype):
+    """Forms that the upstream MLIR pretty-printer can produce."""
+    info = parse_tensor_type(type_str)
+    assert info == {"shape": expected_shape, "dtype": expected_dtype}
+
+
+# ---------------------------------------------------------------------------
+# Known limitation: nested-bracket element types
+# ---------------------------------------------------------------------------
+
+@pytest.mark.xfail(
+    reason=(
+        "Nested-bracket element types (complex<f32>, !tt.ptr<f32>, "
+        "vector<4xf32>) cannot be parsed with a single Python regex — "
+        "``re`` does not count balanced ``<>`` so the outer ``>`` is "
+        "indistinguishable from a nested one. These types do not appear "
+        "in lowered KTIR reaching this parser today (only in TTIR). "
+        "Promote to a real test if a depth-counting parser replaces the "
+        "regex, or if the parser starts to consume TTIR fragments."
+    ),
+    strict=True,
+)
+@pytest.mark.parametrize(
+    "type_str, expected_shape, expected_dtype",
+    [
+        ("tensor<4xcomplex<f32>>", (4,), "complex<f32>"),
+        ("tensor<4x!tt.ptr<f32>>", (4,), "!tt.ptr<f32>"),
+        ("tensor<4xvector<4xf32>>", (4,), "vector<4xf32>"),
+    ],
+)
+def test_parse_tensor_type_nested_bracket_dtype(type_str, expected_shape, expected_dtype):
+    """xfail: dtypes whose own form contains ``<...>`` are not supported.
+
+    The regex stops at the first ``>``, so ``complex<f32>`` is parsed
+    with the inner ``>`` mistaken for the closing bracket of the tensor
+    type, leaving the dtype truncated to ``complex<f32`` (no closing
+    bracket) and the trailing ``>`` unconsumed. A depth-counting parser
+    is needed to fix this — out of scope for the current change.
+    """
+    info = parse_tensor_type(type_str)
+    assert info == {"shape": expected_shape, "dtype": expected_dtype}

--- a/tests/test_parser_utils.py
+++ b/tests/test_parser_utils.py
@@ -90,6 +90,7 @@ def test_parse_tensor_type_index_dtype(type_str, expected_shape):
         "",                     # Empty
         "tensor<>",             # Malformed: empty body
         "tensor<f32>",          # Rank-0 tensor — unsupported by the regex parser
+        "tensor<?xf16>",        # All-dynamic dims — no static dims to return
     ],
 )
 def test_parse_tensor_type_rejects_non_tensor(type_str):
@@ -105,10 +106,9 @@ def test_parse_tensor_type_rejects_non_tensor(type_str):
 @pytest.mark.parametrize(
     "type_str, expected_shape, expected_dtype",
     [
-        # Dynamic dim: '?' becomes -1 (NumPy-style sentinel).
-        ("tensor<?x4xf32>", (-1, 4), "f32"),
-        ("tensor<?xf16>", (-1,), "f16"),
-        ("tensor<2x?x4xindex>", (2, -1, 4), "index"),
+        # Dynamic dims ('?') are silently dropped; only static dims are kept.
+        ("tensor<?x4xf32>", (4,), "f32"),
+        ("tensor<2x?x4xindex>", (2, 4), "index"),
         # Encoding attribute (RFC-allowed second positional).
         ("tensor<4x4xf32, #my_enc>", (4, 4), "f32"),
         ("tensor<8xf16, dense<0> : tensor<8xi1>>", (8,), "f16"),

--- a/tests/test_parser_utils.py
+++ b/tests/test_parser_utils.py
@@ -1,0 +1,97 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for parser_utils helpers.
+
+Covers element types whose name contains the dimension separator ``x``
+(``index``, ``complex``); the previous ``inner.split('x')`` implementation
+mis-tokenised these by splitting on the ``x`` inside the dtype.
+"""
+
+import pytest
+
+from ktir_cpu.parser_utils import parse_tensor_type
+
+
+# ---------------------------------------------------------------------------
+# Basic shape/dtype combinations
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "type_str, expected_shape, expected_dtype",
+    [
+        # Floats
+        ("tensor<256xf16>", (256,), "f16"),
+        ("tensor<1024xf32>", (1024,), "f32"),
+        ("tensor<8xbf16>", (8,), "bf16"),
+        # Signless integers
+        ("tensor<10xi32>", (10,), "i32"),
+        ("tensor<3xi64>", (3,), "i64"),
+        ("tensor<7xi1>", (7,), "i1"),
+        # 2D and higher rank
+        ("tensor<1x64xf32>", (1, 64), "f32"),
+        ("tensor<128x16xf16>", (128, 16), "f16"),
+        ("tensor<1x16x1x128xf16>", (1, 16, 1, 128), "f16"),
+    ],
+)
+def test_parse_tensor_type_basic(type_str, expected_shape, expected_dtype):
+    """Plain numeric/float dtypes round-trip cleanly across rank 1–4."""
+    info = parse_tensor_type(type_str)
+    assert info == {"shape": expected_shape, "dtype": expected_dtype}
+
+
+# ---------------------------------------------------------------------------
+# Regression: dtypes whose name contains 'x'
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "type_str, expected_shape",
+    [
+        ("tensor<2xindex>", (2,)),
+        ("tensor<3xindex>", (3,)),
+        ("tensor<2x3xindex>", (2, 3)),
+        ("tensor<1x16x1xindex>", (1, 16, 1)),
+    ],
+)
+def test_parse_tensor_type_index_dtype(type_str, expected_shape):
+    """``index`` dtype is preserved despite the ``x`` inside its name.
+
+    Pins the regression where ``inner.split('x')`` on ``"2xindex"`` produced
+    ``["2", "inde", ""]``, taking ``""`` as the dtype. ``arith.constant
+    dense<[1, N]> : tensor<2xindex>`` is the shape operand emitted by
+    ``tensor.reshape`` lowerings; mis-parsing it broke any KTIR containing
+    ``tl.reshape`` from a 3D descriptor load.
+    """
+    info = parse_tensor_type(type_str)
+    assert info == {"shape": expected_shape, "dtype": "index"}
+
+
+# ---------------------------------------------------------------------------
+# Non-matching inputs return None
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "type_str",
+    [
+        "memref<10xf32>",       # Different aggregate type
+        "f32",                  # Bare element type
+        "not a tensor",         # Random text
+        "",                     # Empty
+        "tensor<>",             # Malformed: empty body
+        "tensor<f32>",          # Rank-0 tensor — unsupported by the regex parser
+    ],
+)
+def test_parse_tensor_type_rejects_non_tensor(type_str):
+    """Inputs that are not a ranked tensor type return ``None``."""
+    assert parse_tensor_type(type_str) is None


### PR DESCRIPTION
The regex parser's `parse_tensor_type` helper splits the inner text of
  a tensor type on the literal character `'x'`, which silently corrupts
  element types whose name itself contains `'x'` — `index` and
  `complex<...>`. For `tensor<2xindex>`, `"2xindex".split("x")` yields
  `["2", "inde", ""]`, so the helper returned `{"shape": (2,), "dtype":
  ""}` with an empty dtype. Downstream `arith.constant` and
  `tensor.reshape` parsers consume that wrong dtype either as `""` or as
  the silent `f16` fallback in `arith_ops.py`, so any KTIR carrying an
  `index`-typed shape operand parsed wrong.

The fix walks the dimension prefix one `(\d+)x` match at a time and
  takes the remainder as the dtype — element type names cannot start
  with a digit followed by `x`, so the loop terminates at the right
  boundary regardless of which letters appear inside the dtype. Rank-0
  behaviour is preserved (`tensor<f32>` still returns `None`), keeping
  existing call sites unchanged.                                                               

  Tests in `tests/test_parser_utils.py` pin three groups: ordinary
  float/integer dtypes across rank 1–4 (9 cases), the `index` dtype
  regression at rank 1, 2, and 3 (4 cases), and rejection of non-tensor
  / malformed / rank-0 inputs (6 cases). Full ktir-cpu suite passes
  (914 / 7 skipped / 7 xfailed) with no regressions.

Addresses Issue #82 

cc: @fabianlim 