### PR TITLE
[Feature] Support tensor.reshape and dense list constants

### DIFF
--- a/ktir_cpu/dialects/arith_ops.py
+++ b/ktir_cpu/dialects/arith_ops.py
@@ -331,6 +331,10 @@ def arith__constant(op, context, env):
         shape = op.attributes["shape"]
         dtype_str = op.attributes.get("dtype", "f16")
         np_dtype = to_np_dtype(dtype_str)
+        # dense<[v0, v1, ...]> list form: each element is distinct, so
+        # build the array element-by-element rather than splatting one value.
+        if op.attributes.get("dense_list"):
+            return Tile(np.array(value, dtype=np_dtype).reshape(shape), dtype_str, shape)
         return Tile(np.full(shape, value, dtype=np_dtype), dtype_str, shape)
     return value
 
@@ -448,6 +452,27 @@ def arith__select(op, context, env):
 # Parsers
 # ---------------------------------------------------------------------------
 
+def _parse_dense_payload(payload, elem_dtype):
+    """Parse the inside of `dense<...>`.
+
+    Returns ``(value, is_list)``. Two forms appear in MLIR:
+
+    - splat:  ``dense<0.0>``         -> single scalar broadcast across the shape
+    - list:   ``dense<[16, 32]>``    -> one value per element
+
+    The list form shows up as the shape operand of folded ``tensor.reshape``
+    ops (e.g. ``dense<[16, 32]> : tensor<2xindex>``); the splat form covers
+    plain zero-/constant-init tensors.
+    """
+    from ..parser_utils import parse_numeric
+
+    payload = payload.strip()
+    if payload.startswith("[") and payload.endswith("]"):
+        parts = [p.strip() for p in payload[1:-1].split(",") if p.strip()]
+        return [parse_numeric(p, dtype=elem_dtype) for p in parts], True
+    return parse_numeric(payload, dtype=elem_dtype), False
+
+
 @register_parser("arith.constant")
 def parse_arith_constant(op_text, parse_ctx):
     from ..parser_utils import parse_numeric, parse_tensor_type
@@ -486,7 +511,9 @@ def parse_arith_constant(op_text, parse_ctx):
 
         dense_match = re.match(r'dense<([^>]+)>', inner)
         if dense_match:
-            value = parse_numeric(dense_match.group(1), dtype=elem_dtype)
+            value, is_list = _parse_dense_payload(dense_match.group(1), elem_dtype)
+            if is_list:
+                attributes["dense_list"] = True
         else:
             typed_val = re.match(r'(.+?)\s*:\s*\S+', inner)
             if typed_val:
@@ -514,10 +541,12 @@ def parse_arith_constant(op_text, parse_ctx):
             result_type = dense_match.group(2).strip()
             type_info = parse_tensor_type(result_type)
             elem_dtype = type_info.get("dtype") if type_info else None
-            value = parse_numeric(dense_match.group(1), dtype=elem_dtype)
+            value, is_list = _parse_dense_payload(dense_match.group(1), elem_dtype)
             attributes["shape"] = type_info["shape"]
             attributes["dtype"] = type_info["dtype"]
             attributes["is_tensor"] = True
+            if is_list:
+                attributes["dense_list"] = True
         elif simple_match:
             result_type = simple_match.group(2).strip()
             value = parse_numeric(simple_match.group(1), dtype=result_type)

--- a/ktir_cpu/dialects/arith_ops.py
+++ b/ktir_cpu/dialects/arith_ops.py
@@ -452,30 +452,9 @@ def arith__select(op, context, env):
 # Parsers
 # ---------------------------------------------------------------------------
 
-def _parse_dense_payload(payload, elem_dtype):
-    """Parse the inside of `dense<...>`.
-
-    Returns ``(value, is_list)``. Two forms appear in MLIR:
-
-    - splat:  ``dense<0.0>``         -> single scalar broadcast across the shape
-    - list:   ``dense<[16, 32]>``    -> one value per element
-
-    The list form shows up as the shape operand of folded ``tensor.reshape``
-    ops (e.g. ``dense<[16, 32]> : tensor<2xindex>``); the splat form covers
-    plain zero-/constant-init tensors.
-    """
-    from ..parser_utils import parse_numeric
-
-    payload = payload.strip()
-    if payload.startswith("[") and payload.endswith("]"):
-        parts = [p.strip() for p in payload[1:-1].split(",") if p.strip()]
-        return [parse_numeric(p, dtype=elem_dtype) for p in parts], True
-    return parse_numeric(payload, dtype=elem_dtype), False
-
-
 @register_parser("arith.constant")
 def parse_arith_constant(op_text, parse_ctx):
