### PR TITLE
Multi dimension tensor reduction op (linalg.reduce) support 

### DIFF
--- a/ktir_cpu/dialects/linalg_ops.py
+++ b/ktir_cpu/dialects/linalg_ops.py
@@ -194,7 +194,6 @@ def linalg__reduce(op, context, env):
         ]
 
     dims = op.attributes.get("dims")
-    # Back-compat: legacy single-axis attribute
     if dims is None and op.attributes.get("dim") is not None:
         dims = [op.attributes["dim"]]
 

--- a/ktir_cpu/dialects/linalg_ops.py
+++ b/ktir_cpu/dialects/linalg_ops.py
@@ -207,6 +207,8 @@ def linalg__reduce(op, context, env):
         else:
             # Fold each axis, fastest-moving (rightmost) first.
             folded = tile.data
+	    # Tree-folding each axis independently reorders element groupings vs.
+	    # MLIR's left-associative scalar loop — see test_reduce_multi_axis_treefold_bug.
             for d in sorted(dims, reverse=True):
                 folded = _tree_fold(
                     Tile(folded, tile.dtype, folded.shape),

--- a/ktir_cpu/dialects/linalg_ops.py
+++ b/ktir_cpu/dialects/linalg_ops.py
@@ -193,17 +193,35 @@ def linalg__reduce(op, context, env):
             ),
         ]
 
-    dim = op.attributes.get("dim")  # axis to reduce; None → collapse all
+    dims = op.attributes.get("dims")
+    # Back-compat: legacy single-axis attribute
+    if dims is None and op.attributes.get("dim") is not None:
+        dims = [op.attributes["dim"]]
 
     outs_var = op.attributes.get("outs_var")
     outs_tile = context.get_value(outs_var) if outs_var else None
 
     if isinstance(tile, Tile):
-        folded = _tree_fold(tile, dim, bb0_names, body_ops, context, env)
-        if dim is None:
+        if dims is None:
+            # Collapse all axes: flatten then fold.
+            folded = _tree_fold(tile, None, bb0_names, body_ops, context, env)
+        else:
+            # Fold each axis, fastest-moving (rightmost) first.
+            folded = tile.data
+            for d in sorted(dims, reverse=True):
+                folded = _tree_fold(
+                    Tile(folded, tile.dtype, folded.shape),
+                    d, bb0_names, body_ops, context, env,
+                )
+
+        # Squeeze all reduced axes.
+        if dims is None:
             reduced = folded.reshape(()).astype(tile.data.dtype)
         else:
-            reduced = np.squeeze(folded, axis=dim).astype(tile.data.dtype)
+            reduced = folded
+            for d in sorted(dims, reverse=True):
+                reduced = np.squeeze(reduced, axis=d)
+            reduced = reduced.astype(tile.data.dtype)
 
         # Combine with the outs initial accumulator.
         if isinstance(outs_tile, Tile):
@@ -451,12 +469,11 @@ def parse_linalg_reduce(op_text, parse_ctx):
     if combiner_match:
         reduce_fn = combiner_match.group(1)
 
-    # dimensions = [1]
-    dim = None
+    # dimensions = [1] or dimensions = [0, 1]
+    dims = None
     dims_match = re.search(r'dimensions\s*=\s*\[(\d+(?:\s*,\s*\d+)*)\]', op_text)
     if dims_match:
         dims = [int(d.strip()) for d in dims_match.group(1).split(',')]
-        dim = dims[0]
 
     # ins(%x : type) — first operand is the input
     operands = []
@@ -471,8 +488,8 @@ def parse_linalg_reduce(op_text, parse_ctx):
         outs_var = outs_match.group(1)
 
     attributes = {"reduce_fn": reduce_fn}
-    if dim is not None:
-        attributes["dim"] = dim
+    if dims is not None:
+        attributes["dims"] = dims
     if outs_var is not None:
         attributes["outs_var"] = outs_var
 

--- a/ktir_cpu/dialects/linalg_ops.py
+++ b/ktir_cpu/dialects/linalg_ops.py
@@ -468,11 +468,12 @@ def parse_linalg_reduce(op_text, parse_ctx):
     if combiner_match:
         reduce_fn = combiner_match.group(1)
 
-    # dimensions = [1] or dimensions = [0, 1]
+    # dimensions = [1] or dimensions = [0, 1] or dimensions = []
     dims = None
-    dims_match = re.search(r'dimensions\s*=\s*\[(\d+(?:\s*,\s*\d+)*)\]', op_text)
+    dims_match = re.search(r'dimensions\s*=\s*\[([^\]]*)\]', op_text)
     if dims_match:
