### PR TITLE
Reduce: do update to the output parameter instead of assignment, with…

### DIFF
--- a/examples/ktir/reduce_multiop.mlir
+++ b/examples/ktir/reduce_multiop.mlir
@@ -5,7 +5,7 @@
 module {
   func.func @reduce_multiop(%arg0: index) attributes {grid = [1, 1]} {
     %c0 = arith.constant 0 : index
-    %cst = arith.constant 0xFF80 : f16  // -inf (identity for max)
+    %cst = arith.constant 0xFC00 : f16  // -inf (identity for max)
     %view = ktdp.construct_memory_view %arg0, sizes : [1, 8], strides : [8, 1] {coordinate_set = affine_set<(d0, d1) : (d0 >= 0, -d0 >= 0, d1 >= 0, -d1 + 7 >= 0)>, memory_space = #ktdp.spyre_memory_space<HBM>} : memref<1x8xf16>
     %acc = ktdp.construct_access_tile %view[%c0, %c0] {
         access_tile_set = affine_set<(d0, d1) : (d0 >= 0, -d0 >= 0, d1 >= 0, -d1 + 7 >= 0)>,

--- a/examples/ktir/softmax_wide.mlir
+++ b/examples/ktir/softmax_wide.mlir
@@ -29,7 +29,7 @@ module {
       } : memref<2x262144xf16> -> !ktdp.access_tile<1x262144xindex>
       %row_13 = ktdp.load %input_acc_1 : !ktdp.access_tile<1x262144xindex> -> tensor<1x262144xf16>
       
-      %neg_inf = arith.constant 0xFF80 : f16
+      %neg_inf = arith.constant 0xFC00 : f16
       %max_init = tensor.splat %neg_inf : tensor<1xf16>
       %row_max = linalg.reduce { arith.maxnumf }
           ins(%row_13 : tensor<1x262144xf16>)

--- a/examples/latency/softmax_small.mlir
+++ b/examples/latency/softmax_small.mlir
@@ -26,7 +26,7 @@ module {
 
       %input_row = ktdp.load %input_acc : !ktdp.access_tile<1x64xindex> -> tensor<1x64xf16>
 
-      %neg_inf = arith.constant 0xFF80 : f16
+      %neg_inf = arith.constant 0xFC00 : f16
       %max_init = tensor.splat %neg_inf : tensor<1xf16>
       %reduce_max = linalg.reduce { arith.maximumf }
         ins(%input_row : tensor<1x64xf16>)

--- a/examples/latency/softmax_small_explicit.mlir
+++ b/examples/latency/softmax_small_explicit.mlir
@@ -30,7 +30,7 @@ module {
 
       %input_row = ktdp.load %input_acc : !ktdp.access_tile<1x64xindex> -> tensor<1x64xf16>
 
-      %neg_inf = arith.constant 0xFF80 : f16
+      %neg_inf = arith.constant 0xFC00 : f16
       %max_init = tensor.splat %neg_inf : tensor<1xf16>
       %reduce_max = linalg.reduce
         ins(%input_row : tensor<1x64xf16>)

--- a/examples/triton-ktir/sdpa_2d.mlir
+++ b/examples/triton-ktir/sdpa_2d.mlir
@@ -43,7 +43,7 @@ module {
     %c0       = arith.constant 0          : index
     %zero_f16 = arith.constant 0.0        : f16
     %scale    = arith.constant 1.25e-01   : f16   // 1/sqrt(64) = 0.125
-    %neg_inf  = arith.constant 0xFF80 : f16   // -infinity (f16)
+    %neg_inf  = arith.constant 0xFC00 : f16   // -infinity (f16)
 
     // -----------------------------------------------------------------------
     // 1. Load Q block: [BLOCK_SIZE_M=32, HEAD_DIM=64]

--- a/examples/triton-ktir/softmax_fwd_ktir.mlir
+++ b/examples/triton-ktir/softmax_fwd_ktir.mlir
@@ -26,7 +26,7 @@ module {
 
       %input_row = ktdp.load %input_acc : !ktdp.access_tile<1x1024xindex> -> tensor<1x1024xf16>
 
-      %neg_inf = arith.constant 0xFF80 : f16  // -inf in f16
+      %neg_inf = arith.constant 0xFC00 : f16  // -inf in f16
       %max_init = tensor.splat %neg_inf : tensor<1xf16>
       %reduce_max = linalg.reduce { arith.maxnumf }
         ins(%input_row : tensor<1x1024xf16>)

--- a/ktir_cpu/dialects/linalg_ops.py
+++ b/ktir_cpu/dialects/linalg_ops.py
@@ -195,24 +195,32 @@ def linalg__reduce(op, context, env):
 
     dim = op.attributes.get("dim")  # axis to reduce; None → collapse all
 
+    outs_var = op.attributes.get("outs_var")
+    outs_tile = context.get_value(outs_var) if outs_var else None
+
     if isinstance(tile, Tile):
         folded = _tree_fold(tile, dim, bb0_names, body_ops, context, env)
         if dim is None:
-            result = folded.reshape(()).astype(tile.data.dtype).item()
+            reduced = folded.reshape(()).astype(tile.data.dtype)
         else:
             reduced = np.squeeze(folded, axis=dim).astype(tile.data.dtype)
-            if reduced.ndim == 0:
-                result = reduced.item()
-            else:
-                result = Tile(reduced, tile.dtype, reduced.shape)
+
+        # Combine with the outs initial accumulator.
+        if isinstance(outs_tile, Tile):
+            reduced_tile = Tile(reduced.copy(), tile.dtype, reduced.shape)
+            combined = _run_combiner(
+                bb0_names, body_ops, reduced_tile, outs_tile, context, env,
+            )
+            reduced = combined.data if isinstance(combined, Tile) else np.asarray(combined)
+
+        if reduced.ndim == 0:
+            result = reduced.item()
+        else:
+            result = Tile(reduced, tile.dtype, reduced.shape)
     else:
         # Already a scalar, nothing to reduce.
         result = tile
 
-    # In MLIR linalg semantics the result is written back into the outs buffer,
-    # so downstream ops may reference it by the outs SSA name rather than the
-    # result name. Bind both so either reference resolves correctly.
-    outs_var = op.attributes.get("outs_var")
     if outs_var and result is not None:
         context.set_value(outs_var, result)
 

--- a/tests/test_dialects_exec.py
+++ b/tests/test_dialects_exec.py
@@ -917,11 +917,6 @@ class TestLinalg:
         val = float(result.data.flat[0]) if isinstance(result, Tile) else float(result)
         assert val == pytest.approx(15.0, abs=1e-2)
 
-    @pytest.mark.xfail(reason="outs init value is not folded into the reduction; "
-                              "the tree fold seeds from the input only. Harmless "
-                              "while the frontend inits outs to the identity. "
-                              "Tracked in issue #85.",
-                       strict=True)
     def test_reduce_folds_outs_init(self):
         # MLIR semantics: outs is the initial accumulator. sum([1,2,3,4]) with
         # outs init = 100 should be 110, not 10.

--- a/tests/test_latency.py
+++ b/tests/test_latency.py
@@ -498,14 +498,14 @@ class TestReduceLatency:
 
         # Combiner ops carry the cost. Core 0 processes 2 rows; per row a max
         # (arith.maximumf) and a sum (arith.addf) each fold a 1×64 tile → the
-        # tree fold processes 63 elements per reduce. Summed per op across both
-        # rows: 2 × 63 / simd_elements_per_cycle.
-        per_reduce = 63 / cfg.simd_elements_per_cycle  # N-1 for N=64
+        # tree fold processes N-1 elements, plus one final combine with the outs
+        # accumulator (1 element). Total per reduce: N-1+1 = N elements.
+        per_reduce = 64 / cfg.simd_elements_per_cycle  # N-1 tree fold + 1 outs combine
         for combiner in ("arith.maximumf", "arith.addf"):
             total = sum(e.cycles for e in core0.trace if e.op_type == combiner)
             assert total == pytest.approx(2 * per_reduce), (
                 f"{combiner} should total {2 * per_reduce} cyc over 2 rows "
-                f"(tree fold of 1×64 → N-1 elems each); got {total}"
+                f"(tree fold of 1×64 + outs combine each); got {total}"
             )
 
     @pytest.mark.parametrize("path,func_name,entry", get_test_params("reduce_explicit_region"))
@@ -523,13 +523,13 @@ class TestReduceLatency:
         ), "linalg.reduce must be zero-cost in the explicit-region form too"
 
         # reduce_generic.mlir folds a 1×4 input tile with arith.addf. A pairwise
-        # tree fold of 4 elements processes 2 + 1 = 3 elements total →
-        # 3 / simd_elements_per_cycle cycles, charged to the combiner.
-        expected = 3 / cfg.simd_elements_per_cycle  # N-1 for N=4
+        # tree fold of 4 elements processes N-1=3 elements, plus one final
+        # combine with the outs accumulator (1 element). Total: 4 elements.
+        expected = 4 / cfg.simd_elements_per_cycle  # N-1 tree fold + 1 outs combine
         total = sum(e.cycles for e in core0.trace if e.op_type == "arith.addf")
         assert total == pytest.approx(expected), (
             f"combiner arith.addf should total {expected} cyc "
-            f"(tree fold of 1×4 → N-1 elems); got {total}"
+            f"(tree fold of 1×4 + outs combine); got {total}"
         )
 
     @pytest.mark.parametrize("path,func_name,entry", get_test_params("reduce_explicit_region"))
@@ -551,12 +551,12 @@ class TestReduceLatency:
         core0 = report.counters[0]
 
         assert all(e.cycles == 0.0 for e in core0.trace if e.op_type == "linalg.reduce")
-        per_reduce = 63 / cfg.simd_elements_per_cycle  # N-1 for N=64
+        per_reduce = 64 / cfg.simd_elements_per_cycle  # N-1 tree fold + 1 outs combine
         for combiner in ("arith.maximumf", "arith.addf"):
             total = sum(e.cycles for e in core0.trace if e.op_type == combiner)
             assert total == pytest.approx(2 * per_reduce), (
                 f"{combiner} should total {2 * per_reduce} cyc (explicit-region "
-                f"softmax, 2 rows of 1×64 tree fold); got {total}"
+                f"softmax, 2 rows of 1×64 tree fold + outs combine); got {total}"
             )
 
     @pytest.mark.parametrize("path,func_name,entry", get_test_params("reduce_multiop"))
@@ -569,12 +569,12 @@ class TestReduceLatency:
         core0 = report.counters[0]
 
         assert all(e.cycles == 0.0 for e in core0.trace if e.op_type == "linalg.reduce")
-        # 1×8 tree fold → 7 elements processed; each region op charged 7/simd.
-        expected = 7 / cfg.simd_elements_per_cycle  # N-1 for N=8
+        # 1×8 tree fold → 7 elements processed + 1 outs combine = 8 total.
+        expected = 8 / cfg.simd_elements_per_cycle  # N-1 tree fold + 1 outs combine
         for region_op in ("arith.cmpf", "arith.select"):
             total = sum(e.cycles for e in core0.trace if e.op_type == region_op)
             assert total == pytest.approx(expected), (
-                f"{region_op} should total {expected} cyc (1×8 tree fold); "
+                f"{region_op} should total {expected} cyc (1×8 tree fold + outs combine); "
                 f"got {total}"
             )
 


### PR DESCRIPTION
Issue #85, part 2

## Fix Description

**Targeted fix:**

1. support Update ops to the output parameter of a linalg.reduce op, instead of assignment. 
2. toggled the test checker in `test_reduce_folds_outs_init` to expect pass (from xfail)

**Voluntary fixes:**

3. test_latency's reference (expected) value for reduce ops got adjusted with "+1" (by Claude)
4. In a handful mlir example programs (under examples/ folder), the `neg_inf` (negative infinity, -inf) in fp16 data type got initialized as `0xFF80` (NaN, aka, _Not a Number_, in fp16 data format), it'd be `0xFC00` (-inf in fp16). (by Claude, for 1 hr)

## Code changes

The numbering of the code changes are associated with the numberings of the 4 items in the "fix description" section

1. Fix `linalg__reduce` op to add a combination op (mlir term: combiner) to perform: Output_Parameter `+=` Reducd_result_in_the_reduce_op. A simple fix was to "add one extra combiner call with inputs `reduced_tile` and `outs_tile`, and output `combined` and return it. 
2. Removed the xfail test-checker for `test_reduce_folds_outs_init`. This was specified in the issue.
3. Constant expected value adjustments, 13 lines in test_latency.py.
4. Constant adjustment, from 0xFF80 to 0xFC00, aka, NaN to _inf for fp16 data format.


## Conclusion
1. issue #85 is half way done, the easy half. 
2. part 1 of issue #85 is for multiple dimensional reduction ( number_reduce_dimension >= 2 ), working on it now. 