### PR TITLE
First issue: issue 76, latency for linalg.reduce

### DIFF
--- a/examples/ktir/reduce_multiop.mlir
+++ b/examples/ktir/reduce_multiop.mlir
@@ -1,0 +1,36 @@
+// linalg.reduce with a MULTI-OP combiner region: max expressed as
+// cmpf(ogt) + select rather than a single arith.maximumf.  This exercises the
+// general tree fold — every op in the region is executed and charged, and the
+// result does not depend on recognising a single combiner op by name.
+module {
+  func.func @reduce_multiop(%arg0: index) attributes {grid = [1, 1]} {
+    %c0 = arith.constant 0 : index
+    %cst = arith.constant 0xFF80 : f16  // -inf (identity for max)
+    %view = ktdp.construct_memory_view %arg0, sizes : [1, 8], strides : [8, 1] {coordinate_set = affine_set<(d0, d1) : (d0 >= 0, -d0 >= 0, d1 >= 0, -d1 + 7 >= 0)>, memory_space = #ktdp.spyre_memory_space<HBM>} : memref<1x8xf16>
+    %acc = ktdp.construct_access_tile %view[%c0, %c0] {
+        access_tile_set = affine_set<(d0, d1) : (d0 >= 0, -d0 >= 0, d1 >= 0, -d1 + 7 >= 0)>,
+        access_tile_order = affine_map<(d0, d1) -> (d0, d1)>
+    } : memref<1x8xf16> -> !ktdp.access_tile<1x8xindex>
+    %data = ktdp.load %acc : !ktdp.access_tile<1x8xindex> -> tensor<1x8xf16>
+
+    %init = tensor.empty() : tensor<1xf16>
+    %init_filled = linalg.fill ins(%cst : f16) outs(%init : tensor<1xf16>) -> tensor<1xf16>
+
+    %reduced = linalg.reduce ins(%data : tensor<1x8xf16>) outs(%init_filled : tensor<1xf16>) dimensions = [1]
+      (%in: f16, %out: f16) {
+        %cmp = arith.cmpf ogt, %in, %out : f16
+        %max = arith.select %cmp, %in, %out : f16
+        linalg.yield %max : f16
+      }
+
+    %scalar = tensor.extract %reduced[%c0] : tensor<1xf16>
+    %splat = tensor.splat %scalar : tensor<1x8xf16>
+    %out_view = ktdp.construct_memory_view %arg0, sizes : [1, 8], strides : [8, 1] {coordinate_set = affine_set<(d0, d1) : (d0 >= 0, -d0 >= 0, d1 >= 0, -d1 + 7 >= 0)>, memory_space = #ktdp.spyre_memory_space<HBM>} : memref<1x8xf16>
+    %out_acc = ktdp.construct_access_tile %out_view[%c0, %c0] {
+        access_tile_set = affine_set<(d0, d1) : (d0 >= 0, -d0 >= 0, d1 >= 0, -d1 + 7 >= 0)>,
+        access_tile_order = affine_map<(d0, d1) -> (d0, d1)>
+    } : memref<1x8xf16> -> !ktdp.access_tile<1x8xindex>
+    ktdp.store %splat, %out_acc : tensor<1x8xf16>, !ktdp.access_tile<1x8xindex>
+    return
+  }
+}

--- a/examples/latency/softmax_small_explicit.mlir
+++ b/examples/latency/softmax_small_explicit.mlir
@@ -1,0 +1,79 @@
+// Same kernel as softmax_small.mlir, but the two linalg.reduce ops use the
+// EXPLICIT combiner-region form `(%in, %out) { ... linalg.yield }` instead of
+// the `{ arith.maximumf }` / `{ arith.addf }` shorthand.  Exercises the
+// explicit-region path of linalg.reduce through the same tree fold.
+module {
+  func.func @softmax_kernel_small_explicit(
+      %output_ptr: index,
+      %input_ptr: index,
+      %n_rows: index // 64
+  ) attributes {grid = [32, 1]} {
+    %core_id = ktdp.get_compute_tile_id : index
+
+    %c32_i32 = arith.constant 32 : index
+    %c0_i32 = arith.constant 0 : index
+
+    %input_view = ktdp.construct_memory_view %input_ptr, sizes: [64, 64], strides: [64, 1] {
+      coordinate_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 63 >= 0, d1 >= 0, -d1 + 63 >= 0)>, memory_space = #ktdp.spyre_memory_space<HBM>
+    } : memref<64x64xf16>
+
+    %output_view = ktdp.construct_memory_view %output_ptr, sizes: [64, 64], strides: [64, 1] {
+      coordinate_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 63 >= 0, d1 >= 0, -d1 + 63 >= 0)>, memory_space = #ktdp.spyre_memory_space<HBM>
+    } : memref<64x64xf16>
+
+    scf.for %row = %core_id to %n_rows step %c32_i32 : index {
+
+      %input_acc = ktdp.construct_access_tile %input_view[%row, %c0_i32] {
+        access_tile_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 0 >= 0, d1 >= 0, -d1 + 63 >= 0)>,
+        access_tile_order = affine_map<(d0, d1) -> (d0, d1)>
+      } : memref<64x64xf16> -> !ktdp.access_tile<1x64xindex>
+
+      %input_row = ktdp.load %input_acc : !ktdp.access_tile<1x64xindex> -> tensor<1x64xf16>
+
+      %neg_inf = arith.constant 0xFF80 : f16
+      %max_init = tensor.splat %neg_inf : tensor<1xf16>
+      %reduce_max = linalg.reduce
+        ins(%input_row : tensor<1x64xf16>)
+        outs(%max_init : tensor<1xf16>)
+        dimensions = [1]
+        (%in: f16, %out: f16) {
+          %m = arith.maximumf %in, %out : f16
+          linalg.yield %m : f16
+        }
+
+      %c0 = arith.constant 0 : index
+      %max_scalar = tensor.extract %reduce_max[%c0] : tensor<1xf16>
+      %max_row = tensor.splat %max_scalar : tensor<1x64xf16>
+
+      %input_minus_max = arith.subf %input_row, %max_row : tensor<1x64xf16>
+
+      %numerator = math.exp %input_minus_max : tensor<1x64xf16>
+
+      %zero = arith.constant 0.0 : f16
+      %sum_init = tensor.splat %zero : tensor<1xf16>
+      %reduce_add = linalg.reduce
+        ins(%numerator : tensor<1x64xf16>)
+        outs(%sum_init : tensor<1xf16>)
+        dimensions = [1]
+        (%in2: f16, %out2: f16) {
+          %s = arith.addf %in2, %out2 : f16
+          linalg.yield %s : f16
+        }
+
+      %denom_scalar = tensor.extract %reduce_add[%c0] : tensor<1xf16>
+      %denominator_row = tensor.splat %denom_scalar : tensor<1x64xf16>
+
+      %softmax_output = arith.divf %numerator, %denominator_row : tensor<1x64xf16>
+
+      %output_acc = ktdp.construct_access_tile %output_view[%row, %c0_i32] {
+          access_tile_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 0 >= 0, d1 >= 0, -d1 + 63 >= 0)>,
+          access_tile_order = affine_map<(d0, d1) -> (d0, d1)>
+      } : memref<64x64xf16> -> !ktdp.access_tile<1x64xindex>
+
+      ktdp.store %softmax_output, %output_acc : tensor<1x64xf16>, !ktdp.access_tile<1x64xindex>
+
+      scf.yield
+    }
+    return
+  }
+}