-    from ..parser_utils import parse_numeric, parse_tensor_type
+    from ..parser_utils import parse_numeric, parse_tensor_type, parse_dense_payload
 
     result_match = re.match(r'(%\w+)\s*=\s*arith\.constant\s*(.*)', op_text)
     if not result_match:
@@ -484,7 +463,6 @@ def parse_arith_constant(op_text, parse_ctx):
     result_name = result_match.group(1)
     rest = result_match.group(2).strip()
 
-    value = None
     result_type = None
     attributes = {}
 
@@ -499,36 +477,44 @@ def parse_arith_constant(op_text, parse_ctx):
     # All forms pass dtype to parse_numeric so hex literals are correctly
     # interpreted as IEEE 754 bit patterns for float types.
 
+    def _set_dense(payload, elem_dtype):
+        # Handles both forms inside dense<...>: splat scalar and [v0, v1, ...] list.
+        value, is_list = parse_dense_payload(payload, elem_dtype)
+        attributes["value"] = value
+        if is_list:
+            attributes["dense_list"] = True
+
+    def _set_tensor_attrs(type_info, type_str):
+        # Used by Form 1 (braced) and Form 2 (dense) only — scalar Form 3
+        # has no tensor result type so these attributes are not set there.
+        if type_info and "tensor<" in type_str:
+            attributes["shape"] = type_info["shape"]
+            attributes["dtype"] = type_info.get("dtype", "f16")
+            attributes["is_tensor"] = True
+
     braced_match = re.match(r'\{([^}]+)\}\s*:\s*(.+)$', rest)
     if braced_match:
         # Form 1: {inner} : result_type
         inner = braced_match.group(1).strip()
         result_type = braced_match.group(2).strip()
 
-        # Resolve element dtype from result_type (could be "f32" or "tensor<4xf32>")
         _type_info = parse_tensor_type(result_type)
         elem_dtype = _type_info.get("dtype") if _type_info else result_type
 
         dense_match = re.match(r'dense<([^>]+)>', inner)
         if dense_match:
-            value, is_list = _parse_dense_payload(dense_match.group(1), elem_dtype)
-            if is_list:
-                attributes["dense_list"] = True
+            _set_dense(dense_match.group(1), elem_dtype)
         else:
             typed_val = re.match(r'(.+?)\s*:\s*\S+', inner)
-            if typed_val:
-                value = parse_numeric(typed_val.group(1).strip(), dtype=elem_dtype)
-            else:
-                value = parse_numeric(inner, dtype=elem_dtype)
+            raw = typed_val.group(1).strip() if typed_val else inner
+            attributes["value"] = parse_numeric(raw, dtype=elem_dtype)
 
-        if _type_info and 'tensor<' in result_type:
-            attributes["shape"] = _type_info["shape"]
-            attributes["dtype"] = _type_info.get("dtype", "f16")
-            attributes["is_tensor"] = True
+        _set_tensor_attrs(_type_info, result_type)
     else:
         # Form 2: dense<value> : type.  Covers:
         #   dense<0.0> : tensor<4xf16>       (splat tensor constant)
         #   dense<42> : tensor<1xi32>         (scalar tensor constant)
+        #   dense<[16, 32]> : tensor<2xindex> (list — one value per element)
         dense_match = re.match(r'dense<([^>]+)>\s*:\s*(.+)$', rest)
         # Form 3: scalar value : type.  Covers:
         #   42 : index              (decimal integer)
@@ -541,35 +527,22 @@ def parse_arith_constant(op_text, parse_ctx):
             result_type = dense_match.group(2).strip()
             type_info = parse_tensor_type(result_type)
             elem_dtype = type_info.get("dtype") if type_info else None
-            value, is_list = _parse_dense_payload(dense_match.group(1), elem_dtype)
-            attributes["shape"] = type_info["shape"]
-            attributes["dtype"] = type_info["dtype"]
-            attributes["is_tensor"] = True
-            if is_list:
-                attributes["dense_list"] = True
+            _set_dense(dense_match.group(1), elem_dtype)
+            _set_tensor_attrs(type_info, result_type)
         elif simple_match:
             result_type = simple_match.group(2).strip()
