### PR TITLE
fix: close executor↔frontend op coverage gaps + add guard test

### DIFF
--- a/ktir_cpu/dialects/_helpers.py
+++ b/ktir_cpu/dialects/_helpers.py
@@ -24,6 +24,7 @@ _is_scalar(v)                  — True if v is a numeric scalar (not Tile)
 _float_binop(op, context, fn)  — fetch two operands, dispatch float binop
 _int_binop(op, context, fn)    — fetch two operands, dispatch int binop
 _unary(op, context, tile_fn, scalar_fn) — fetch one operand, dispatch unary
+unwrap_yield(result)           — unwrap a _YieldResult sentinel; pass through anything else
 """
 
 import numpy as np
@@ -80,3 +81,22 @@ def _unary(op, context, tile_fn, scalar_fn=None):
     if isinstance(val, Tile):
         return tile_fn(val)
     return (scalar_fn or tile_fn)(val)
+
+
+def unwrap_yield(result):
+    """Unwrap a _YieldResult sentinel produced by scf.yield / linalg.yield.
+
+    Dialect region drivers (scf.if, scf.for, linalg.generic) call this on
+    the value returned by execute_region so they always receive plain values.
+    Returns the single value for a 1-element yield, a tuple for multi-value,
+    None for an empty yield, or *result* unchanged if it is not a _YieldResult.
+    """
+    from ..ops.control_ops import _YieldResult
+    if not isinstance(result, _YieldResult):
+        return result
+    values = result.values
+    if not values:
+        return None
+    if len(values) == 1:
+        return values[0]
+    return tuple(values)

--- a/ktir_cpu/dialects/linalg_ops.py
+++ b/ktir_cpu/dialects/linalg_ops.py
@@ -23,6 +23,7 @@ from ..latency import LatencyCategory as LC
 from ..ops.arith_ops import ArithOps
 from ..parser_ast import parse_affine_map
 from ..parser_utils import find_ssa_names, parse_attr_list
+from ._helpers import unwrap_yield
 from .registry import register, register_parser
 
 
@@ -181,8 +182,6 @@ def linalg__generic(op, context, env):
     (np.expand_dims for missing dims), binds bb0 block-arg names, then
     executes the region body once with full arrays.
     """
-    from ..ops.control_ops import _YieldResult
-
     n_ins = op.attributes.get("n_ins", 0)
     indexing_maps = op.attributes.get("indexing_maps", [])
 
@@ -237,10 +236,7 @@ def linalg__generic(op, context, env):
     result = env.execute_region(context, body_ops)
     context.pop_scope()
 
-    if isinstance(result, _YieldResult):
-        out_data = result.values[0]
-    else:
-        out_data = result
+    out_data = unwrap_yield(result)
 
     if isinstance(out_data, Tile):
         data = np.broadcast_to(out_data.data, out_shape).copy().astype(out_np_dtype)
@@ -261,9 +257,9 @@ def linalg__index(op, context, env):
 
 @register("linalg.yield")
 def linalg__yield(op, context, env):
-    from ..ops.control_ops import _YieldResult
+    from ..ops.control_ops import ControlOps
     values = [context.get_value(n) for n in op.operands]
-    return _YieldResult(values)
+    return ControlOps.yield_op(values)
 
 
 @register("linalg.transpose")