--- a/ktir_cpu/dialects/linalg_ops.py
+++ b/ktir_cpu/dialects/linalg_ops.py
@@ -26,63 +26,191 @@ from ..parser_utils import find_ssa_names, parse_attr_list
 from .registry import register, register_parser
 
 
-@register("linalg.reduce", latency_category=LC.COMPUTE_REDUCE)
+def _resolve_region_body(op):
+    """Resolve a linalg op's region into ``(bb0_names, body_ops)``.
+
+    Shared by ``linalg.generic`` and ``linalg.reduce`` so both capture block
+    arguments uniformly, whether the source wrote an explicit ``^bb0`` label
+    or used inline block args / shorthand.  Block-argument names are found in
+    priority order:
+
+      1. a synthetic ``region.bb0_args`` op (from the ``^bb0(...)`` parser);
+      2. an ``op.attributes["bb0_names"]`` list (mlir_frontend path);
+      3. the operand names of the region's first non-yield op — this is the
+         ``linalg.reduce`` explicit form ``(%in, %out) { %s = addf %in, %out }``,
+         where the block args appear only as the combiner's operands.
+
+    Returns ``([], [])`` when the op has no region (e.g. reduce shorthand);
+    callers synthesize a region in that case.
+    """
+    region = op.regions[0] if op.regions else []
+    body_ops = [o for o in region if o.op_type != "region.bb0_args"]
+
+    bb0_op = next((o for o in region if o.op_type == "region.bb0_args"), None)
+    if bb0_op is not None:
+        return bb0_op.attributes.get("names", []), body_ops
+    if "bb0_names" in op.attributes:
+        return op.attributes["bb0_names"], body_ops
+    if body_ops:
+        # Inline-block form: block args are the first body op's operands.
+        return list(body_ops[0].operands), body_ops
+    return [], []
+
+
+def _run_combiner(bb0_names, body_ops, lhs, rhs, context, env):
+    """Run the combiner region once on two equal-shaped operands.
+
+    Binds the block args to ``lhs``/``rhs`` (Tiles or scalars) in an isolated
+    scope and dispatches the region via ``execute_region`` — so each combiner
+    op fires through ``record_op`` and is charged latency under its own
+    category.  Returns the yielded value.
+    """
+    from ..ops.control_ops import _YieldResult
+
+    context.push_scope()
+    try:
+        if bb0_names:
+            context.set_value(bb0_names[0], lhs)
+        if len(bb0_names) > 1:
+            context.set_value(bb0_names[1], rhs)
+        result = env.execute_region(context, body_ops)
+    finally:
+        context.pop_scope()
+
+    if isinstance(result, _YieldResult):
+        return result.values[0]
+    return result
+
+
+def _tree_fold(tile, dim, bb0_names, body_ops, context, env):
+    """Reduce ``tile`` along ``dim`` by folding the combiner region pairwise.
+
+    MLIR legalizes ``linalg.reduce`` only for an **associative** combiner, so
+    the fold order is free to choose.  We fold pairwise (tree reduction): split
+    the reduced axis in half, combine the two halves with one *vectorised*
+    region call, and repeat.  This needs ``ceil(log2(N))`` region executions
+    instead of ``N`` sequential steps — each call combines whole sub-arrays in
+    a single op, so a 1×262144 reduce is ~18 vectorised passes, not 262k scalar
+    folds.  Odd lengths carry the unpaired slice forward to the next round.
+
+    The value *and* the latency both come from these region calls — there is no
+    NumPy reduction shortcut and no mapping from combiner name to a NumPy op;
+    whatever ops the region contains are executed and charged as-is.
+    """
+    data = tile.data
+
+    # Reduce to scalar (no dim) → flatten everything onto one axis first.
+    if dim is None:
+        data = data.reshape(-1)
+        dim = 0
+    n = data.shape[dim]
+
+    def slice_along(arr, lo, hi):
+        idx = [slice(None)] * arr.ndim
+        idx[dim] = slice(lo, hi)
+        return arr[tuple(idx)]
+
+    # Current accumulator is the full tile; collapse `dim` from n → 1 pairwise.
+    acc = data
+    while n > 1:
+        half = n // 2
+        left = slice_along(acc, 0, half)
+        right = slice_along(acc, half, 2 * half)
+        combined = _run_combiner(
+            bb0_names, body_ops,
+            Tile(left.copy(), tile.dtype, left.shape),
+            Tile(right.copy(), tile.dtype, right.shape),
+            context, env,
+        )
+        combined = combined.data if isinstance(combined, Tile) else np.asarray(combined)
+        if n % 2:  # odd: carry the leftover slice into the next round
+            tail = slice_along(acc, 2 * half, n)
+            combined = np.concatenate([combined, tail], axis=dim)
+        acc = combined
+        n = acc.shape[dim]
+
+    return acc  # extent 1 along `dim`
+
+
+@register("linalg.reduce", latency_category=LC.ZERO)
 def linalg__reduce(op, context, env):