-            value = parse_numeric(simple_match.group(1), dtype=result_type)
+            attributes["value"] = parse_numeric(simple_match.group(1), dtype=result_type)
         else:
             # Defensive fallback: type-only with no parseable value — defaults to 0.
             # No known MLIR examples hit this path; kept for robustness.
             #   : tensor<1x64xf16>     (zero-initialized tensor)
             #   : index                (zero scalar)
-
             type_only_match = re.match(r':\s*(.+)$', rest)
             if type_only_match:
                 result_type = type_only_match.group(1).strip()
-                if result_type and 'tensor<' in result_type:
-                    type_info = parse_tensor_type(result_type)
-                    if type_info:
-                        attributes["shape"] = type_info["shape"]
-                        attributes["dtype"] = type_info.get("dtype", "f16")
-                        attributes["is_tensor"] = True
-
-    if value is None:
-        value = 0
-
-    attributes["value"] = value
+                type_info = parse_tensor_type(result_type) if result_type and "tensor<" in result_type else None
+                _set_tensor_attrs(type_info, result_type or "")
+            attributes.setdefault("value", 0)
 
     return Operation(
         result=result_name,

--- a/ktir_cpu/dialects/tensor_ops.py
+++ b/ktir_cpu/dialects/tensor_ops.py
@@ -121,6 +121,61 @@ def tensor__collapse_shape(op, context, env):
     return src
 
 
+@register("tensor.reshape")
+def tensor__reshape(op, context, env):
+    """Reinterpret a tensor with the same total element count under a new shape.
+
+    The MLIR op carries two operands: the source tensor and a 1-D shape tensor
+    (typically ``tensor<Nxindex>``) holding the target dimensions. The result
+    type annotation always pins the target shape statically, so the executor
+    reads ``target_shape`` from attributes (synthesized by the parser from the
+    result type) rather than reading the runtime shape operand — matching how
+    ``tensor.expand_shape`` / ``tensor.collapse_shape`` already behave.
+    """
+    src = context.get_value(op.operands[0])
+    target_shape = op.attributes.get("target_shape")
+    if target_shape is None:
+        raise ValueError(
+            f"tensor.reshape: missing 'target_shape' attribute on op {op}"
+        )
+    if not isinstance(src, Tile):
+        return src
+    reshaped = src.data.reshape(target_shape)
+    return Tile(reshaped, src.dtype, target_shape)
+
+
+@register("tensor.from_elements")
+def tensor__from_elements(op, context, env):
+    """Build a 1-D tensor from N scalar SSA operands.
+
+    Used as the shape-operand producer for tensor.reshape. Each operand is
+    fetched from the context, coerced to a Python scalar, and stacked into a
+    NumPy array of the result type. Scalars from arith.constant arrive as
+    plain ints/floats; those from another tensor (rare) arrive as Tiles —
+    flatten the first element in that case.
+    """
+    shape_attr = op.attributes.get("shape")
+    if shape_attr is None:
+        raise ValueError(
+            f"tensor.from_elements: missing 'shape' attribute on op {op}"
+        )
+    shape = tuple(shape_attr)
+    dtype_str = op.attributes.get("dtype")
+    if dtype_str is None:
+        raise ValueError(
+            f"tensor.from_elements: missing 'dtype' attribute on op {op}"
+        )
+    np_dtype = to_np_dtype(dtype_str)
+    values = []
+    for name in op.operands:
+        v = context.get_value(name)
+        if isinstance(v, Tile):
+            v = v.data.flat[0]
+        values.append(v)
+    data = np.array(values, dtype=np_dtype).reshape(shape)
+    return Tile(data, dtype_str, shape)
+
+
 @register("tensor.yield")
 def tensor__yield(op, context, env):
     """Yield a value from a tensor.generate body — same semantics as scf.yield."""
@@ -405,3 +460,73 @@ def parse_tensor_expand_shape(op_text, parse_ctx):
 @register_parser("tensor.collapse_shape")
 def parse_tensor_collapse_shape(op_text, parse_ctx):
     return _parse_reshape_op(op_text, "collapse_shape")
+
+
+@register_parser("tensor.reshape")
+def parse_tensor_reshape(op_text, parse_ctx):
+    """Parse `%out = tensor.reshape %src(%shape) : (...) -> tensor<...>`.
+
+    Two SSA operands: source tensor and shape tensor. Target shape is read
+    from the trailing result-type annotation (after `->`), since that is
+    always statically pinned, while the shape operand may be runtime.
+    """
+    from ..parser_utils import parse_tensor_type
+    m = re.match(
+        r'(%\w+)\s*=\s*tensor\.reshape\s+(%\w+)\s*\(\s*(%\w+)\s*\)', op_text
+    )
+    if not m:
+        return None
+    result_name, src, shape_operand = m.group(1), m.group(2), m.group(3)
+
+    arrow = re.search(r'->\s*(tensor<[^>]+>)', op_text)
+    if not arrow:
+        raise ValueError(f"tensor.reshape: missing result type in '{op_text}'")
+    result_type = arrow.group(1)
+    info = parse_tensor_type(result_type)
+    if info is None:
+        raise ValueError(
+            f"tensor.reshape: cannot parse result type {result_type!r} in '{op_text}'"
+        )
+
+    return Operation(
+        result=result_name,
+        op_type="tensor.reshape",
+        operands=[src, shape_operand],
+        attributes={
+            "target_shape": info["shape"],
+            "dtype": info["dtype"],
+        },
+        result_type=result_type,
+    )
+
+
+@register_parser("tensor.from_elements")
+def parse_tensor_from_elements(op_text, parse_ctx):
+    """Parse `%shape = tensor.from_elements %d0, %d1, ... : tensor<NxT>`."""
+    from ..parser_utils import parse_tensor_type
+    m = re.match(
+        r'(%\w+)\s*=\s*tensor\.from_elements\s+(.*?)\s*:\s*(tensor<[^>]+>)', op_text
+    )
+    if not m:
+        return None
+    result_name = m.group(1)
+    operand_text = m.group(2)
+    type_str = m.group(3)
+    operands = find_ssa_names(operand_text)
+
+    info = parse_tensor_type(type_str)
+    if info is None:
+        raise ValueError(
+            f"tensor.from_elements: cannot parse result type {type_str!r} in '{op_text}'"
+        )
+
+    return Operation(
+        result=result_name,
+        op_type="tensor.from_elements",
+        operands=operands,
+        attributes={
+            "shape": info["shape"],
+            "dtype": info["dtype"],
+        },
+        result_type=type_str,
+    )

--- a/ktir_cpu/mlir_frontend/parser.py
+++ b/ktir_cpu/mlir_frontend/parser.py
@@ -454,6 +454,33 @@ def _adapt_tensor_collapse_shape(mlir_op, attributes, result_type, operands):
     attributes["dtype"] = info["dtype"]
 
 
+@MLIRTypeAdapter.install("tensor.reshape")
+def _adapt_tensor_reshape(mlir_op, attributes, result_type, operands):
+    """Synthesize target_shape/dtype from the result type annotation.
+
+    The shape operand (operands[1]) is left in place so the IR remains
+    well-formed; only the result type is consulted, since it always pins
+    the target shape statically.
+    """
+    from ..parser_utils import parse_tensor_type
+    info = parse_tensor_type(result_type)
+    if info is None:
+        raise ValueError(f"tensor.reshape: cannot parse result type {result_type!r}")
+    attributes["target_shape"] = info["shape"]
+    attributes["dtype"] = info["dtype"]
+
+
+@MLIRTypeAdapter.install("tensor.from_elements")
+def _adapt_tensor_from_elements(mlir_op, attributes, result_type, operands):
+    """Synthesize shape/dtype from result type — operands carry the values."""
+    from ..parser_utils import parse_tensor_type
+    info = parse_tensor_type(result_type)
+    if info is None:
+        raise ValueError(f"tensor.from_elements: cannot parse result type {result_type!r}")
+    attributes["shape"] = info["shape"]
+    attributes["dtype"] = info["dtype"]
+
+
 @MLIRTypeAdapter.install("tensor.splat")
 def _adapt_tensor_splat(mlir_op, attributes, result_type, operands):
     """Synthesize shape/dtype from result type."""
@@ -467,19 +494,41 @@ def _adapt_tensor_splat(mlir_op, attributes, result_type, operands):
 
 @MLIRTypeAdapter.install("arith.constant")
 def _adapt_arith_constant(mlir_op, attributes, result_type, operands):
-    """Extract value: unwrap splat tensors, convert int/float attrs."""
+    """Extract value: unwrap splat tensors, iterate dense lists, convert int/float attrs.
+
+    Three cases for the ``value`` attribute:
+
+    - splat ``DenseElementsAttr`` (e.g. ``dense<0.0> : tensor<4xf16>``):
+      unwrap to the single splat value via ``get_splat_value()``.
+    - non-splat ``DenseElementsAttr`` (e.g. ``dense<[16, 32]> : tensor<2xindex>``):
+      iterate the elements; record ``dense_list = True`` so the executor
+      builds the array element-by-element rather than splatting one value.
+    - scalar ``IntegerAttr`` / ``FloatAttr`` (e.g. ``42 : index``): use directly.
+    """
     val_attr = mlir_op.attributes["value"]
-    if isinstance(val_attr, DenseElementsAttr) and val_attr.is_splat:
-        val_attr = val_attr.get_splat_value()
-    if not isinstance(val_attr, (IntegerAttr, FloatAttr)):
-        raise TypeError(f"arith.constant: unhandled value attr type {type(val_attr)}")
-    attributes["value"] = val_attr.value
+    is_list = False
+    if isinstance(val_attr, DenseElementsAttr):
+        if val_attr.is_splat:
+            val_attr = val_attr.get_splat_value()
+        else:
+            # Iterating DenseElementsAttr yields Python scalars (int/float)
+            # directly, not wrapped IntegerAttr/FloatAttr.
+            attributes["value"] = [
+                e.value if hasattr(e, "value") else e for e in val_attr
+            ]
+            is_list = True
+    if not is_list:
+        if not isinstance(val_attr, (IntegerAttr, FloatAttr)):
+            raise TypeError(f"arith.constant: unhandled value attr type {type(val_attr)}")
+        attributes["value"] = val_attr.value
     if result_type and "tensor<" in result_type:
         from ..parser_utils import parse_tensor_type
         info = parse_tensor_type(result_type)
         attributes["shape"] = info["shape"]
         attributes["dtype"] = info["dtype"]
         attributes["is_tensor"] = True
+        if is_list:
+            attributes["dense_list"] = True
 
 
 @MLIRTypeAdapter.install("linalg.broadcast")

--- a/ktir_cpu/mlir_frontend/parser.py
+++ b/ktir_cpu/mlir_frontend/parser.py
@@ -509,7 +509,7 @@ def _adapt_arith_constant(mlir_op, attributes, result_type, operands):
     is_list = False
     if isinstance(val_attr, DenseElementsAttr):
         if val_attr.is_splat:
-            val_attr = val_attr.get_splat_value()
+            attributes["value"] = val_attr.get_splat_value().value
         else:
             # Iterating DenseElementsAttr yields Python scalars (int/float)
             # directly, not wrapped IntegerAttr/FloatAttr.
@@ -517,10 +517,10 @@ def _adapt_arith_constant(mlir_op, attributes, result_type, operands):
                 e.value if hasattr(e, "value") else e for e in val_attr
             ]
             is_list = True
