### PR TITLE
fix: track_lx for multi-result ops; unify result-binding; strengthen batch_matmul test

### DIFF
--- a/ktir_cpu/interpreter.py
+++ b/ktir_cpu/interpreter.py
@@ -214,14 +214,12 @@ class KTIRInterpreter:
         # Other result types — TileRef (metadata), AccessTile (coordinates),
         # int/index (scalars) — are bookkeeping and use no scratchpad memory.
         if op.result and result is not None:
-            # Multi-result ops return a tuple and have a list of result names.
-            if isinstance(op.result, list) and isinstance(result, tuple):
-                for name, val in zip(op.result, result):
-                    context.set_value(name, val)
-            else:
-                context.set_value(op.result, result)
-                if isinstance(result, Tile):
-                    context.track_lx(op.result, result.size_bytes())
+            names = op.result if isinstance(op.result, list) else [op.result]
+            values = result if isinstance(result, tuple) else [result]
+            for name, val in zip(names, values):
+                context.set_value(name, val)
+                if isinstance(val, Tile):
+                    context.track_lx(name, val.size_bytes())
 
         # Record latency
         if self._latency_tracker is not None:

--- a/ktir_cpu/interpreter.py
+++ b/ktir_cpu/interpreter.py
@@ -216,9 +216,10 @@ class KTIRInterpreter:
         if op.result and result is not None:
             names = op.result if isinstance(op.result, list) else [op.result]
             values = result if isinstance(result, tuple) else [result]
-            assert len(names) == len(values), (
-                f"{op.op_type}: expected {len(names)} result(s), got {len(values)}"
-            )
+            if len(names) != len(values):
+                raise RuntimeError(
+                    f"{op.op_type}: expected {len(names)} result(s), got {len(values)}"
+                )
             for name, val in zip(names, values):
                 context.set_value(name, val)
                 if isinstance(val, Tile):

--- a/ktir_cpu/interpreter.py
+++ b/ktir_cpu/interpreter.py
@@ -216,6 +216,9 @@ class KTIRInterpreter:
         if op.result and result is not None:
             names = op.result if isinstance(op.result, list) else [op.result]
             values = result if isinstance(result, tuple) else [result]
+            assert len(names) == len(values), (
+                f"{op.op_type}: expected {len(names)} result(s), got {len(values)}"
+            )
             for name, val in zip(names, values):
                 context.set_value(name, val)
                 if isinstance(val, Tile):

--- a/tests/test_dialects_exec.py
+++ b/tests/test_dialects_exec.py
@@ -946,15 +946,16 @@ class TestLinalg:
         assert np.allclose(result.data, b.data, rtol=1e-2)
 
     def test_batch_matmul(self):
-        # batched identity: for each batch, I @ B == B
-        eye = np.broadcast_to(np.eye(2, dtype=np.float16), (3, 2, 2)).copy()
-        bdata = np.arange(3 * 2 * 2, dtype=np.float16).reshape(3, 2, 2)
-        a = Tile(eye, "f16", (3, 2, 2))
+        # non-identity A so index transposition bugs would produce wrong values
+        adata = np.array([[[1, 2], [3, 4]], [[2, 0], [1, 3]], [[1, 1], [0, 2]]], dtype=np.float16)
+        bdata = np.array([[[5, 6], [7, 8]], [[1, 2], [3, 4]], [[2, 3], [1, 0]]], dtype=np.float16)
+        expected = np.einsum("bij,bjk->bik", adata, bdata).astype(np.float16)
+        a = Tile(adata, "f16", (3, 2, 2))
         b = Tile(bdata, "f16", (3, 2, 2))
         ctx = _ctx_with(**{"%a": a, "%b": b})
         result = _call("linalg.batch_matmul", ctx, _make_env(), operands=["%a", "%b"])
         assert result.shape == (3, 2, 2)
-        assert np.allclose(result.data, bdata, rtol=1e-2)
+        assert np.allclose(result.data, expected, rtol=1e-2)
 
     def test_generic_reads_outs_arg(self):
         # linalg.generic where the body reads the outs bb0 arg.

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -221,12 +221,9 @@ module {
 
 
 def test_multi_result_single_value_raises_error():
-    """When op.result is a list but handler returns a non-tuple, a TypeError is raised.
+    """When op.result is a list but handler returns a non-tuple, an AssertionError is raised.
 
-    This documents the current (unguarded) behavior: the interpreter tries to
-    use the list as a dict key in set_value, which is unhashable.  This is a
-    known edge-case that callers must avoid by always returning a tuple from
-    multi-result handlers.
+    The arity guard catches the mismatch before any set_value call.
     """
     from unittest.mock import patch
     from ktir_cpu.dialects import registry
@@ -255,5 +252,5 @@ module {
             result_type=None,
             regions=[],
         )
-        with pytest.raises(TypeError):
+        with pytest.raises(AssertionError):
             interp._execute_op(op, core)

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -221,7 +221,7 @@ module {
 
 
 def test_multi_result_single_value_raises_error():
-    """When op.result is a list but handler returns a non-tuple, an AssertionError is raised.
+    """When op.result is a list but handler returns a non-tuple, a RuntimeError is raised.
 
     The arity guard catches the mismatch before any set_value call.
     """
@@ -252,5 +252,5 @@ module {
             result_type=None,
             regions=[],
         )
-        with pytest.raises(AssertionError):
+        with pytest.raises(RuntimeError):
             interp._execute_op(op, core)


### PR DESCRIPTION
## What

Addresses two review comments from #89.

## Changes

- **`interpreter.py`** — multi-result branch (`op.result` is a list) never called `context.track_lx` for `Tile` values, while the single-result path did. Unified both paths into one loop over zipped names/values so `track_lx` is called for any `Tile` regardless of result count.
- **`test_batch_matmul`** — replaced identity-matrix `A` with non-identity data; uses `np.einsum` as the reference so index transposition bugs would produce wrong values.

## Related

- Follows #89