-    """Standard linalg.reduce — removes the reduced dimension."""
+    """Standard linalg.reduce — removes the reduced dimension.
+
+    Like ``linalg.generic``, ``linalg.reduce`` is a zero-cost orchestrator: the
+    cost belongs to the ops in its combiner *region*, not to the reduce op
+    itself.  Rather than mapping the combiner to a hardcoded NumPy reduction
+    (which only covers the handful of combiners we anticipated), we **execute
+    the region** to compute the result — so the data value and the latency both
+    come from the real combiner ops, whatever they are.
+
+    Both surface forms feed the same region path:
+
+      * explicit form — use the region as parsed, capturing bb0 args via
+        :func:`_resolve_region_body`;
+      * shorthand form (``linalg.reduce { arith.addf }``) — *build* a one-op
+        region from the named combiner so it goes through the identical path.
+        (We read the combiner *name* to construct the op — that is the
+        shorthand syntax itself, not a semantic interpretation of it.)
+
+    The reduction is computed by a pairwise tree fold of the combiner region
+    (:func:`_tree_fold`); this relies on the combiner being associative, which
+    MLIR's ``linalg.reduce`` legalization already requires.
+    """
     # operands[0] is the ins tensor; the outs tensor is handled separately via outs_var
     tile = context.get_value(op.operands[0])
-    # Resolve the combiner op name.  The shorthand form stores it in
-    # attributes; the explicit-region form has it in op.regions.
+
+    # --- Resolve the combiner region (capturing bb0 args) ------------------
+    bb0_names, body_ops = _resolve_region_body(op)
+
+    # Combiner op name: explicit form has it as the region's first op;
+    # shorthand form stores it in the reduce_fn attribute.
     reduce_fn = op.attributes.get("reduce_fn")
-    if reduce_fn is None and op.regions:
-        for region_op in op.regions[0]:
-            if region_op.op_type != "linalg.yield":
-                reduce_fn = region_op.op_type
-                break
+    if reduce_fn is None and body_ops:
+        reduce_fn = next(
+            (o.op_type for o in body_ops if o.op_type != "linalg.yield"), None
+        )
     if reduce_fn is None:
         reduce_fn = "arith.addf"
-    # axis to reduce along; None means reduce all elements to a scalar
-    dim = op.attributes.get("dim")
 
-    # Map MLIR combiner names to NumPy reduction functions
-    np_reduce = {
-        "arith.addf": np.sum,
-        "arith.maxf": np.max,
-        "arith.maxnumf": np.fmax.reduce,
-        "arith.maximumf": np.maximum.reduce,
-        "arith.minf": np.min,
-        "arith.minimumf": np.minimum.reduce,
-        "arith.minnumf": np.fmin.reduce,
-        "arith.mulf": np.prod,
-    }.get(reduce_fn)
+    # Shorthand has no region — build one so it goes through the same fold.
+    # The synthesized block mirrors the explicit form:
+    #   (%in, %out) { %s = <reduce_fn> %in, %out; linalg.yield %s }
+    if not body_ops:
+        bb0_names = ["__reduce_in__", "__reduce_acc__"]
+        body_ops = [
+            Operation(
+                result="__reduce_combined__",
+                op_type=reduce_fn,
+                operands=bb0_names,
+                attributes={},
+                result_type="unknown",
+            ),
+            Operation(
+                result=None, op_type="linalg.yield",
+                operands=["__reduce_combined__"], attributes={},
+                result_type=None,
+            ),
+        ]
 