-    if not is_list:
-        if not isinstance(val_attr, (IntegerAttr, FloatAttr)):
-            raise TypeError(f"arith.constant: unhandled value attr type {type(val_attr)}")
+    elif isinstance(val_attr, (IntegerAttr, FloatAttr)):
         attributes["value"] = val_attr.value
+    else:
+        raise TypeError(f"arith.constant: unhandled value attr type {type(val_attr)}")
     if result_type and "tensor<" in result_type:
         from ..parser_utils import parse_tensor_type
         info = parse_tensor_type(result_type)

--- a/ktir_cpu/parser_utils.py
+++ b/ktir_cpu/parser_utils.py
@@ -127,6 +127,22 @@ def parse_numeric(s: str, dtype: Optional[str] = None) -> Any:
     return 0
 
 
+def parse_dense_payload(payload: str, elem_dtype: Optional[str] = None):
+    """Parse the content already extracted from inside ``dense<...>``.
+
+    Returns ``(value, is_list)``:
+    - scalar payload ``0.0``       → ``(scalar, False)``
+    - list payload   ``[16, 32]``  → ``([16, 32], True)``
+    """
+    payload = payload.strip()
+    is_list = payload.startswith("[")
+    if is_list:
+        assert payload.endswith("]"), f"malformed dense list payload: {payload!r}"
+        parts = [p.strip() for p in payload[1:-1].split(",") if p.strip()]
+        return [parse_numeric(p, dtype=elem_dtype) for p in parts], True
+    return parse_numeric(payload, dtype=elem_dtype), False
+
+
 def _extract_bracket_content(op_text: str, brackets: str = '{}') -> Optional[str]:
     """Return the content inside the outermost matched bracket pair.
 

--- a/tests/test_dialects_exec.py
+++ b/tests/test_dialects_exec.py
@@ -463,6 +463,23 @@ class TestArithCastsConstants:
         assert result.shape == (4,)
         assert np.all(result.data == 0)
 
+    def test_constant_dense_list(self):
+        """``arith.constant dense<[16, 32]>`` materializes the list element-by-element.
+
+        Pins the regression where the parser called ``parse_numeric`` on
+        ``[16, 32]`` and produced a splat-of-zero tensor.
+        """
+        result = _call("arith.constant", _make_ctx(), _make_env(),
+                       attributes={
+                           "value": [16, 32],
+                           "shape": (2,),
+                           "dtype": "index",
+                           "is_tensor": True,
+                           "dense_list": True,
+                       })
+        assert result.shape == (2,)
+        assert list(result.data) == [16, 32]
+
     def test_extsi(self):
         # sign-extend integer — returns Python int
         ctx = _ctx_with(**{"%a": 5})
@@ -1062,6 +1079,83 @@ class TestTensor:
                        operands=["%t"], attributes={"target_shape": (4,)})
         assert result.shape == (4,)
         assert np.array_equal(result.data, [1, 2, 3, 4])
+
+    def test_reshape(self):
+        """1D -> 2D reshape preserves element order and total count."""
+        t = Tile(np.arange(8, dtype=np.float16), "f16", (8,))
+        shape_tile = Tile(np.array([2, 4], dtype=np.intp), "index", (2,))
+        ctx = _ctx_with(**{"%t": t, "%s": shape_tile})
+        result = _call("tensor.reshape", ctx, _make_env(),
+                       operands=["%t", "%s"],
+                       attributes={"target_shape": (2, 4), "dtype": "f16"})
+        assert result.shape == (2, 4)
+        assert np.array_equal(result.data, np.arange(8).reshape(2, 4))
+
+    def test_reshape_non_square_target(self):
+        """Rank-changing reshape with a non-square target preserves row-major order.
+
+        Pins that 1-D[12] -> 2-D[3,4] places elements as
+        ``[[0,1,2,3],[4,5,6,7],[8,9,10,11]]`` (rightmost index varies fastest),
+        not column-major.
+        """
+        t = Tile(np.arange(12, dtype=np.float16), "f16", (12,))
+        shape_tile = Tile(np.array([3, 4], dtype=np.intp), "index", (2,))
+        ctx = _ctx_with(**{"%t": t, "%s": shape_tile})
+        result = _call("tensor.reshape", ctx, _make_env(),
+                       operands=["%t", "%s"],
+                       attributes={"target_shape": (3, 4), "dtype": "f16"})
+        assert result.shape == (3, 4)
+        assert np.array_equal(result.data, np.arange(12).reshape(3, 4))
+
+    def test_reshape_size_mismatch_raises(self):
+        """Element-count mismatch must fail loud, not silently truncate.
+
+        Source has 7 elements; target shape (3, 3) demands 9. NumPy's
+        ``ndarray.reshape`` raises ``ValueError``; the executor propagates it
+        rather than returning a partial result.
+        """
+        t = Tile(np.arange(7, dtype=np.float16), "f16", (7,))
+        shape_tile = Tile(np.array([3, 3], dtype=np.intp), "index", (2,))
+        ctx = _ctx_with(**{"%t": t, "%s": shape_tile})
+        with pytest.raises(ValueError, match="cannot reshape"):
+            _call("tensor.reshape", ctx, _make_env(),
+                  operands=["%t", "%s"],
+                  attributes={"target_shape": (3, 3), "dtype": "f16"})
+
+    def test_reshape_to_3d(self):
+        """Rank-3 endpoint: 1-D[24] -> 3-D[2,3,4] preserves row-major order."""
+        t = Tile(np.arange(24, dtype=np.float16), "f16", (24,))
+        shape_tile = Tile(np.array([2, 3, 4], dtype=np.intp), "index", (3,))
+        ctx = _ctx_with(**{"%t": t, "%s": shape_tile})
+        result = _call("tensor.reshape", ctx, _make_env(),
+                       operands=["%t", "%s"],
+                       attributes={"target_shape": (2, 3, 4), "dtype": "f16"})
+        assert result.shape == (2, 3, 4)
+        assert np.array_equal(result.data, np.arange(24).reshape(2, 3, 4))
+
+    def test_from_elements(self):
+        """Stack scalar SSA operands into a 1-D index tensor."""
+        ctx = _ctx_with(**{"%a": 16, "%b": 32})
+        result = _call("tensor.from_elements", ctx, _make_env(),
+                       operands=["%a", "%b"],
+                       attributes={"shape": (2,), "dtype": "index"})
+        assert result.shape == (2,)
+        assert list(result.data) == [16, 32]
+
+    def test_from_elements_n1(self):
+        """N=1 endpoint: single-element 1-D shape tensor.
+
+        Guards the smallest legal grammar match (one operand). Useful when a
+        ``tensor.reshape`` collapses a 2-D tensor to 1-D via a 1-element shape
+        operand (e.g. ``tensor.from_elements %total : tensor<1xindex>``).
+        """
+        ctx = _ctx_with(**{"%a": 128})
+        result = _call("tensor.from_elements", ctx, _make_env(),
+                       operands=["%a"],
+                       attributes={"shape": (1,), "dtype": "index"})
+        assert result.shape == (1,)
+        assert list(result.data) == [128]
+
 
 # ---------------------------------------------------------------------------
 # tensor.generate exec

--- a/tests/test_dialects_parse.py
+++ b/tests/test_dialects_parse.py
@@ -265,6 +265,37 @@ class TestArithParsers(ParseTestMixin):
         self.assert_attribute(op, "shape", (4,))
         self.assert_attribute(op, "dtype", "f16")
 
+    def test_constant_dense_list(self):
+        """dense<[16, 32]> : tensor<2xindex> — list form, one value per element.
+
+        Folded ``tensor.from_elements`` of constant ``index`` values appears
+        as the shape operand of ``tensor.reshape``. Without per-element
+        parsing this would mis-parse to a splat-of-zero tensor.
+        """
+        op = self._parse("%c = arith.constant dense<[16, 32]> : tensor<2xindex>")
+        self.assert_op_type(op, "arith.constant")
+        self.assert_attribute(op, "is_tensor", True)
+        self.assert_attribute(op, "shape", (2,))
+        self.assert_attribute(op, "dtype", "index")
+        self.assert_attribute(op, "value", [16, 32])
+        self.assert_attribute(op, "dense_list", True)
+
+    def test_constant_dense_list_float(self):
+        """dense<[1.5, 2.5]> : tensor<2xf32> — list form with float dtype.
+
+        Confirms the dense-list path is dtype-generic: ``_parse_dense_payload``
+        runs each token through ``parse_numeric`` with the element dtype, so
+        floats parse correctly even though the splat path was the original
+        motivating case for index-only shape operands.
+        """
+        op = self._parse("%c = arith.constant dense<[1.5, 2.5]> : tensor<2xf32>")
+        self.assert_op_type(op, "arith.constant")
+        self.assert_attribute(op, "is_tensor", True)
+        self.assert_attribute(op, "shape", (2,))
+        self.assert_attribute(op, "dtype", "f32")
+        self.assert_attribute(op, "value", [1.5, 2.5])
+        self.assert_attribute(op, "dense_list", True)
+
     @pytest.mark.parametrize("op_name", [
         "arith.addi", "arith.subi", "arith.muli",
         "arith.divsi", "arith.divui",
@@ -557,6 +588,74 @@ class TestTensorParsers(ParseTestMixin):
         self.assert_num_operands(yield_op, 1)
         self.assert_operand_names(yield_op, "%val")
         assert yield_op.result is None
+
+    def test_reshape(self):
+        """1D -> 2D reshape, primary form emitted by Spyre's LowerComputeOps.
+
+        Two SSA operands (source and shape tensor); target shape is read from
+        the result type after ``->``.
+        """
+        op = self._parse(
+            "%out = tensor.reshape %src(%shape) : "
+            "(tensor<512xf32>, tensor<2xindex>) -> tensor<16x32xf32>",
+            args={"%src": "tensor<512xf32>", "%shape": "tensor<2xindex>"},
+        )
+        self.assert_op_type(op, "tensor.reshape")
+        self.assert_num_operands(op, 2)
+        self.assert_operand_names(op, "%src", "%shape")
+        self.assert_attribute(op, "target_shape", (16, 32))
+        self.assert_attribute(op, "dtype", "f32")
+
+    def test_reshape_to_1d(self):
+        """Endpoint test: rank-reducing reshape (2D -> 1D)."""
+        op = self._parse(
+            "%out = tensor.reshape %src(%shape) : "
+            "(tensor<8x16xf16>, tensor<1xindex>) -> tensor<128xf16>",
+            args={"%src": "tensor<8x16xf16>", "%shape": "tensor<1xindex>"},
+        )
+        self.assert_op_type(op, "tensor.reshape")
+        self.assert_attribute(op, "target_shape", (128,))
+        self.assert_attribute(op, "dtype", "f16")
+
+    def test_from_elements(self):
+        """``tensor.from_elements %d0, %d1 : tensor<2xindex>`` — shape-operand
+        producer for ``tensor.reshape``."""
+        op = self._parse(
+            "%shape = tensor.from_elements %d0, %d1 : tensor<2xindex>",
+            args={"%d0": "index", "%d1": "index"},
+        )
+        self.assert_op_type(op, "tensor.from_elements")
+        self.assert_num_operands(op, 2)
+        self.assert_operand_names(op, "%d0", "%d1")
+        self.assert_attribute(op, "shape", (2,))
+        self.assert_attribute(op, "dtype", "index")
+
+    def test_from_elements_n1(self):
+        """N=1 endpoint: single-operand form.
+
+        The grammar ``tensor.from_elements %a, ... : tensor<NxT>`` admits N>=1;
+        this guards the smallest legal match. Used when a reshape needs a
+        rank-1 target with a single dimension (e.g. flatten).
+        """
+        op = self._parse(
+            "%shape = tensor.from_elements %a : tensor<1xindex>",
+            args={"%a": "index"},
+        )
+        self.assert_op_type(op, "tensor.from_elements")
+        self.assert_num_operands(op, 1)
+        self.assert_operand_names(op, "%a")
+        self.assert_attribute(op, "shape", (1,))
+        self.assert_attribute(op, "dtype", "index")
+
+    def test_from_elements_three(self):
+        """N>2 endpoint: rank-3 shape producer (e.g. for tensor<2x2x16xT>)."""
+        op = self._parse(
+            "%shape = tensor.from_elements %a, %b, %c : tensor<3xindex>",
+            args={"%a": "index", "%b": "index", "%c": "index"},
+        )
+        self.assert_num_operands(op, 3)
+        self.assert_operand_names(op, "%a", "%b", "%c")
+        self.assert_attribute(op, "shape", (3,))
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Lowers tt.reshape to tensor.reshape, fed by either tensor.from_elements 
(when the target shape is built from SSA values) or a folded arith.constant 
of the form dense<[16, 32]> : tensor<2xindex>. The interpreter previously
supported none of these, so any reshape-bearing kernel failed at parse
or execution time.

- Add tensor.reshape executor + parsers (regex and MLIR-frontend).
  Target shape is read from the result-type annotation rather than the
  runtime shape operand, matching how tensor.expand_shape and
  tensor.collapse_shape already work — the result type always pins the
  target shape statically, even when the operand is dynamic.
- Add tensor.from_elements executor + parsers, since it is the typical
  shape-operand producer for tensor.reshape.
- Extend arith.constant to handle non-splat dense<[...]> payloads. The
  splat path was the only one implemented, which silently mis-parsed
  list payloads to a splat-of-zero tensor. A new dense_list attribute
  routes the executor to materialize the array element-by-element.
  Covers both the regex parser and the MLIR-frontend adapter.

Tests pin the regression cases and exercise rank-changing reshapes
(1D->2D, 2D->1D, 1D->3D), the smallest legal tensor.from_elements
(N=1), an N>2 case, dtype generality of the dense-list path (index
and f32), and the size-mismatch error path.