--- a/ktir_cpu/mlir_frontend/parser.py
+++ b/ktir_cpu/mlir_frontend/parser.py
@@ -158,8 +158,10 @@ MLIRTypeAdapter.install(
     "func.return",
     "linalg.fill",
     "linalg.matmul",
+    "linalg.batch_matmul",
     "linalg.yield",
     "scf.yield",
+    "scf.if",
     # float binary
     "arith.addf", "arith.subf", "arith.mulf", "arith.divf", "arith.remf",
     # float unary
@@ -183,6 +185,8 @@ MLIRTypeAdapter.install(
     "arith.extf", "arith.truncf",
     "arith.extsi", "arith.extui", "arith.trunci",
     "arith.index_cast",
+    "arith.index_castui",
+    "arith.ceildivui",
     "arith.maxnumf",
     "arith.maximumf",
     "arith.minimumf",

--- a/ktir_cpu/ops/control_ops.py
+++ b/ktir_cpu/ops/control_ops.py
@@ -70,7 +70,8 @@ class ControlOps:
         context.push_scope()
         result = region_executor(context, region)
         context.pop_scope()
-        return result
+        from ..dialects._helpers import unwrap_yield
+        return unwrap_yield(result)
 
     @staticmethod
     def for_op(

--- a/tests/mlir_frontend/test_parse_adapt.py
+++ b/tests/mlir_frontend/test_parse_adapt.py
@@ -111,6 +111,25 @@ class TestKtdpAdapt(MLIRFrontendParseTestMixin, _TestKtdpParsers):
 class TestScfAdapt(MLIRFrontendParseTestMixin, _TestScfParsers):
     """Scf tests via MLIRFrontendParser."""
 
+    def test_if_then_else(self):
+        # scf.if is supported by the MLIR frontend (the regex parser does not
+        # parse it, so this test is frontend-only rather than in the shared
+        # base class). operand[0] is the condition; then/else are regions
+        # [0]/[1]; no execution-relevant attributes.
+        op = self._parse(
+            "%r = scf.if %c -> (i32) {\n"
+            "      %a = arith.constant 1 : i32\n"
+            "      scf.yield %a : i32\n"
+            "    } else {\n"
+            "      %b = arith.constant 2 : i32\n"
+            "      scf.yield %b : i32\n"
+            "    }",
+            args={"%c": "i1"},
+        )
+        self.assert_op_type(op, "scf.if")
+        self.assert_num_operands(op, 1)
+        assert len(op.regions) == 2
+
 
 # ---------------------------------------------------------------------------
 # Math

--- a/tests/mlir_frontend/test_registry_consistency.py
+++ b/tests/mlir_frontend/test_registry_consistency.py
@@ -1,0 +1,101 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Guard test: every executor op must be reachable through the MLIR frontend.
+
+The regex parser tolerates new ops via a catch-all fallback
+(``_parse_general_operation``), so a freshly ``@register``'d executor op
+"just works" on that path with no parser change. The MLIR frontend has no
+fallback — ``MLIRTypeAdapter.adapt_op`` raises ``NotImplementedError`` for any
+op lacking an explicit ``@MLIRTypeAdapter.install`` handler.
+
+That asymmetry means an op can be added to the executor (with only a direct
+handler-level test) and silently break the frontend, undetected, because the
+frontend's coverage is derived from whichever regex test classes happen to be
+subclassed into the adapter suites. This has bitten us repeatedly
+(dynamic shapes, distributed views, ``linalg.batch_matmul``).
+
+This test makes the divergence fail loudly: any executor op that is neither
+frontend-installed nor explicitly listed below (with a reason) breaks the
+build the moment it is registered.
+"""
+
+import pytest
+
+import ktir_cpu.dialects  # noqa: F401 — triggers @register side effects
+from ktir_cpu.dialects import registry
+from ktir_cpu.mlir_frontend.parser import MLIRTypeAdapter
+
+
+# Executor ops intentionally NOT reachable through the MLIR frontend.
+# Every entry must carry a reason; remove an entry once its handler lands.
+FRONTEND_UNSUPPORTED = {
+    # Synthetic / non-IR ops — never appear in parsed MLIR text.
+    "region.bb0_args": "regex-only synthetic op; the frontend carries bb0 "
+                       "names on linalg.generic via the bb0_names attribute.",
+    "return": "alias of func.return for the bare-`return` regex form; the "
+              "bindings always emit func.return.",
+
+    # NON-SPEC ops: invented op names that only survive on the regex path
+    # (which validates against no dialect). They are NOT in the authoritative
+    # ktdp dialect (ktir-mlir-frontend KtdpOps.td) / upstream arith, so the
+    # MLIR frontend rightly rejects them. These are ktir-cpu conformance bugs
+    # to reconcile to the real op form or remove — NOT frontend gaps to fill.
+    "arith.convertf": "not a real upstream arith op — unknown to the MLIR "
+                      "parser; reconcile to a real cast op or remove.",
+    "ktdp.reduce": "non-spec op (not in the ktdp dialect). Reconcile to the "
+                   "real cross-core reduce form or remove. See issue #88.",
+    "ktdp.coreid": "non-spec op (not in the ktdp dialect). Reconcile to the "
+                   "real core-identity form or remove. See issue #88.",
+
+    # Real spec op missing only a frontend adapter handler (distinct from the
+    # non-spec ops above).
+    "ktdp.construct_distributed_memory_view": "real ktdp dialect op; no frontend "
+                   "adapter handler yet. Tracked in issue #87.",
+}
+
+
+def test_every_executor_op_is_frontend_reachable():
+    exec_ops = set(registry._REGISTRY)
+    frontend_ops = set(MLIRTypeAdapter._adapt_handlers)
+
+    missing = exec_ops - frontend_ops - set(FRONTEND_UNSUPPORTED)
+    assert not missing, (
+        "Executor ops with no MLIRTypeAdapter handler and not in "
+        "FRONTEND_UNSUPPORTED:\n  "
+        + "\n  ".join(sorted(missing))
+        + "\n\nEither add a @MLIRTypeAdapter.install handler in "
+        "ktir_cpu/mlir_frontend/parser.py, or add the op to "
+        "FRONTEND_UNSUPPORTED with a reason."
+    )
+
+
+def test_unsupported_allowlist_has_no_stale_entries():
+    # An op listed as unsupported must still be a real executor op, and must
+    # NOT have quietly gained a frontend handler (which would make the entry
+    # stale and misleading).
+    exec_ops = set(registry._REGISTRY)
+    frontend_ops = set(MLIRTypeAdapter._adapt_handlers)
+
+    not_registered = set(FRONTEND_UNSUPPORTED) - exec_ops
+    assert not not_registered, (
+        "FRONTEND_UNSUPPORTED lists ops that are not executor-registered "
+        f"(remove them): {sorted(not_registered)}"
+    )
+
+    now_supported = set(FRONTEND_UNSUPPORTED) & frontend_ops
+    assert not now_supported, (
+        "FRONTEND_UNSUPPORTED lists ops that now HAVE a frontend handler "
+        f"(remove them from the allowlist): {sorted(now_supported)}"
+    )

--- a/tests/test_dialects_exec.py
+++ b/tests/test_dialects_exec.py
@@ -1085,6 +1085,26 @@ class TestScfFunc:
         dispatch("scf.if")(op, ctx, env)
         assert ran == ["else"]
 
+    def test_if_then_else_yield_result(self):
+        # scf.if with a yielding then-branch returns the unwrapped value, not a _YieldResult wrapper
+        ctx = _ctx_with(**{"%cond": True, "%val": 42})
+        op = Operation(op_type="scf.if", operands=["%cond"], attributes={},
+                       result="%res", result_type=None,
+                       regions=[[Operation(op_type="scf.yield", operands=["%val"],
+                                           attributes={}, result=None, result_type=None)],
+                                 []])
+        env = _make_env()
+
+        def real_execute_region(ctx, ops):
+            result = None
+            for o in ops:
+                result = dispatch(o.op_type)(o, ctx, env)
+            return result
+
+        env.execute_region = real_execute_region
+        result = dispatch("scf.if")(op, ctx, env)
+        assert result == 42, f"expected 42, got {result!r}"
+
 # ---------------------------------------------------------------------------
 # ktdp dialect parsers
 # ---------------------------------------------------------------------------

--- a/tests/test_dialects_exec.py
+++ b/tests/test_dialects_exec.py
@@ -866,6 +866,17 @@ class TestLinalg:
         result = _call("linalg.matmul", ctx, _make_env(), operands=["%a", "%b"])
         assert np.allclose(result.data, b.data, rtol=1e-2)
 
+    def test_batch_matmul(self):
+        # batched identity: for each batch, I @ B == B
+        eye = np.broadcast_to(np.eye(2, dtype=np.float16), (3, 2, 2)).copy()
+        bdata = np.arange(3 * 2 * 2, dtype=np.float16).reshape(3, 2, 2)
+        a = Tile(eye, "f16", (3, 2, 2))
+        b = Tile(bdata, "f16", (3, 2, 2))
+        ctx = _ctx_with(**{"%a": a, "%b": b})
+        result = _call("linalg.batch_matmul", ctx, _make_env(), operands=["%a", "%b"])
+        assert result.shape == (3, 2, 2)
+        assert np.allclose(result.data, bdata, rtol=1e-2)
+
     def test_generic_reads_outs_arg(self):
         # linalg.generic where the body reads the outs bb0 arg.
         # outs is non-zero — the body adds the input to the existing outs value.

--- a/tests/test_dialects_parse.py
+++ b/tests/test_dialects_parse.py
@@ -313,6 +313,22 @@ class TestArithParsers(ParseTestMixin):
         self.assert_op_type(op, "arith.index_cast")
         self.assert_num_operands(op, 1)
 
+    def test_index_castui(self):
+        op = self._parse(
+            "%r = arith.index_castui %a : i32 to index",
+            args={"%a": "i32"},
+        )
+        self.assert_op_type(op, "arith.index_castui")
+        self.assert_num_operands(op, 1)
+
+    def test_ceildivui(self):
+        op = self._parse(
+            "%r = arith.ceildivui %a, %b : i32",
+            args={"%a": "i32", "%b": "i32"},
+        )
+        self.assert_op_type(op, "arith.ceildivui")
+        self.assert_num_operands(op, 2)
+
     def test_select(self):
         op = self._parse(
             "%r = arith.select %cond, %a, %b : i32",
@@ -440,6 +456,31 @@ class TestLinalgParsers(ParseTestMixin):
         self.assert_attribute(op, "dimensions", [1])
         self.assert_num_operands(op, 2)
         self.assert_operand_names(op, "%x", "%buf")
+
+    def test_matmul(self):
+        # matmul carries no attributes; operands are [A, B, C] (ins then outs)
+        op = self._parse(
+            "%r = linalg.matmul ins(%a, %b : tensor<4x8xf16>, tensor<8x16xf16>)"
+            " outs(%c : tensor<4x16xf16>) -> tensor<4x16xf16>",
+            args={"%a": "tensor<4x8xf16>", "%b": "tensor<8x16xf16>", "%c": "tensor<4x16xf16>"},
+        )
+        self.assert_op_type(op, "linalg.matmul")
+        self.assert_num_operands(op, 3)
+        self.assert_operand_names(op, "%a", "%b", "%c")
+
+    def test_batch_matmul(self):
+        # batch_matmul has the same operand structure as matmul: [A, B, C].
+        # Added in #81 on the executor side; this verifies both parser
+        # backends handle it (the MLIR frontend needs an installed handler).
+        op = self._parse(
+            "%r = linalg.batch_matmul"
+            " ins(%a, %b : tensor<2x4x8xf16>, tensor<2x8x16xf16>)"
+            " outs(%c : tensor<2x4x16xf16>) -> tensor<2x4x16xf16>",
+            args={"%a": "tensor<2x4x8xf16>", "%b": "tensor<2x8x16xf16>", "%c": "tensor<2x4x16xf16>"},
+        )
+        self.assert_op_type(op, "linalg.batch_matmul")
+        self.assert_num_operands(op, 3)
+        self.assert_operand_names(op, "%a", "%b", "%c")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Closes a class of bug where ops handled by the executor are silently unreachable through `MLIRFrontendParser`.

**Root cause:** the regex parser tolerates any `@register`'d executor op via its catch-all fallback (`_parse_general_operation`), but the MLIR frontend rejects any op lacking an explicit `@MLIRTypeAdapter.install` handler. Frontend test coverage is purely derived from which regex test classes are subclassed into the adapter suites — so an executor op plus a direct handler-level test passes CI while leaving the frontend broken (exactly what happened to `linalg.batch_matmul` in #81, and to dynamic shapes in #86).

## Changes

Install the missing frontend handlers and add tests on both parser paths:
- `linalg.batch_matmul` — regex parse, frontend parse, and exec tests (none existed)
- `arith.index_castui`, `arith.ceildivui` — portable parse tests
- `scf.if` — frontend handler + frontend-only test (the regex parser also silently drops `scf.if` — noted for follow-up)

**Guard test** — `tests/mlir_frontend/test_registry_consistency.py` asserts every executor op is either frontend-installed or explicitly allowlisted with a reason, so this whole class of divergence fails loudly going forward. The allowlist distinguishes:
- synthetic/alias ops (`region.bb0_args`, `return`)
- **non-spec ops** to reconcile or remove (`arith.convertf`, `ktdp.reduce`, `ktdp.coreid` — these are invented op names not in the authoritative `ktdp` dialect; see #88)
- **real spec ops** still missing a handler (`construct_distributed_memory_view` — see #87)

## Testing

`uv run pytest tests/mlir_frontend/ tests/test_dialects_parse.py tests/test_dialects_exec.py` → 372 passed, 7 skipped.

## Related

- Follows #86 (now merged)
- #87 — distributed memory view frontend handler + per-core LX memory space
- #88 — non-spec `ktdp.reduce` / `ktdp.coreid` to reconcile or remove

🤖 Generated with [Claude Code](https://claude.com/claude-code)