-    if np_reduce is None:
-        raise ValueError(f"Unknown linalg.reduce combiner: {reduce_fn}")
+    dim = op.attributes.get("dim")  # axis to reduce; None → collapse all
 
     if isinstance(tile, Tile):
-        if dim is not None:
-            # Reduce along the specified axis; promote to f32 to avoid overflow
-            reduced = np_reduce(tile.data.astype(np.float32), axis=dim, keepdims=False)
-            # Cast back to the original element dtype
-            reduced = reduced.astype(tile.data.dtype)
+        folded = _tree_fold(tile, dim, bb0_names, body_ops, context, env)
+        if dim is None:
+            result = folded.reshape(()).astype(tile.data.dtype).item()
+        else:
+            reduced = np.squeeze(folded, axis=dim).astype(tile.data.dtype)
             if reduced.ndim == 0:
-                # Fully reduced to a Python scalar
                 result = reduced.item()
             else:
-                # Partial reduction — wrap remaining dimensions back into a Tile
                 result = Tile(reduced, tile.dtype, reduced.shape)
-        else:
-            # No dim specified — collapse everything to a scalar
-            result = np_reduce(tile.data).astype(tile.data.dtype)
     else:
-        # Already a scalar, nothing to reduce
+        # Already a scalar, nothing to reduce.
         result = tile
 
     # In MLIR linalg semantics the result is written back into the outs buffer,
     # so downstream ops may reference it by the outs SSA name rather than the
     # result name. Bind both so either reference resolves correctly.
-    # Note: this is a pure context-dict write — no latency is charged here;
-    # the cost was already recorded by the dispatcher when the handler ran.
     outs_var = op.attributes.get("outs_var")
     if outs_var and result is not None:
         context.set_value(outs_var, result)
@@ -189,18 +317,10 @@ def linalg__generic(op, context, env):
     ins_vals = [context.get_value(op.operands[i]) for i in range(n_ins)]
     outs_val = context.get_value(op.operands[n_ins])
 
-    region = op.regions[0] if op.regions else []
-
-    # Resolve bb0 block-argument names.
-    # Path 1: synthetic region.bb0_args op prepended to the region (from ^bb0 parser).
-    # Path 2: names stored directly in op.attributes["bb0_names"].
-    bb0_op = next((o for o in region if o.op_type == "region.bb0_args"), None)
-    body_ops = [o for o in region if o.op_type != "region.bb0_args"]
-    if bb0_op is not None:
-        bb0_names = bb0_op.attributes.get("names", [])
-    elif "bb0_names" in op.attributes:
-        bb0_names = op.attributes["bb0_names"]
-    else:
+    # Resolve bb0 block-argument names and body via the shared helper
+    # (also used by linalg.reduce).
+    bb0_names, body_ops = _resolve_region_body(op)
+    if not bb0_names:
         raise ValueError("linalg.generic: cannot determine bb0 argument names")
 
     if not isinstance(outs_val, Tile):

--- a/ktir_cpu/dialects/linalg_ops.py
+++ b/ktir_cpu/dialects/linalg_ops.py
@@ -26,7 +26,7 @@ from ..parser_utils import find_ssa_names, parse_attr_list
 from .registry import register, register_parser
 
 
-@register("linalg.reduce", latency_category=LC.COMPUTE_FLOAT)
+@register("linalg.reduce", latency_category=LC.COMPUTE_REDUCE)
 def linalg__reduce(op, context, env):
     """Standard linalg.reduce — removes the reduced dimension."""
     # operands[0] is the ins tensor; the outs tensor is handled separately via outs_var

--- a/ktir_cpu/dialects/linalg_ops.py
+++ b/ktir_cpu/dialects/linalg_ops.py
@@ -152,6 +152,27 @@ def linalg__matmul(op, context, env):
     return result
 
 