-        dims = [int(d.strip()) for d in dims_match.group(1).split(',')]
+        content = dims_match.group(1).strip()
+        dims = [int(d.strip()) for d in content.split(',') if d.strip()] if content else []
 
     # ins(%x : type) — first operand is the input
     operands = []

--- a/ktir_cpu/mlir_frontend/parser.py
+++ b/ktir_cpu/mlir_frontend/parser.py
@@ -422,7 +422,7 @@ def _adapt_construct_indirect_access_tile(mlir_op, attributes, result_type, oper
 @MLIRTypeAdapter.install("linalg.reduce")
 def _adapt_linalg_reduce(mlir_op, attributes, result_type, operands):
     """Extract scalar dim; synthesize outs_var and reduce_fn; drop outs from operands."""
-    attributes["dim"] = list(DenseI64ArrayAttr(mlir_op.attributes["dimensions"]))[0]
+    attributes["dims"] = list(DenseI64ArrayAttr(mlir_op.attributes["dimensions"]))
     n_ins = len(operands) // 2
     attributes["outs_var"] = operands[n_ins]
     del operands[n_ins:]  # drop outs — executor only uses ins operands

--- a/tests/test_dialects_exec.py
+++ b/tests/test_dialects_exec.py
@@ -883,8 +883,8 @@ class TestLinalg:
 
     def test_reduce_multiop_combiner(self):
         # MULTI-OP combiner: max expressed as cmpf(ogt) + select. The general
-        # tree fold must run BOTH region ops - here is no single combiner name
-        # to map to a NumPy reduction - nd still return the correct max.
+        # tree fold must run BOTH region ops - there is no single combiner name
+        # to map to a NumPy reduction - and still return the correct max.
         data = np.array([[0.1, 0.9, 0.3, 0.2, 0.5, 0.05, 0.7, 0.05]], dtype=np.float16)
         neg_inf = np.float16("-inf")
         ctx = _ctx_with(**{"%x": Tile(data, "f16", data.shape),
@@ -949,6 +949,19 @@ class TestLinalg:
                               "left-associative sequential reduction MLIR "
                               "semantics prescribe.",
                        strict=True)
+    # Tree-fold vs. MLIR sequential order for dims=[0, 1] on shape (2, 3):
+    #
+    #   data = [[a, b, c],
+    #            [d, e, f]]
+    #
+    # MLIR (scalar loop, row-major left-associative):
+    #   ((((( a + b ) + c ) + d ) + e ) + f )
+    #
+    # Tree-fold (this impl): fold axis 1 first, then axis 0:
+    #   axis-1: (a+b)+c,  (d+e)+f
+    #   axis-0: ((a+b)+c) + ((d+e)+f)
+    #
+    # These groupings differ, so f16 rounding can diverge.
     def test_reduce_multi_axis_treefold_bug(self):
         # (3,4,2) reduce dims=[0,2]. Large cancelling values at [0,:,0] and
         # [2,:,0] expose the reordering: tree fold pairs partial sums from

--- a/tests/test_dialects_exec.py
+++ b/tests/test_dialects_exec.py
@@ -839,7 +839,7 @@ class TestMath:
 
 class TestLinalg:
     def test_reduce_along_dim(self):
-        # reduce a 1×4 tile along dim 1 — result is a (1,) tile summing to 10
+        # reduce a 1x4 tile along dim 1 - result is a (1,) tile summing to 10
         data = np.array([[1, 2, 3, 4]], dtype=np.float16)
         t = Tile(data, "f16", data.shape)
         ctx = _ctx_with(**{"%x": t, "%init": Tile(np.zeros((1,), dtype=np.float16), "f16", (1,))})
@@ -883,8 +883,8 @@ class TestLinalg:
 
     def test_reduce_multiop_combiner(self):
         # MULTI-OP combiner: max expressed as cmpf(ogt) + select. The general
-        # tree fold must run BOTH region ops — there is no single combiner name
-        # to map to a NumPy reduction — and still return the correct max.
+        # tree fold must run BOTH region ops - here is no single combiner name
+        # to map to a NumPy reduction - nd still return the correct max.
         data = np.array([[0.1, 0.9, 0.3, 0.2, 0.5, 0.05, 0.7, 0.05]], dtype=np.float16)
         neg_inf = np.float16("-inf")
         ctx = _ctx_with(**{"%x": Tile(data, "f16", data.shape),
@@ -915,7 +915,7 @@ class TestLinalg:
         assert val == pytest.approx(15.0, abs=1e-2)
 
     def test_reduce_multi_axis_3d_disjoint_2d(self):
-        # dimensions = [0, 2] on a (3, 4, 2) tensor — disjoint axes.
+        # dimensions = [0, 2] on a (3, 4, 2) tensor - disjoint axes.
         # Output shape (4,): for each dim1 slot, sum over dim0 and dim2.
         data = np.arange(24, dtype=np.float16).reshape(3, 4, 2)
         expected = data.sum(axis=(0, 2))  # shape (4,)
@@ -926,6 +926,20 @@ class TestLinalg:
                        attributes={"reduce_fn": "arith.addf", "dims": [0, 2],
                                    "outs_var": "%init"})
         assert result.shape == (4,)
+        np.testing.assert_allclose(result.data, expected, rtol=1e-2)
+
+    def test_reduce_multi_axis_3d_0d(self):
+        # dimensions = [] on a (3, 4, 2) tensor - zero reduce dims is a no-op.
+        # Output shape must equal input shape; values unchanged.
+        data = np.arange(24, dtype=np.float16).reshape(3, 4, 2)
+        expected = data.copy()  # no reduction - identity
+        ctx = _ctx_with(**{"%x": Tile(data, "f16", data.shape),
+                           "%init": Tile(np.zeros_like(data), "f16", data.shape)})
+        result = _call("linalg.reduce", ctx, _make_env(),
+                       operands=["%x"],
+                       attributes={"reduce_fn": "arith.addf", "dims": [],
+                                   "outs_var": "%init"})
+        assert result.shape == (3, 4, 2)
         np.testing.assert_allclose(result.data, expected, rtol=1e-2)
 
     @pytest.mark.xfail(reason="tree-fold (pairwise halving) breaks the "

--- a/tests/test_dialects_exec.py
+++ b/tests/test_dialects_exec.py
@@ -902,21 +902,55 @@ class TestLinalg:
         val = float(result.data.flat[0]) if isinstance(result, Tile) else float(result)
         assert val == pytest.approx(float(data.max()), abs=1e-2)
 
-    @pytest.mark.xfail(reason="multi-axis reduce not supported: parser keeps only "
-                              "dims[0] and the tree fold indexes a single axis. "
-                              "Tracked in issue #85.",
-                       strict=True)
     def test_reduce_multi_axis(self):
         # dimensions = [0, 1] should reduce BOTH axes (2x3 -> scalar 15).
         data = np.arange(6, dtype=np.float16).reshape(2, 3)  # sum = 15
         ctx = _ctx_with(**{"%x": Tile(data, "f16", data.shape),
-                           "%init": Tile(np.zeros((1,), dtype=np.float16), "f16", (1,))})
+                           "%init": Tile(np.zeros((), dtype=np.float16), "f16", ())})
         result = _call("linalg.reduce", ctx, _make_env(),
                        operands=["%x"],
-                       attributes={"reduce_fn": "arith.addf", "dim": [0, 1],
+                       attributes={"reduce_fn": "arith.addf", "dims": [0, 1],
                                    "outs_var": "%init"})
         val = float(result.data.flat[0]) if isinstance(result, Tile) else float(result)
         assert val == pytest.approx(15.0, abs=1e-2)
+
+    def test_reduce_multi_axis_3d_disjoint_2d(self):
+        # dimensions = [0, 2] on a (3, 4, 2) tensor — disjoint axes.
+        # Output shape (4,): for each dim1 slot, sum over dim0 and dim2.
+        data = np.arange(24, dtype=np.float16).reshape(3, 4, 2)
+        expected = data.sum(axis=(0, 2))  # shape (4,)
+        ctx = _ctx_with(**{"%x": Tile(data, "f16", data.shape),
+                           "%init": Tile(np.zeros((4,), dtype=np.float16), "f16", (4,))})
+        result = _call("linalg.reduce", ctx, _make_env(),
+                       operands=["%x"],
+                       attributes={"reduce_fn": "arith.addf", "dims": [0, 2],
+                                   "outs_var": "%init"})
+        assert result.shape == (4,)
+        np.testing.assert_allclose(result.data, expected, rtol=1e-2)
+
+    @pytest.mark.xfail(reason="tree-fold (pairwise halving) breaks the "
+                              "linalg.reduce associativity-only contract: "
+                              "partial sums across axes reorder elements, "
+                              "producing different f16 rounding than the "
+                              "left-associative sequential reduction MLIR "
+                              "semantics prescribe.",
+                       strict=True)
+    def test_reduce_multi_axis_treefold_bug(self):
+        # (3,4,2) reduce dims=[0,2]. Large cancelling values at [0,:,0] and
+        # [2,:,0] expose the reordering: tree fold pairs partial sums from
+        # dim2 before folding dim0, changing which elements cancel first.
+        data = np.ones((3, 4, 2), dtype=np.float16)
+        data[0, :, 0] = 10000
+        data[2, :, 0] = -10000
+        expected = data.sum(axis=(0, 2))  # numpy left-associative: [1,1,1,1]
+        ctx = _ctx_with(**{"%x": Tile(data, "f16", data.shape),
+                           "%init": Tile(np.zeros((4,), dtype=np.float16), "f16", (4,))})
+        result = _call("linalg.reduce", ctx, _make_env(),
+                       operands=["%x"],
+                       attributes={"reduce_fn": "arith.addf", "dims": [0, 2],
+                                   "outs_var": "%init"})
+        assert result.shape == (4,)
+        np.testing.assert_allclose(result.data, expected, rtol=1e-2)
 
     def test_reduce_folds_outs_init(self):
         # MLIR semantics: outs is the initial accumulator. sum([1,2,3,4]) with

--- a/tests/test_dialects_parse.py
+++ b/tests/test_dialects_parse.py
@@ -467,7 +467,7 @@ class TestLinalgParsers(ParseTestMixin):
         )
         self.assert_op_type(op, "linalg.reduce")
         self.assert_attribute(op, "reduce_fn", "arith.maxnumf")
-        self.assert_attribute(op, "dim", 1)
+        self.assert_attribute(op, "dims", [1])
         self.assert_num_operands(op, 1)
         self.assert_operand_names(op, "%x")
 

--- a/tests/test_dialects_parse.py
+++ b/tests/test_dialects_parse.py
@@ -471,6 +471,30 @@ class TestLinalgParsers(ParseTestMixin):
         self.assert_num_operands(op, 1)
         self.assert_operand_names(op, "%x")
 
+    def test_reduce_empty_dims(self):
+        # dimensions = [] means zero reduce dimensions (shape-preserving no-op)
+        op = self._parse(
+            "%r = linalg.reduce { arith.addf }"
+            " ins(%x : tensor<4x8xf16>)"
+            " outs(%init : tensor<4x8xf16>)"
+            " dimensions = []",
+            args={"%x": "tensor<4x8xf16>", "%init": "tensor<4x8xf16>"},
+        )
+        self.assert_op_type(op, "linalg.reduce")
+        self.assert_attribute(op, "dims", [])
+
+    def test_reduce_multi_dims(self):
+        # dimensions = [0, 2] - multiple axes
+        op = self._parse(
+            "%r = linalg.reduce { arith.addf }"
+            " ins(%x : tensor<2x3x4xf16>)"
+            " outs(%init : tensor<3xf16>)"
+            " dimensions = [0, 2]",
+            args={"%x": "tensor<2x3x4xf16>", "%init": "tensor<3xf16>"},
+        )
+        self.assert_op_type(op, "linalg.reduce")
+        self.assert_attribute(op, "dims", [0, 2])
+
     def test_fill(self):
         # fill records both ins and outs operands
         op = self._parse(


### PR DESCRIPTION
Issue #85 request 1

## Operational design requirements with Claude: 

1. augment linalg.reduce support with tree_fold for multiple-dimension reduction
2. the number of reduce dimensions will be from 0 to number_of_dimensions of the inputy tensor
3. the reduce dimension can be adjecent or not adjecent.
4. the reduce operator does not have assumed commutativity, only with associativity.

## Implementation planning (penned by Claude): 

1. Parse and preserve the full dimensions list (no truncation to dims[0]).
2. Sort dimensions descending — rightmost (fastest-moving) axis folds first, matching linalg.reduce's innermost-first iteration order.
3. Loop _tree_fold once per axis; 
4. After all folds complete, squeeze all reduced axes together and combine with outs.

## Tests involved: 

1. `test_reduce_multi_axis`  --> expected to pass
2. `test_reduce_multi_axis_3d_disjoint_2d`. --> expected to pass
3. `test_reduce_multi_axis_treefold_bug`. --> expected to fail
4. TestLinalgParsers::test_reduce --> to intake 'dims' instead of 'dim'

## Next openings: tree_fold is not MLIR complied

MLIR's upstream documentation **does not** explicitly require **commutativity** for `linalg.reduce combiners` — only **associativity**. This is corroborated by IREE's documentation which states: "The combiner must be associative. It does not need to be commutative." In practice, all standard combiners used today (arith.addf, arith.maximumf, arith.mulf) happen to be commutative, but the spec does not contract on it — meaning **an implementation that reorders elements (as our tree fold does across disjoint axes) technically violates the semantics for a non-commutative associative combiner.** (penned by Claude).