+@register("linalg.batch_matmul", latency_category=LC.COMPUTE_MATMUL)
+def linalg__batch_matmul(op, context, env):
+    """Execute linalg.batch_matmul: result = outs + ins[0] @ ins[1] (batched).
+
+    MLIR linalg.batch_matmul syntax:
+        %result = linalg.batch_matmul
+                    ins(%A, %B : tensor<BxMxKxf32>, tensor<BxKxNxf32>)
+                    outs(%C    : tensor<BxMxNxf32>) -> tensor<BxMxNxf32>
+
+    Operands = [%A, %B, %C] (fallback parser order).
+    """
+    tile_a = context.get_value(op.operands[0])  # ins[0] = A  (B×M×K)
+    tile_b = context.get_value(op.operands[1])  # ins[1] = B  (B×K×N)
+    result = Tile(tile_a.data @ tile_b.data, tile_a.dtype, (tile_a.data @ tile_b.data).shape)
+    if len(op.operands) > 2:
+        acc = context.get_value(op.operands[2])
+        if isinstance(acc, Tile):
+            result = Tile(acc.data + result.data, acc.dtype, acc.shape)
+    return result
+
+
 @register("linalg.generic", latency_category=LC.COMPUTE_FLOAT)
 def linalg__generic(op, context, env):
     """Vectorised linalg.generic executor.

--- a/ktir_cpu/latency.py
+++ b/ktir_cpu/latency.py
@@ -45,6 +45,7 @@ class LatencyCategory(StrEnum):
     COMPUTE_TRANSCENDENTAL = "compute_transcendental"
     COMPUTE_INT = "compute_int"
     COMPUTE_MATMUL = "compute_matmul"
+    COMPUTE_REDUCE = "compute_reduce"
     COMM = "comm"
 
 
@@ -216,6 +217,14 @@ class LatencyTracker:
             flops = 2.0 * m * n * k
             cycles = flops / self.config.systolic_flops_per_cycle
             return ("compute", cycles, flops, 0)
+
+        if category == LC.COMPUTE_REDUCE:
+            # Reduction: the combiner (addf, maxf, …) processes every input
+            # element once.  Cost = input_elements / simd_width.
+            # operands[0] is the input tile.
+            n_elems = self._num_elements(operands[0] if operands else result, [])
+            cycles = n_elems / self.config.simd_elements_per_cycle
+            return ("compute", cycles, float(n_elems), 0)
 
         if category == LC.COMPUTE_TRANSCENDENTAL:
             # Transcendentals (exp, log, …): 1 FLOP per element, same

--- a/ktir_cpu/latency.py
+++ b/ktir_cpu/latency.py
@@ -45,7 +45,6 @@ class LatencyCategory(StrEnum):
     COMPUTE_TRANSCENDENTAL = "compute_transcendental"
     COMPUTE_INT = "compute_int"
     COMPUTE_MATMUL = "compute_matmul"
-    COMPUTE_REDUCE = "compute_reduce"
     COMM = "comm"
 
 
@@ -217,14 +216,6 @@ class LatencyTracker:
             flops = 2.0 * m * n * k
             cycles = flops / self.config.systolic_flops_per_cycle
             return ("compute", cycles, flops, 0)
-
-        if category == LC.COMPUTE_REDUCE:
-            # Reduction: the combiner (addf, maxf, …) processes every input
-            # element once.  Cost = input_elements / simd_width.
-            # operands[0] is the input tile.
-            n_elems = self._num_elements(operands[0] if operands else result, [])
-            cycles = n_elems / self.config.simd_elements_per_cycle
-            return ("compute", cycles, float(n_elems), 0)
 
         if category == LC.COMPUTE_TRANSCENDENTAL:
             # Transcendentals (exp, log, …): 1 FLOP per element, same

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -173,6 +173,29 @@ EXAMPLE_PARAMS: dict[str, list[dict]] = {
             "execute_kwargs": {},
         },
     ],
+    "reduce_multiop": [
+        {
+            "path": "ktir/reduce_multiop.mlir",
+            # linalg.reduce with a MULTI-OP combiner region (max via cmpf+select).
+            # Exercises the general tree fold: every region op runs and is
+            # charged, with no single-combiner-name assumption.
+            "execute_kwargs": {},
+        },
+    ],
+    "softmax_kernel_small_explicit": [
+        {
+            "path": "latency/softmax_small_explicit.mlir",
+            # softmax_small with the linalg.reduce combiners written as explicit
+            # (%in, %out){ ... yield } regions instead of the { op } shorthand.
+            "execute_kwargs": {
+                "input_row_stride": 64,
+                "output_row_stride": 64,
+                "n_rows": 64,
+                "BLOCK_SIZE": 64,
+                "n_cols": None,
+            },
+        },
+    ],
     "sdpa_kernel_2d": [
         {
             "path": "triton-ktir/sdpa_2d.mlir",

--- a/tests/test_dialects_exec.py
+++ b/tests/test_dialects_exec.py
@@ -59,12 +59,19 @@ def _make_env(grid_shape=(1, 1, 1)):
     grid = GridExecutor(grid_shape=grid_shape, memory=memory)
 
     def execute_region(context, ops):
+        # Mirror the real ExecutionEnv contract (interpreter._execute_op):
+        # dispatch each Operation through its registered handler.
         result = None
         for op in ops:
-            result = op(context)
+            handler = dispatch(op.op_type)
+            assert handler is not None, f"No handler for {op.op_type!r}"
+            result = handler(op, context, env)
+            if op.result and result is not None:
+                context.set_value(op.result, result)
         return result
 
-    return ExecutionEnv(grid_executor=grid, execute_region=execute_region)
+    env = ExecutionEnv(grid_executor=grid, execute_region=execute_region)
+    return env
 
 
 def _call(op_type, context, env, **op_kwargs):
@@ -838,6 +845,44 @@ class TestLinalg:
         result = _call("linalg.reduce", ctx, _make_env(),
                        operands=["%x"], attributes={"reduce_fn": "arith.addf"})
         assert float(result) == pytest.approx(5.0, rel=1e-2)
+
+    def test_reduce_explicit_region_single_op(self):
+        # Explicit combiner region (%in, %out){ %s = addf %in,%out; yield %s }
+        # computes the same sum as the shorthand form via the tree fold.
+        data = np.array([[1, 2, 3, 4]], dtype=np.float16)
+        ctx = _ctx_with(**{"%x": Tile(data, "f16", data.shape),
+                           "%init": Tile(np.zeros((1,), dtype=np.float16), "f16", (1,))})
+        region = [
+            _op("arith.addf", operands=["%in", "%out"], result="%s"),
+            _op("linalg.yield", operands=["%s"]),
+        ]
+        result = _call("linalg.reduce", ctx, _make_env(),
+                       operands=["%x"],
+                       attributes={"reduce_fn": None, "dim": 1, "outs_var": "%init"},
+                       regions=[region])
+        val = float(result.data.flat[0]) if isinstance(result, Tile) else float(result)
+        assert abs(val - 10.0) < 0.1
+
+    def test_reduce_multiop_combiner(self):
+        # MULTI-OP combiner: max expressed as cmpf(ogt) + select. The general
+        # tree fold must run BOTH region ops — there is no single combiner name
+        # to map to a NumPy reduction — and still return the correct max.
+        data = np.array([[0.1, 0.9, 0.3, 0.2, 0.5, 0.05, 0.7, 0.05]], dtype=np.float16)
+        neg_inf = np.float16("-inf")
+        ctx = _ctx_with(**{"%x": Tile(data, "f16", data.shape),
+                           "%init": Tile(np.full((1,), neg_inf, dtype=np.float16), "f16", (1,))})
+        region = [
+            _op("arith.cmpf", operands=["%in", "%out"], result="%cmp",
+                attributes={"predicate": "ogt"}),
+            _op("arith.select", operands=["%cmp", "%in", "%out"], result="%m"),
+            _op("linalg.yield", operands=["%m"]),
+        ]
+        result = _call("linalg.reduce", ctx, _make_env(),
+                       operands=["%x"],
+                       attributes={"reduce_fn": None, "dim": 1, "outs_var": "%init"},
+                       regions=[region])
+        val = float(result.data.flat[0]) if isinstance(result, Tile) else float(result)
+        assert val == pytest.approx(float(data.max()), abs=1e-2)
 
     def test_fill(self):
         # fill a tile with a scalar value

--- a/tests/test_dialects_exec.py
+++ b/tests/test_dialects_exec.py
@@ -884,6 +884,40 @@ class TestLinalg:
         val = float(result.data.flat[0]) if isinstance(result, Tile) else float(result)
         assert val == pytest.approx(float(data.max()), abs=1e-2)
 
+    @pytest.mark.xfail(reason="multi-axis reduce not supported: parser keeps only "
+                              "dims[0] and the tree fold indexes a single axis. "
+                              "Tracked in issue #85.",
+                       strict=True)
+    def test_reduce_multi_axis(self):
+        # dimensions = [0, 1] should reduce BOTH axes (2x3 -> scalar 15).
+        data = np.arange(6, dtype=np.float16).reshape(2, 3)  # sum = 15
+        ctx = _ctx_with(**{"%x": Tile(data, "f16", data.shape),
+                           "%init": Tile(np.zeros((1,), dtype=np.float16), "f16", (1,))})
+        result = _call("linalg.reduce", ctx, _make_env(),
+                       operands=["%x"],
+                       attributes={"reduce_fn": "arith.addf", "dim": [0, 1],
+                                   "outs_var": "%init"})
+        val = float(result.data.flat[0]) if isinstance(result, Tile) else float(result)
+        assert val == pytest.approx(15.0, abs=1e-2)
+
+    @pytest.mark.xfail(reason="outs init value is not folded into the reduction; "
+                              "the tree fold seeds from the input only. Harmless "
+                              "while the frontend inits outs to the identity. "
+                              "Tracked in issue #85.",
+                       strict=True)
+    def test_reduce_folds_outs_init(self):
+        # MLIR semantics: outs is the initial accumulator. sum([1,2,3,4]) with
+        # outs init = 100 should be 110, not 10.
+        data = np.array([[1, 2, 3, 4]], dtype=np.float16)
+        ctx = _ctx_with(**{"%x": Tile(data, "f16", data.shape),
+                           "%init": Tile(np.array([100.0], dtype=np.float16), "f16", (1,))})
+        result = _call("linalg.reduce", ctx, _make_env(),
+                       operands=["%x"],
+                       attributes={"reduce_fn": "arith.addf", "dim": 1,
+                                   "outs_var": "%init"})
+        val = float(result.data.flat[0]) if isinstance(result, Tile) else float(result)
+        assert val == pytest.approx(110.0, abs=1e-1)
+
     def test_fill(self):
         # fill a tile with a scalar value
         out = Tile(np.zeros((4,), dtype=np.float16), "f16", (4,))

--- a/tests/test_latency.py
+++ b/tests/test_latency.py
@@ -92,6 +92,31 @@ def _run_matmul(path, func_name, entry, cfg, trace=False):
     return interp.get_latency_report()
 
 
+def _run_vector_reduce(path, func_name, entry, cfg, trace=False):
+    """Run a vector reduce (per-core tile) and return report."""
+    interp = KTIRInterpreter(latency_config=cfg, trace_latency=trace)
+    interp.load(path)
+    # Build tensor args using the interpreter's declared arg names so we
+    # match the parser's normalization (arg0, arg1, ...).
+    arg_names = interp.arg_names(func_name)
+    sizes = interp.tensor_input_output_sizes(func_name)
+
+    # Use the first argument as the input tensor for the reduce example.
+    arg0 = arg_names[0]
+    shape = sizes[arg0]["shape"]
+    # shape may be a tuple like (1, 4)
+    rng = np.random.default_rng(42)
+    inp = rng.standard_normal(tuple(shape)).astype(np.float16)
+
+    scalars = {k: v for k, v in entry["execute_kwargs"].items() if v is not None}
+    overlap = set(scalars.keys()) & {arg0}
+    assert not overlap, f"duplicate keys in tensors and scalars: {overlap}"
+
+    kwargs = {**scalars, **{arg0: inp}}
+    interp.execute_function(func_name, **kwargs)
+    return interp.get_latency_report()
+
+
 # ---------------------------------------------------------------------------
 # Vector add latency — memory-dominated
 # ---------------------------------------------------------------------------
@@ -231,6 +256,14 @@ class TestRoofline:
         # AI should be well below the ridge point (memory-bound)
         assert rf["arithmetic_intensity"] < rf["ridge_point"]
 
+    @pytest.mark.parametrize("path,func_name,entry", get_test_params("reduce_explicit_region"))
+    def test_vector_reduce_is_memory_bound(self, path, func_name, entry):
+        """A simple vector reduce should be memory-bound on the roofline."""
+        report = _run_vector_reduce(path, func_name, entry, HardwareConfig())
+        rf = report.roofline()
+        assert "arithmetic_intensity" in rf
+        assert rf["arithmetic_intensity"] < rf["ridge_point"]
+
     @pytest.mark.parametrize("path,func_name,entry", get_test_params("add_kernel"))
     def test_roofline_in_report_str(self, path, func_name, entry):
         """Roofline section should appear in report __str__."""
@@ -361,6 +394,40 @@ class TestSoftmaxLatency:
 
         # exp cycles should scale linearly with penalty
         assert scaled_exp == pytest.approx(baseline_exp * penalty, rel=1e-3)
+
+
+# ---------------------------------------------------------------------------
+# Reduce latency
+# ---------------------------------------------------------------------------
+
+class TestReduceLatency:
+    @pytest.mark.parametrize("path,func_name,entry", get_test_params("softmax_kernel_small"))
+    def test_reduce_charges_input_element_cycles(self, path, func_name, entry):
+        """linalg.reduce charges cycles based on *input* element count
+        (combiner work), not the reduced output shape."""
+        cfg = HardwareConfig()
+        report = _run_softmax(path, func_name, entry, cfg, trace=True)
+        core0 = report.counters[0]
+
+        reduce_entries = [e for e in core0.trace if e.op_type == "linalg.reduce"]
+        assert len(reduce_entries) > 0, "expected at least one linalg.reduce in softmax"
+
+        # softmax_small reduces 1×64 tiles → 1 element.
+        # Cost = 64 input elements / 64 simd_elements_per_cycle = 1.0 cycle.
+        expected_cycles = 64 / cfg.simd_elements_per_cycle
+        for entry_e in reduce_entries:
+            assert entry_e.cycles == pytest.approx(expected_cycles), (
+                f"linalg.reduce should charge {expected_cycles} cycles "
+                f"(input_elems / simd_width), got {entry_e.cycles}"
+            )
+
+    @pytest.mark.parametrize("path,func_name,entry", get_test_params("reduce_explicit_region"))
+    def test_reduce_kernel_is_memory_bound(self, path, func_name, entry):
+        """Vector reduce per-core tile should be memory-dominated."""
+        report = _run_vector_reduce(path, func_name, entry, HardwareConfig())
+        core0 = report.counters[0]
+        assert report.bottleneck == "memory"
+        assert core0.memory_cycles > core0.compute_cycles
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_latency.py
+++ b/tests/test_latency.py
@@ -402,24 +402,60 @@ class TestSoftmaxLatency:
 
 class TestReduceLatency:
     @pytest.mark.parametrize("path,func_name,entry", get_test_params("softmax_kernel_small"))
-    def test_reduce_charges_input_element_cycles(self, path, func_name, entry):
-        """linalg.reduce charges cycles based on *input* element count
-        (combiner work), not the reduced output shape."""
+    def test_reduce_defers_cost_to_combiner(self, path, func_name, entry):
+        """linalg.reduce is a zero-cost orchestrator (like linalg.generic); the
+        reduction cost is charged to the combiner ops executed by the tree fold.
+        Folding N elements pairwise processes N/2 + N/4 + … = N-1 elements total,
+        so the combiner's *summed* cost scales with input size (~N/simd_width),
+        not the reduced output shape.  Holds for the shorthand form (softmax
+        uses ``linalg.reduce { arith.maximumf }`` and ``{ arith.addf }``)."""
         cfg = HardwareConfig()
         report = _run_softmax(path, func_name, entry, cfg, trace=True)
         core0 = report.counters[0]
 
+        # The orchestrator op itself charges nothing.
         reduce_entries = [e for e in core0.trace if e.op_type == "linalg.reduce"]
         assert len(reduce_entries) > 0, "expected at least one linalg.reduce in softmax"
-
-        # softmax_small reduces 1×64 tiles → 1 element.
-        # Cost = 64 input elements / 64 simd_elements_per_cycle = 1.0 cycle.
-        expected_cycles = 64 / cfg.simd_elements_per_cycle
-        for entry_e in reduce_entries:
-            assert entry_e.cycles == pytest.approx(expected_cycles), (
-                f"linalg.reduce should charge {expected_cycles} cycles "
-                f"(input_elems / simd_width), got {entry_e.cycles}"
+        for e in reduce_entries:
+            assert e.category == "zero" and e.cycles == 0.0, (
+                f"linalg.reduce must be zero-cost, got {e.category}/{e.cycles}"
             )
+
+        # Combiner ops carry the cost. Core 0 processes 2 rows; per row a max
+        # (arith.maximumf) and a sum (arith.addf) each fold a 1×64 tile → the
+        # tree fold processes 63 elements per reduce. Summed per op across both
+        # rows: 2 × 63 / simd_elements_per_cycle.
+        per_reduce = 63 / cfg.simd_elements_per_cycle  # N-1 for N=64
+        for combiner in ("arith.maximumf", "arith.addf"):
+            total = sum(e.cycles for e in core0.trace if e.op_type == combiner)
+            assert total == pytest.approx(2 * per_reduce), (
+                f"{combiner} should total {2 * per_reduce} cyc over 2 rows "
+                f"(tree fold of 1×64 → N-1 elems each); got {total}"
+            )
+
+    @pytest.mark.parametrize("path,func_name,entry", get_test_params("reduce_explicit_region"))
+    def test_reduce_explicit_region_charges_combiner(self, path, func_name, entry):
+        """Explicit-region form routes through the same tree-fold path: the
+        combiner op in the region (arith.addf) carries the cycles and
+        linalg.reduce itself is zero-cost."""
+        cfg = HardwareConfig()
+        report = _run_vector_reduce(path, func_name, entry, cfg, trace=True)
+        core0 = report.counters[0]
+
+        reduce_entries = [e for e in core0.trace if e.op_type == "linalg.reduce"]
+        assert reduce_entries and all(
+            e.category == "zero" and e.cycles == 0.0 for e in reduce_entries
+        ), "linalg.reduce must be zero-cost in the explicit-region form too"
+
+        # reduce_generic.mlir folds a 1×4 input tile with arith.addf. A pairwise
+        # tree fold of 4 elements processes 2 + 1 = 3 elements total →
+        # 3 / simd_elements_per_cycle cycles, charged to the combiner.
+        expected = 3 / cfg.simd_elements_per_cycle  # N-1 for N=4
+        total = sum(e.cycles for e in core0.trace if e.op_type == "arith.addf")
+        assert total == pytest.approx(expected), (
+            f"combiner arith.addf should total {expected} cyc "
+            f"(tree fold of 1×4 → N-1 elems); got {total}"
+        )
 
     @pytest.mark.parametrize("path,func_name,entry", get_test_params("reduce_explicit_region"))
     def test_reduce_kernel_is_memory_bound(self, path, func_name, entry):
@@ -428,6 +464,44 @@ class TestReduceLatency:
         core0 = report.counters[0]
         assert report.bottleneck == "memory"
         assert core0.memory_cycles > core0.compute_cycles
+
+    @pytest.mark.parametrize("path,func_name,entry",
+                             get_test_params("softmax_kernel_small_explicit"))
+    def test_explicit_region_softmax_matches_shorthand(self, path, func_name, entry):
+        """Softmax with explicit (%in,%out){...} combiner regions charges the
+        same combiner cost as the shorthand softmax — proving both forms feed
+        the identical tree-fold path. linalg.reduce stays zero-cost."""
+        cfg = HardwareConfig()
+        report = _run_softmax(path, func_name, entry, cfg, trace=True)
+        core0 = report.counters[0]
+
+        assert all(e.cycles == 0.0 for e in core0.trace if e.op_type == "linalg.reduce")
+        per_reduce = 63 / cfg.simd_elements_per_cycle  # N-1 for N=64
+        for combiner in ("arith.maximumf", "arith.addf"):
+            total = sum(e.cycles for e in core0.trace if e.op_type == combiner)
+            assert total == pytest.approx(2 * per_reduce), (
+                f"{combiner} should total {2 * per_reduce} cyc (explicit-region "
+                f"softmax, 2 rows of 1×64 tree fold); got {total}"
+            )
+
+    @pytest.mark.parametrize("path,func_name,entry", get_test_params("reduce_multiop"))
+    def test_multiop_combiner_charges_all_region_ops(self, path, func_name, entry):
+        """A multi-op combiner (max via cmpf+select) charges EVERY op in the
+        region — there is no single-combiner-name shortcut. Both arith.cmpf and
+        arith.select carry the tree-fold cost; linalg.reduce is zero."""
+        cfg = HardwareConfig()
+        report = _run_vector_reduce(path, func_name, entry, cfg, trace=True)
+        core0 = report.counters[0]
+
+        assert all(e.cycles == 0.0 for e in core0.trace if e.op_type == "linalg.reduce")
+        # 1×8 tree fold → 7 elements processed; each region op charged 7/simd.
+        expected = 7 / cfg.simd_elements_per_cycle  # N-1 for N=8
+        for region_op in ("arith.cmpf", "arith.select"):
+            total = sum(e.cycles for e in core0.trace if e.op_type == region_op)
+            assert total == pytest.approx(expected), (
+                f"{region_op} should total {expected} cyc (1×8 tree fold); "
+                f"got {total}"
+            )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Op notes on the first PR: 

1. Mostly claude directly to address issue #76 . 
2. Went through a mindful learning process with Bob-the-AI over the repo, test, with goal to build some fidelity of the vide'd test serves the purpose. 
3. Added tests with vector_reduce and vector_reduce for roofline, with the reduce mlir code under examples. 
4. Added a latency category: COMPUTE_REDUCE for 2 reasons:
   1.  REDUCE op can be non float strictly speaking (e.g. max). 
   2. Latency_of_reduce ~ O( size_of_inputs_to_reduce ),. slightly different from the existing ones for COMPUTE_FLOAT, which uses latency ~ O( size_inputs + size_outputs ). Yet the former estimation is specified in issue 76. 