### PR TITLE
feat: per-unit roofline model + latency demo notebook

### DIFF
--- a/docs/latency.md
+++ b/docs/latency.md
@@ -1,5 +1,14 @@
 # Latency Estimation
 
+> **Notebook maintenance:** `notebooks/latency_demo.ipynb` is the live demo for this doc.
+> Update it (and re-run if keeping executed outputs) when changing:
+> - `HardwareConfig` fields or defaults
+> - `LatencyReport` / `CoreLatencyCounters` API
+> - `roofline()` return shape
+> - any cycle-cost formula in `_estimate()`
+>
+> The notebook covers: matmul, softmax, sdpa, indexed_add — add new example kernels there when they become interesting.
+
 The interpreter can estimate cycle-approximate execution latency on Spyre hardware without access to real hardware. This is **opt-in** — pass a `HardwareConfig` to enable it. When disabled (the default), there is zero overhead and existing behavior is unchanged.
 
 ```python

--- a/ktir_cpu/latency.py
+++ b/ktir_cpu/latency.py
@@ -109,33 +109,43 @@ class _TraceEntry:
     """Single operation trace entry."""
     op_type: str
     cycles: float
-    category: str  # "compute", "memory", "comm", "zero"
+    category: str
 
 
 @dataclass
 class CoreLatencyCounters:
     """Per-core cycle counters."""
-    compute_cycles: float = 0.0
     memory_cycles: float = 0.0
     comm_cycles: float = 0.0
-    total_flops: float = 0.0
     total_bytes: int = 0
+    # Per-category flops and cycles — keys are LatencyCategory string values.
+    # Compute categories: "compute_matmul", "compute_float", "compute_transcendental", "compute_int".
+    flops_by_category: Dict[str, float] = field(default_factory=dict)
+    cycles_by_category: Dict[str, float] = field(default_factory=dict)
     trace: Optional[List[_TraceEntry]] = None
 
     @property
     def total_cycles(self) -> float:
         return self.compute_cycles + self.memory_cycles + self.comm_cycles
 
+    @property
+    def compute_cycles(self) -> float:
+        return sum(self.cycles_by_category.values())
+
+    @property
+    def total_flops(self) -> float:
+        return sum(self.flops_by_category.values())
+
     def record(self, category: str, cycles: float, op_type: str = "",
                flops: float = 0.0, nbytes: int = 0):
-        if category == "compute":
-            self.compute_cycles += cycles
+        if category == "compute" or category.startswith("compute_"):
+            self.cycles_by_category[category] = self.cycles_by_category.get(category, 0.0) + cycles
+            self.flops_by_category[category] = self.flops_by_category.get(category, 0.0) + flops
         elif category == "memory":
             self.memory_cycles += cycles
         elif category == "comm":
             self.comm_cycles += cycles
 
-        self.total_flops += flops
         self.total_bytes += nbytes
 
         if self.trace is not None:
@@ -215,7 +225,7 @@ class LatencyTracker:
             m, n, k = self._matmul_dims(operands)
             flops = 2.0 * m * n * k
             cycles = flops / self.config.systolic_flops_per_cycle
-            return ("compute", cycles, flops, 0)
+            return (str(LC.COMPUTE_MATMUL), cycles, flops, 0)
 
         if category == LC.COMPUTE_TRANSCENDENTAL:
             # Transcendentals (exp, log, …): 1 FLOP per element, same
@@ -224,14 +234,14 @@ class LatencyTracker:
             # increase the FLOP count.
             n_elems = self._num_elements(result, operands)
             cycles = (n_elems / self.config.simd_elements_per_cycle) * self.config.transcendental_penalty
-            return ("compute", cycles, float(n_elems), 0)
+            return (str(LC.COMPUTE_TRANSCENDENTAL), cycles, float(n_elems), 0)
 
         if category == LC.COMPUTE_FLOAT:
             # Elementwise float (addf, mulf, …): 1 FLOP per element,
             # one SIMD-width per cycle.  No memory traffic.
             n_elems = self._num_elements(result, operands)
             cycles = n_elems / self.config.simd_elements_per_cycle
-            return ("compute", cycles, float(n_elems), 0)
+            return (str(LC.COMPUTE_FLOAT), cycles, float(n_elems), 0)
 
         if category == LC.COMPUTE_INT:
             # Integer ops (addi, muli, index casts, …): 1 FLOP per element.
@@ -239,9 +249,9 @@ class LatencyTracker:
             if n_elems <= 1:
                 # Scalar index arithmetic (e.g. address/offset computation) is
                 # resolved at compile time and has no runtime cost.
-                return ("compute", 0.0, 0.0, 0)
+                return (str(LC.COMPUTE_INT), 0.0, 0.0, 0)
             cycles = n_elems / self.config.simd_elements_per_cycle
-            return ("compute", cycles, float(n_elems), 0)
+            return (str(LC.COMPUTE_INT), cycles, float(n_elems), 0)
 
         if category == LC.COMM:
             # Ring communication (allgather, reduce, …): bytes over
@@ -428,19 +438,19 @@ class LatencyReport:
             })
         return summaries
 
-    def roofline(self) -> Dict[str, float]:
-        """Compute roofline metrics for the critical-path core.
+    def roofline(self) -> Dict[str, Any]:
+        """Compute per-unit roofline metrics for the critical-path core.
 
-        The roofline model shows the maximum achievable performance as a
-        function of a kernel's arithmetic intensity (AI = FLOPs / bytes
-        transferred).  Two hardware limits form a "roof"::
+        Two compute units are modelled (systolic for matmul, SIMD for everything
+        else).  The dominant unit — whichever accumulated the most FLOPs — sets
+        the compute ceiling.  The chart shows one roof::
 
             GFLOP/s
               ^
-              |         peak_gflops
-              |        .-----------——————————  compute ceiling
+              |         peak (dominant unit)
+              |        .----------------------------  compute ceiling
               |       /
-              |      /    * achieved (kernel)
+              |      /    * kernel dot
               |     /
               |    /
               |   /  BW ceiling = peak_bw × AI
@@ -448,76 +458,86 @@ class LatencyReport:
               | /
               +-----------------------------------> AI (FLOP/B)
                        ^
-                  ridge_point
+                  ridge point
 
-        - **BW ceiling** (the slope): ``peak_bw × AI``.  When a kernel
-          has low AI it cannot feed the compute units fast enough and
-          performance is limited by memory bandwidth.
-        - **Compute ceiling** (the flat top): ``peak_gflops``.  Once AI
-          is high enough the compute units are fully utilized.
-        - **Ridge point**: the AI where the two ceilings meet,
-          ``peak_gflops / peak_bw``.  Left of it the kernel is
-          memory-bound; right of it, compute-bound.
-        - **Efficiency**: ``achieved / ceiling`` — how close the kernel
-          gets to the roofline at its operating point.
 
-        .. note:: The roofline model only covers compute and HBM bandwidth.
+
+        - **systolic**: ``linalg.matmul`` ops, peak = ``systolic_flops_per_cycle × clock``
+        - **simd**: all other compute ops (float, transcendental, int),
+          peak = ``simd_elements_per_cycle × clock``
+
+        The **dominant unit** is whichever accumulated the most FLOPs in the
+        kernel trace — it reflects which unit did the real work.  The summary
+        ``efficiency`` is reported for the dominant unit.
+
+        For each unit, ``achieved_gflops`` is ``unit_flops / total_wall_time``
+        (not unit_flops / unit_cycles) so the achieved rate reflects true
+        end-to-end throughput including memory stalls.
+
+        .. note:: The roofline covers compute and HBM bandwidth only.
            Communication cycles (ring allgather/reduce) are not modelled.
-           For comm-dominated kernels the ``bottleneck`` property may
-           report ``"comm"`` while the roofline classifies the kernel
-           based on the compute-vs-HBM ratio alone.  For kernels where
-           the bottleneck is ``"compute"`` or ``"memory"``, the roofline
-           bound (AI vs ridge point) will always agree with ``bottleneck``.
 
         Returns a dict with:
-            arithmetic_intensity: FLOPs / byte transferred (FLOP/B).
-            achieved_gflops: Actual throughput of the critical-path core.
-            peak_gflops: Hardware peak compute throughput.
+            arithmetic_intensity: total FLOPs / total bytes (FLOP/B).
             peak_bw_gb_s: Per-core HBM bandwidth in GB/s.
-            ridge_point: AI where BW ceiling meets compute ceiling.
-            ceiling_gflops: Roofline ceiling at this kernel's AI.
-            efficiency: achieved / ceiling (0..1).
+            dominant_unit: ``"systolic"`` or ``"simd"`` (most FLOPs).
+            efficiency: achieved / ceiling for the dominant unit (0..1).
+            units: per-unit dict, each with:
+                achieved_gflops, ceiling_gflops, ridge_point, efficiency.
         """
         if not self.counters:
             return {}
         critical = max(self.counters.values(), key=lambda c: c.total_cycles)
 
-        # Clock in Hz (e.g. 1.0 GHz → 1e9 cycles/s)
         clock = self.config.clock_ghz * 1e9
-
-        # The flat top of the roof: how many FLOPs/s the SIMD pipe can
-        # sustain if it never stalls on memory.
-        peak_flops = self.config.simd_elements_per_cycle * clock
-
-        # The slope of the roof: how many bytes/s HBM can deliver to
-        # this core.  Multiplied by AI this gives the BW ceiling.
+        elapsed_s = critical.total_cycles / clock
         peak_bw = self.config.hbm_bytes_per_cycle_per_core * clock
 
-        # Where the slope meets the flat top (FLOP/B).  Kernels with
-        # AI < ridge_point are memory-bound; AI > ridge_point are
-        # compute-bound.
-        ridge_point = peak_flops / peak_bw
+        ai = (critical.total_flops / critical.total_bytes
+              if critical.total_bytes > 0 else float('inf'))
 
-        # Achieved throughput: total FLOPs the kernel executed divided
-        # by wall-clock time on this core.
-        elapsed_s = critical.total_cycles / clock
-        achieved_flops = critical.total_flops / elapsed_s if elapsed_s > 0 else 0
+        # Per-unit hardware ceilings (hardware constants, not kernel-derived).
+        unit_ceilings = {
+            "systolic": self.config.systolic_flops_per_cycle * clock,
+            "simd": self.config.simd_elements_per_cycle * clock,
+        }
 
-        # Arithmetic intensity: how many FLOPs per byte of HBM traffic.
-        # Higher AI means more reuse of each byte loaded.
-        ai = critical.total_flops / critical.total_bytes if critical.total_bytes > 0 else float('inf')
+        # Which LatencyCategory strings belong to each unit.
+        _LC = LatencyCategory
+        unit_categories = {
+            "systolic": {str(_LC.COMPUTE_MATMUL)},
+            "simd": {str(_LC.COMPUTE_FLOAT), str(_LC.COMPUTE_TRANSCENDENTAL), str(_LC.COMPUTE_INT)},
+        }
 
-        # The roofline ceiling at this kernel's AI: the lower of the
-        # two ceilings (BW slope vs compute flat top).
-        ceiling = min(peak_flops, peak_bw * ai)
+        units: Dict[str, Any] = {}
+        for unit_name, peak in unit_ceilings.items():
+            cats = unit_categories[unit_name]
+            flops = sum(critical.flops_by_category.get(c, 0.0) for c in cats)
+            achieved = flops / elapsed_s if elapsed_s > 0 else 0.0
+            # Roofline ceiling at this kernel's AI for this unit.
+            ceiling = min(peak, peak_bw * ai)
+            units[unit_name] = {
+                "achieved_gflops": achieved / 1e9,
+                "ceiling_gflops": ceiling / 1e9,
+                "ridge_point": peak / peak_bw,
+                "efficiency": achieved / ceiling if ceiling > 0 else 0.0,
+            }
+
+        # Dominant unit = most FLOPs. Fall back to "simd" when no compute.
+        dominant = max(
+            unit_ceilings,
+            key=lambda u: sum(critical.flops_by_category.get(c, 0.0)
+                              for c in unit_categories[u]),
+        )
+        if all(units[u]["achieved_gflops"] == 0.0 for u in units):
+            dominant = "simd"
+
         return {
             "arithmetic_intensity": ai,
-            "achieved_gflops": achieved_flops / 1e9,
-            "peak_gflops": peak_flops / 1e9,
             "peak_bw_gb_s": peak_bw / 1e9,
-            "ridge_point": ridge_point,
-            "ceiling_gflops": ceiling / 1e9,
-            "efficiency": achieved_flops / ceiling if ceiling > 0 else 0,
+            "dominant_unit": dominant,
+            "efficiency": units[dominant]["efficiency"],
+            "units": units,
         }
 
     def summary_dict(self) -> Dict[str, Any]:
@@ -561,12 +581,21 @@ class LatencyReport:
             ai = rf["arithmetic_intensity"]
             ai_str = f"{ai:.2f} FLOP/B" if ai != float('inf') else "inf (no memory traffic)"
             lines.append(f"  Arithmetic intensity : {ai_str}")
-            lines.append(f"  Achieved             : {rf['achieved_gflops']:.2f} GFLOP/s")
-            lines.append(f"  Roofline ceiling     : {rf['ceiling_gflops']:.2f} GFLOP/s")
-            lines.append(f"  Peak compute         : {rf['peak_gflops']:.2f} GFLOP/s")
             lines.append(f"  Peak bandwidth       : {rf['peak_bw_gb_s']:.2f} GB/s")
-            lines.append(f"  Ridge point          : {rf['ridge_point']:.2f} FLOP/B")
-            lines.append(f"  Efficiency           : {rf['efficiency']:.1%}")
+            lines.append(f"  Dominant unit        : {rf['dominant_unit']}")
+            lines.append(f"  Efficiency           : {rf['efficiency']:.1%}  (dominant unit)")
+            lines.append("")
+            lines.append(f"  {'Unit':>10}  {'Achieved':>12}  {'Ceiling':>12}  {'Ridge':>10}  {'Eff':>7}")
+            lines.append(f"  {'-'*10}  {'-'*12}  {'-'*12}  {'-'*10}  {'-'*7}")
+            for unit_name, u in rf["units"].items():
+                marker = " *" if unit_name == rf["dominant_unit"] else "  "
+                lines.append(
+                    f"{marker} {unit_name:>10}  "
+                    f"{u['achieved_gflops']:>10.2f} G  "
+                    f"{u['ceiling_gflops']:>10.2f} G  "
+                    f"{u['ridge_point']:>8.1f} F/B  "
+                    f"{u['efficiency']:>6.1%}"
+                )
             lines.append("=" * 60)
 
         return "\n".join(lines)

--- a/ktir_cpu/latency.py
+++ b/ktir_cpu/latency.py
@@ -138,7 +138,7 @@ class CoreLatencyCounters:
 
     def record(self, category: str, cycles: float, op_type: str = "",
                flops: float = 0.0, nbytes: int = 0):
-        if category == "compute" or category.startswith("compute_"):
+        if category.startswith("compute_"):
             self.cycles_by_category[category] = self.cycles_by_category.get(category, 0.0) + cycles
             self.flops_by_category[category] = self.flops_by_category.get(category, 0.0) + flops
         elif category == "memory":

--- a/notebooks/latency_demo.ipynb
+++ b/notebooks/latency_demo.ipynb
@@ -1,0 +1,844 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# KTIR Latency Estimation Demo\n",
+    "\n",
+    "This notebook shows how to use `ktir_cpu` to get cycle-approximate latency estimates\n",
+    "for KTIR kernels — no Spyre hardware required.\n",
+    "\n",
+    "**What we cover:**\n",
+    "1. Load a kernel and run it (regex parser, no extra dependencies)\n",
+    "2. Inspect the `LatencyReport` — cycles, time, bottleneck, roofline\n",
+    "3. Compare two kernels (matmul vs softmax)\n",
+    "4. Multi-kernel roofline: matmul, softmax, sdpa, paged attention\n",
+    "5. Per-op trace: paged attention (indirect K/V loads via block_tables)\n",
+    "6. Tune `HardwareConfig` to model different hardware targets\n",
+    "7. Using the MLIR frontend parser (optional, requires `mlir_ktdp`)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "```bash\n",
+    "uv sync --group dev   # installs jupyter + matplotlib\n",
+    "```\n",
+    "\n",
+    "Then launch:\n",
+    "\n",
+    "```bash\n",
+    "uv run jupyter notebook notebooks/latency_demo.ipynb\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os, pathlib\n",
+    "import numpy as np\n",
+    "from ktir_cpu.interpreter import KTIRInterpreter\n",
+    "from ktir_cpu.latency import HardwareConfig\n",
+    "\n",
+    "# Resolve paths relative to the repo root regardless of launch directory.\n",
+    "# The notebook lives in notebooks/, so the repo root is one level up.\n",
+    "_REPO = pathlib.Path(__file__).parent.parent if \"__file__\" in dir() else pathlib.Path.cwd()\n",
+    "if not (_REPO / \"examples\" / \"latency\").exists():\n",
+    "    _REPO = _REPO.parent   # launched from notebooks/\n",
+    "_LATENCY = _REPO / \"examples\" / \"latency\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "def plot_roofline(hw: HardwareConfig, kernels: list[tuple[str, object]], title: str = \"Roofline\") -> None:\n",
+    "    \"\"\"One subplot per dominant unit (stacked vertically); x-axis zoomed to kernel region.\"\"\"\n",
+    "    clock   = hw.clock_ghz * 1e9\n",
+    "    peak_bw = hw.hbm_bytes_per_cycle_per_core * clock / 1e9  # GB/s per-core\n",
+    "\n",
+    "    unit_peaks = {\n",
+    "        \"systolic\": hw.systolic_flops_per_cycle * clock / 1e9,\n",
+    "        \"simd\":     hw.simd_elements_per_cycle  * clock / 1e9,\n",
+    "    }\n",
+    "\n",
+    "    rfs = [(name, rep.roofline()) for name, rep in kernels]\n",
+    "\n",
+    "    from collections import defaultdict\n",
+    "    groups: dict[str, list] = defaultdict(list)\n",
+    "    for name, rf in rfs:\n",
+    "        groups[rf[\"dominant_unit\"]].append((name, rf))\n",
+    "\n",
+    "    n_panels = len(groups)\n",
+    "    fig, axes = plt.subplots(n_panels, 1, figsize=(7, 4 * n_panels), squeeze=False)\n",
+    "    fig.suptitle(title, fontsize=12)\n",
+    "\n",
+    "    colors = plt.rcParams[\"axes.prop_cycle\"].by_key()[\"color\"]\n",
+    "\n",
+    "    for row, (unit, kgroup) in enumerate(groups.items()):\n",
+    "        ax = axes[row][0]\n",
+    "        peak_gflops = unit_peaks[unit]\n",
+    "        ridge       = peak_gflops / peak_bw\n",
+    "\n",
+    "        ais       = [rf[\"arithmetic_intensity\"] for _, rf in kgroup]\n",
+    "        achieveds = [rf[\"units\"][unit][\"achieved_gflops\"] for _, rf in kgroup]\n",
+    "        max_ai    = max(ais)\n",
+    "\n",
+    "        if ridge <= max_ai * 3:\n",
+    "            ai_max = ridge * 1.3\n",
+    "            show_ridge_in_plot = True\n",
+    "        else:\n",
+    "            ai_max = max_ai * 2.5\n",
+    "            show_ridge_in_plot = False\n",
+    "\n",
+    "        ai_range = np.linspace(0, ai_max, 400)\n",
+    "        roof     = np.minimum(peak_bw * ai_range, peak_gflops)\n",
+    "\n",
+    "        ax.plot(ai_range, roof, color=\"gray\", linewidth=2, label=\"Roofline\")\n",
+    "\n",
+    "        if show_ridge_in_plot:\n",
+    "            ax.axvline(ridge, color=\"gray\", linestyle=\"--\", linewidth=1, alpha=0.6)\n",
+    "            ax.text(ridge * 1.02, peak_gflops * 0.5,\n",
+    "                    f\"ridge={ridge:.1f} F/B\", color=\"gray\", fontsize=8, va=\"center\")\n",
+    "        else:\n",
+    "            ax.axhline(peak_gflops, color=\"gray\", linestyle=\"--\", linewidth=1, alpha=0.5)\n",
+    "            ax.annotate(\n",
+    "                f\"ridge={ridge:.0f} F/B →\",\n",
+    "                xy=(ai_max, peak_bw * ai_max),\n",
+    "                xytext=(ai_max * 0.82, (peak_bw * ai_max) * 1.22),\n",
+    "                fontsize=8, color=\"gray\",\n",
+    "                arrowprops=dict(arrowstyle=\"->\", color=\"gray\", lw=1),\n",
+    "            )\n",
+    "\n",
+    "        for i, (name, rf) in enumerate(kgroup):\n",
+    "            u        = rf[\"units\"][unit]\n",
+    "            achieved = u[\"achieved_gflops\"]\n",
+    "            ceiling  = u[\"ceiling_gflops\"]\n",
+    "            eff      = u[\"efficiency\"]\n",
+    "            ai       = rf[\"arithmetic_intensity\"]\n",
+    "            c        = colors[i % len(colors)]\n",
+    "\n",
+    "            ax.scatter(ai, achieved, s=90, zorder=5, color=c,\n",
+    "                       label=f\"{name}  (AI={ai:.2f} F/B, {achieved:.1f} GFLOP/s, eff={eff:.0%})\")\n",
+    "            ax.plot([ai, ai], [achieved, min(ceiling, (peak_bw * ai_max) * 1.5)],\n",
+    "                    color=c, lw=1, linestyle=\"dotted\")\n",
+    "\n",
+    "        y_top = (peak_bw * ai_max * 1.3) if not show_ridge_in_plot else peak_gflops * 1.15\n",
+    "        ax.set_xlim(left=0, right=ai_max)\n",
+    "        ax.set_ylim(bottom=0, top=y_top)\n",
+    "        ax.set_xlabel(\"Arithmetic intensity (FLOP/B)\", fontsize=10)\n",
+    "        ax.set_ylabel(\"Performance (GFLOP/s)\", fontsize=10)\n",
+    "        ax.set_title(f\"Dominant unit: {unit}\", fontsize=10)\n",
+    "        ax.legend(fontsize=8, loc=\"upper left\")\n",
+    "        ax.grid(True, linestyle=\":\", alpha=0.4)\n",
+    "\n",
+    "    plt.tight_layout()\n",
+    "    plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Matmul — load, run, report\n",
+    "\n",
+    "**Kernel:** `examples/latency/matmul_small.mlir`  \n",
+    "Grid `[2, 2]` (4 cores), each core accumulates an 8×32 output tile over K=64 steps."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hw = HardwareConfig()\n",
+    "\n",
+    "interp = KTIRInterpreter(latency_config=hw)\n",
+    "interp.load(str(_LATENCY / \"matmul_small.mlir\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Max abs error: 0.015625\n"
+     ]
+    }
+   ],
+   "source": [
+    "M, K, N = 16, 64, 64\n",
+    "a = np.random.rand(M, K).astype(np.float16)\n",
+    "b = np.random.rand(K, N).astype(np.float16)\n",
+    "c = np.zeros((M, N), dtype=np.float16)\n",
+    "\n",
+    "outputs = interp.execute_function(\n",
+    "    \"matmul_kernel_small\",\n",
+    "    a_ptr=a, b_ptr=b, c_ptr=c,\n",
+    "    K=K, BLOCK_SIZE_M=8, BLOCK_SIZE_N=32, BLOCK_SIZE_K=32,\n",
+    ")\n",
+    "\n",
+    "# Verify correctness against NumPy\n",
+    "expected = a @ b\n",
+    "print(\"Max abs error:\", np.max(np.abs(outputs[\"c_ptr\"].astype(np.float32) - expected.astype(np.float32))))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "============================================================\n",
+      "KTIR Latency Estimation Report\n",
+      "============================================================\n",
+      "  Kernel cycles : 352\n",
+      "  Kernel time   : 0.352 us\n",
+      "  Bottleneck    : memory\n",
+      "  Cores         : 4\n",
+      "------------------------------------------------------------\n",
+      "  Core       Compute        Memory          Comm         Total\n",
+      "------------------------------------------------------------\n",
+      "     0             8           344             0           352\n",
+      "     1             8           344             0           352\n",
+      "     2             8           344             0           352\n",
+      "     3             8           344             0           352\n",
+      "============================================================\n",
+      "\n",
+      "Roofline Analysis (critical-path core)\n",
+      "------------------------------------------------------------\n",
+      "  Arithmetic intensity : 3.10 FLOP/B\n",
+      "  Peak bandwidth       : 31.25 GB/s\n",
+      "  Dominant unit        : systolic\n",
+      "  Efficiency           : 96.2%  (dominant unit)\n",
+      "\n",
+      "        Unit      Achieved       Ceiling       Ridge      Eff\n",
+      "  ----------  ------------  ------------  ----------  -------\n",
+      " *   systolic       93.06 G       96.73 G   16777.2 F/B   96.2%\n",
+      "         simd        1.45 G       64.00 G       2.0 F/B    2.3%\n",
+      "============================================================\n"
+     ]
+    }
+   ],
+   "source": [
+    "report = interp.get_latency_report()\n",
+    "print(report)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Reading the report\n",
+    "\n",
+    "| Field | Meaning |\n",
+    "|---|---|\n",
+    "| `kernel_cycles` | Max total cycles across all cores (critical path) |\n",
+    "| `kernel_time_us` | Cycles ÷ clock (default 1 GHz → 1 cycle = 1 ns) |\n",
+    "| `bottleneck` | Which category dominates the critical-path core: `compute`, `memory`, or `comm` |\n",
+    "| Per-core table | `compute_cycles`, `memory_cycles`, `comm_cycles` per core |\n",
+    "| Arithmetic intensity | FLOPs ÷ bytes transferred (FLOP/B) |\n",
+    "| Ridge point | AI where BW ceiling meets compute ceiling — left = memory-bound, right = compute-bound |"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Kernel cycles : 352\n",
+      "Kernel time   : 0.352 us\n",
+      "Bottleneck    : memory\n",
+      "\n",
+      "Roofline summary  (dominant unit: systolic)\n",
+      "  Arithmetic intensity : 3.10 FLOP/B\n",
+      "  Ridge point          : 16777.22 FLOP/B\n",
+      "  Efficiency           : 96.2%\n",
+      "  Kernel is memory-bound\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f\"Kernel cycles : {report.kernel_cycles:,.0f}\")\n",
+    "print(f\"Kernel time   : {report.kernel_time_us:.3f} us\")\n",
+    "print(f\"Bottleneck    : {report.bottleneck}\")\n",
+    "\n",
+    "rf = report.roofline()\n",
+    "dominant = rf[\"dominant_unit\"]\n",
+    "u = rf[\"units\"][dominant]\n",
+    "print(f\"\\nRoofline summary  (dominant unit: {dominant})\")\n",
+    "print(f\"  Arithmetic intensity : {rf['arithmetic_intensity']:.2f} FLOP/B\")\n",
+    "print(f\"  Ridge point          : {u['ridge_point']:.2f} FLOP/B\")\n",
+    "print(f\"  Efficiency           : {rf['efficiency']:.1%}\")\n",
+    "print(f\"  Kernel is {'compute-bound' if rf['arithmetic_intensity'] >= u['ridge_point'] else 'memory-bound'}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Per-core breakdown"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "core       compute        memory          comm         total\n",
+      "------------------------------------------------------------\n",
+      "   0             8           344             0           352\n",
+      "   1             8           344             0           352\n",
+      "   2             8           344             0           352\n",
+      "   3             8           344             0           352\n"
+     ]
+    }
+   ],
+   "source": [
+    "per_core = report.per_core_summary()\n",
+    "header = f\"{'core':>4}  {'compute':>12}  {'memory':>12}  {'comm':>12}  {'total':>12}\"\n",
+    "print(header)\n",
+    "print(\"-\" * len(header))\n",
+    "for row in per_core:\n",
+    "    print(f\"{row['core_id']:>4}  {row['compute_cycles']:>12.0f}  \"\n",
+    "          f\"{row['memory_cycles']:>12.0f}  {row['comm_cycles']:>12.0f}  \"\n",
+    "          f\"{row['total_cycles']:>12.0f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Softmax — compare with matmul"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "============================================================\n",
+      "KTIR Latency Estimation Report\n",
+      "============================================================\n",
+      "  Kernel cycles : 28\n",
+      "  Kernel time   : 0.028 us\n",
+      "  Bottleneck    : memory\n",
+      "  Cores         : 32\n",
+      "------------------------------------------------------------\n",
+      "  Core       Compute        Memory          Comm         Total\n",
+      "------------------------------------------------------------\n",
+      "     0            12            16             0            28\n",
+      "     1            12            16             0            28\n",
+      "     2            12            16             0            28\n",
+      "     3            12            16             0            28\n",
+      "     4            12            16             0            28\n",
+      "     5            12            16             0            28\n",
+      "     6            12            16             0            28\n",
+      "     7            12            16             0            28\n",
+      "     8            12            16             0            28\n",
+      "     9            12            16             0            28\n",
+      "    10            12            16             0            28\n",
+      "    11            12            16             0            28\n",
+      "    12            12            16             0            28\n",
+      "    13            12            16             0            28\n",
+      "    14            12            16             0            28\n",
+      "    15            12            16             0            28\n",
+      "    16            12            16             0            28\n",
+      "    17            12            16             0            28\n",
+      "    18            12            16             0            28\n",
+      "    19            12            16             0            28\n",
+      "    20            12            16             0            28\n",
+      "    21            12            16             0            28\n",
+      "    22            12            16             0            28\n",
+      "    23            12            16             0            28\n",
+      "    24            12            16             0            28\n",
+      "    25            12            16             0            28\n",
+      "    26            12            16             0            28\n",
+      "    27            12            16             0            28\n",
+      "    28            12            16             0            28\n",
+      "    29            12            16             0            28\n",
+      "    30            12            16             0            28\n",
+      "    31            12            16             0            28\n",
+      "============================================================\n",
+      "\n",
+      "Roofline Analysis (critical-path core)\n",
+      "------------------------------------------------------------\n",
+      "  Arithmetic intensity : 0.76 FLOP/B\n",
+      "  Peak bandwidth       : 31.25 GB/s\n",
+      "  Dominant unit        : simd\n",
+      "  Efficiency           : 57.6%  (dominant unit)\n",
+      "\n",
+      "        Unit      Achieved       Ceiling       Ridge      Eff\n",
+      "  ----------  ------------  ------------  ----------  -------\n",
+      "     systolic        0.00 G       23.68 G   16777.2 F/B    0.0%\n",
+      " *       simd       13.64 G       23.68 G       2.0 F/B   57.6%\n",
+      "============================================================\n"
+     ]
+    }
+   ],
+   "source": [
+    "softmax_interp = KTIRInterpreter(latency_config=hw)\n",
+    "softmax_interp.load(str(_LATENCY / \"softmax_small.mlir\"))\n",
+    "\n",
+    "n_rows = 64\n",
+    "input_data  = np.random.randn(n_rows, 64).astype(np.float16)\n",
+    "output_data = np.zeros((n_rows, 64), dtype=np.float16)\n",
+    "\n",
+    "softmax_interp.execute_function(\n",
+    "    \"softmax_kernel_small\",\n",
+    "    output_ptr=output_data, input_ptr=input_data,\n",
+    "    n_rows=n_rows,\n",
+    ")\n",
+    "\n",
+    "softmax_report = softmax_interp.get_latency_report()\n",
+    "print(softmax_report)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "matmul      cycles=   352  bottleneck=memory    AI=3.10 FLOP/B  efficiency=96.2%\n",
+      "softmax     cycles=    28  bottleneck=memory    AI=0.76 FLOP/B  efficiency=57.6%\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Side-by-side comparison\n",
+    "for name, r in [(\"matmul\", report), (\"softmax\", softmax_report)]:\n",
+    "    rf = r.roofline()\n",
+    "    print(f\"{name:10s}  cycles={r.kernel_cycles:6.0f}  \"\n",
+    "          f\"bottleneck={r.bottleneck:8s}  \"\n",
+    "          f\"AI={rf['arithmetic_intensity']:.2f} FLOP/B  \"\n",
+    "          f\"efficiency={rf['efficiency']:.1%}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Multi-kernel roofline\n",
+    "\n",
+    "Run four kernels through the latency estimator and plot them together:\n",
+    "- **matmul_small** and **sdpa** — systolic-dominant (matmul ops)\n",
+    "- **softmax** and **indexed_add** — simd-dominant (elementwise / transcendental ops)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "matmul_small     cycles=   352  bottleneck=memory    AI=  3.10 F/B  dom=systolic  eff=96.2%\n",
+      "softmax          cycles=    28  bottleneck=memory    AI=  0.76 F/B  dom=simd      eff=57.6%\n",
+      "sdpa             cycles=   638  bottleneck=memory    AI= 16.25 F/B  dom=systolic  eff=80.9%\n",
+      "paged_attn       cycles=  2728  bottleneck=memory    AI=  7.80 F/B  dom=systolic  eff=78.9%\n"
+     ]
+    }
+   ],
+   "source": [
+    "_TRITON = _REPO / \"examples\" / \"triton-ktir\"\n",
+    "\n",
+    "def _run(path, func_name, tensor_kwargs, scalar_kwargs={}):\n",
+    "    interp = KTIRInterpreter(latency_config=hw)\n",
+    "    interp.load(str(path))\n",
+    "    interp.execute_function(func_name, **tensor_kwargs, **scalar_kwargs)\n",
+    "    return interp.get_latency_report()\n",
+    "\n",
+    "rng = np.random.default_rng(0)\n",
+    "\n",
+    "sdpa_report = _run(\n",
+    "    _TRITON / \"sdpa_2d.mlir\", \"sdpa_kernel_2d\",\n",
+    "    dict(q_ptr      = rng.standard_normal((32, 64)).astype(np.float16),\n",
+    "         k_ptr      = rng.standard_normal((32, 64)).astype(np.float16),\n",
+    "         v_ptr      = rng.standard_normal((32, 64)).astype(np.float16),\n",
+    "         output_ptr = np.zeros((32, 64), dtype=np.float16)),\n",
+    ")\n",
+    "\n",
+    "paged_attn_report = _run(\n",
+    "    _TRITON / \"paged_attention.mlir\", \"kernel_unified_attention_spyre_2d\",\n",
+    "    dict(output_ptr       = np.zeros((8, 32, 128), dtype=np.float16),\n",
+    "         query_ptr        = rng.standard_normal((8, 32, 128)).astype(np.float16),\n",
+    "         key_cache_ptr    = rng.standard_normal((64, 16, 8, 128)).astype(np.float16),\n",
+    "         value_cache_ptr  = rng.standard_normal((64, 16, 8, 128)).astype(np.float16),\n",
+    "         block_tables_ptr = rng.integers(0, 64, size=(1, 16), dtype=np.int32)),\n",
+    "    dict(cur_batch_start_index=0, block_table_offset=0,\n",
+    "         num_tiles=8, context_len=120, scale=0.08838834764831843),\n",
+    ")\n",
+    "\n",
+    "for name, r in [(\"matmul_small\", report), (\"softmax\", softmax_report),\n",
+    "                (\"sdpa\", sdpa_report), (\"paged_attn\", paged_attn_report)]:\n",
+    "    rf = r.roofline()\n",
+    "    print(f\"{name:15s}  cycles={r.kernel_cycles:6.0f}  bottleneck={r.bottleneck:8s}  \"\n",
+    "          f\"AI={rf['arithmetic_intensity']:6.2f} F/B  dom={rf['dominant_unit']:8s}  \"\n",
+    "          f\"eff={rf['efficiency']:.1%}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Per-op trace: paged attention\n",
+    "\n",
+    "Paged attention uses `construct_indirect_access_tile` to load K and V tiles via\n",
+    "`block_tables` — an indirection table mapping sequence positions to KV-cache pages.\n",
+    "Re-running with `trace_latency=True` and grouping by op type shows where cycles go.\n",
+    "\n",
+    "**Scenario:** 8 query tokens attending over 120 context tokens (`context_len=120,\n",
+    "num_tiles=8`). This resembles **chunked prefill or speculative decoding** — not a\n",
+    "pure prefill (where `num_tokens == context_len`) and not single-token decode.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Op                                             Category                   Count      Cycles\n",
+      "-----------------------------------------------------------------------------------------------\n",
+      "ktdp.load                                      memory                        17      2195.5\n",
+      "linalg.generic                                 compute_float                 49       179.0\n",
+      "arith.mulf                                     compute_float                 24       145.0\n",
+      "math.exp                                       compute_transcendental        16        68.0\n",
+      "ktdp.store                                     memory                         1        65.5\n",
+      "arith.subf                                     compute_float                 16        17.0\n",
+      "arith.cmpi                                     compute_float                  8        16.0\n",
+      "arith.select                                   compute_float                  8        16.0\n",
+      "arith.divf                                     compute_float                  1        16.0\n",
+      "arith.addi                                     compute_int                   33         4.0\n",
+      "linalg.reduce                                  compute_float                 16         2.0\n",
+      "linalg.matmul                                  compute_matmul                16         1.0\n",
+      "arith.divui                                    compute_int                    8         1.0\n",
+      "arith.maximumf                                 compute_float                  8         1.0\n",
+      "arith.addf                                     compute_float                  8         1.0\n",
+      "arith.constant                                 zero                           8         0.0\n",
+      "arith.muli                                     compute_int                   10         0.0\n",
+      "ktdp.construct_memory_view                     zero                           5         0.0\n",
+      "ktdp.construct_access_tile                     zero                           2         0.0\n",
+      "tensor.collapse_shape                          zero                          17         0.0\n",
+      "arith.extf                                     zero                          17         0.0\n",
+      "tensor.splat                                   zero                          35         0.0\n",
+      "ktdp.construct_indirect_access_tile            zero                          16         0.0\n",
+      "tensor.empty                                   zero                          57         0.0\n",
+      "linalg.transpose                               zero                           8         0.0\n",
+      "linalg.index                                   zero                          16         0.0\n",
+      "linalg.yield                                   zero                          49         0.0\n",
+      "scf.yield                                      zero                           8         0.0\n",
+      "-----------------------------------------------------------------------------------------------\n",
+      "TOTAL                                                                              2728.0\n",
+      "  compute=467.0  memory=2261.0  comm=0.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "from collections import defaultdict\n",
+    "\n",
+    "trace_interp = KTIRInterpreter(latency_config=hw, trace_latency=True)\n",
+    "trace_interp.load(str(_TRITON / \"paged_attention.mlir\"))\n",
+    "trace_interp.execute_function(\n",
+    "    \"kernel_unified_attention_spyre_2d\",\n",
+    "    output_ptr       = np.zeros((8, 32, 128), dtype=np.float16),\n",
+    "    query_ptr        = rng.standard_normal((8, 32, 128)).astype(np.float16),\n",
+    "    key_cache_ptr    = rng.standard_normal((64, 16, 8, 128)).astype(np.float16),\n",
+    "    value_cache_ptr  = rng.standard_normal((64, 16, 8, 128)).astype(np.float16),\n",
+    "    block_tables_ptr = rng.integers(0, 64, size=(1, 16), dtype=np.int32),\n",
+    "    cur_batch_start_index=0, block_table_offset=0,\n",
+    "    num_tiles=8, context_len=120, scale=0.08838834764831843,\n",
+    ")\n",
+    "trace_report = trace_interp.get_latency_report()\n",
+    "core0 = trace_report.counters[0]\n",
+    "\n",
+    "# Group by (op_type, category), sum cycles and count occurrences\n",
+    "groups = defaultdict(lambda: [0.0, 0])\n",
+    "for e in core0.trace:\n",
+    "    groups[(e.op_type, e.category)][0] += e.cycles\n",
+    "    groups[(e.op_type, e.category)][1] += 1\n",
+    "\n",
+    "print(f\"{'Op':<45}  {'Category':<25}  {'Count':>5}  {'Cycles':>10}\")\n",
+    "print(\"-\" * 95)\n",
+    "for (op, cat), (cyc, cnt) in sorted(groups.items(), key=lambda x: -x[1][0]):\n",
+    "    if cyc > 0 or cnt > 1:\n",
+    "        print(f\"{op:<45}  {cat:<25}  {cnt:>5}  {cyc:>10.1f}\")\n",
+    "print(\"-\" * 95)\n",
+    "print(f\"{'TOTAL':<77}  {core0.total_cycles:>10.1f}\")\n",
+    "print(f\"  compute={core0.compute_cycles:.1f}  memory={core0.memory_cycles:.1f}  comm={core0.comm_cycles:.1f}\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAqgAAAMUCAYAAABwx9XmAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQABAABJREFUeJzsnQeY1FTXgO8C0lGagID0JoIoCIgoilQFFcQKKDYQBEVsiA2xdxR7BQsqWMCGKAJiAaWq9N47iEqv+Z/3+N/5stnpO7M75bzPM7uZmUySe+5NcnLazXAcxzGKoiiKoiiKkiDkye0DUBRFURRFURQ3qqAqiqIoiqIoCYUqqIqiKIqiKEpCoQqqoiiKoiiKklCogqooiqIoiqIkFKqgKoqiKIqiKAmFKqiKoiiKoihKQqEKqqIoiqIoipJQqIKqKIqiKIqiJBSqoCpKArB06VLTtm1bc8wxx5iMjAwzduxYM2LECFletWqVb72zzz5bXqne9kQAOderV88kI1WqVDFXX311zLY3evRoU7JkSbNr166Q69KHDzzwQFT72bx5s7n44otNqVKlZDvPPfeciQfIBhklE+PHjzdFixY1W7duze1DUZQcQRVURTHGpwzaV758+UyFChXkRrZ+/fq4y6hHjx5m7ty55pFHHjHvvfeeOfXUU9OmX9K57cnA4cOHzeDBg81NN90kClI8GTBggPn222/NoEGDZCy0b9/e5AR79uwRpfqHH34Ia33W4zrxySef+P2e64ZbVuedd54pUaKE8c4sPmfOHNlO5cqVs2xj0qRJ8t3rr78u75FFjRo1zGOPPRZh6xQlOcmX2wegKInEgw8+aKpWrWr27dtnfv31V1Fcf/75ZzNv3jxTsGDBuOxz7969Ztq0aeaee+4x/fr1C7rud999Z1KJSNqu5A5ffvmlWbx4senVq1fc94VSduGFF5rbb7/d5CQoqEOGDJHleHgozjjjDPPNN9/IdaR+/fq+z3/55Rd5GF6zZo1Zt26dqVixYqbv7G8tN9xwg8iGYy1WrFjMj1NREgm1oCqKi3PPPdd0797dXH/99ebNN9+Um8Hy5cvNF198ETc5WZdd8eLFQ66bP39+eaUKkbQ91mDNQkHOLXbv3m2SgeHDh5vmzZuLRyHebNmyJVfGQryxSiYPu25QQrGuYm31fsd7Qh1OOOEE32ddunQx+/fvNx9//HEOHbmi5B6qoCpKEM4880z5j5LqtfTwXZEiReSGitVn4cKFWX6PCw+l9+ijj5abUKtWrcQya8GtaN17d9xxh7j0gsXGeWNQrauRGEFc5FhgsPSyn2XLlmX5/W+//SauQuI9CxcubM466yyfpSanCdX2ULKz2+B3XvzF77Ltjh07iguZMIJChQqZ1157LaJjxoKN3K644gpz6NAh+WzRokUSN0mMJrJn294HGns8U6ZMMTfeeKMpU6aMz1pmY10XLFhgWrZsKdtHGXzyySez7B/lBHc7rt4CBQqY448/3tx5553yeTAOHjwoVreaNWvKMaL4oDRNmDAh6O/wJBD72Lp1a7/Hgkv+2GOPFWveBRdcIFZAfxAmc+2115qyZcvKcZ944onm7bffziIfHhpeeuklX6gN/PXXX/KgiOWRccB4YFz88ccfIfvcfY4Ect+zPm0AZGT3HW0crT+aNGkiD5bec433LVq0kO/d3x05ckTG+umnn55pfDNuTjrpJPP555/H7NgUJVFRF7+iBMHe7Igfs3z//fdyg6xWrZrcxLDCvfDCC2Jlmj17tk/Jmj9/viix3FBRIo466ihRiFBIUFSaNm1qLrroIlFwudGj9FhrSqQ8/vjjJk+ePHIj/+eff0S56datmyikbqWa427UqJEoOayPdeycc84xP/30k9wkc5JgbQ9HdtGAq5p94Srt2bOnqV27dti//eqrr0QRveyyy0S5yps3rxyntS7edddd8sDCw0KnTp3Mp59+ajp37pxpGyinKEP3339/Jgvqjh075MEBmVx66aUS2zhw4EBRyugzq7SgBGJZw92OZY3Y3aFDh5olS5YETS5jnBK7iGeAfv7333/NzJkzZby2adMm4O9mzZplDhw4YBo2bJjlO7b1/vvvm65du4oixfjq0KGD38Sn0047TRQtwjhoP+7u6667To7jlltuESWNmNMrr7xSjueqq67y/X7FihXStksuuUTCb9geY4GHK5T68uXLm+zA8bzyyiumT58+0l/0AaAIhmLnzp1m27ZtWT73PjDwUMB557aSrl27Vl7I7u+//zZff/217zv6Fdm43fsWtpMoiYSKElccRVGc4cOHk73gfP/9987WrVudtWvXOp988olz7LHHOgUKFJD3lpNPPtkpU6aMs337dt9nf/zxh5MnTx7nqquu8n3WqVMnJ3/+/M7y5ct9n23YsMEpVqyY06JFC99nK1eulH0/9dRTfo+J7y1nnXWWvCyTJ0+WdU444QRn//79vs+ff/55+Xzu3Lny/siRI07NmjWddu3aybJlz549TtWqVZ02bdrkyigI1PZwZTd48GD5vRd/sqtcubJ8Nn78+LCODTmfeOKJsvzpp586Rx11lNOzZ0/n8OHDvnVatWrl1K9f39m3b5/vM+R7+umni7y9x3PGGWc4hw4dyrIfvnv33Xd9n9GX5cqVc7p06eL77L333pMx9tNPP2X6/auvviq//+WXXzK1tUePHr73DRo0cDp06OBEyptvvplpHFl+//13+fzGG2/M9HnXrl3lc/rFct111znHHXecs23btkzrXn755c4xxxwjY9DCb/v27ZtpPWTrljnQr5yXDz74YNA+d58j/LcgG2Rk4Zz3Hncw7DaDvYoUKZLpN3fccYd8vm7dOnn/4YcfOgULFpS+HjdunJM3b17n33//le9efPHFLH1qefTRR+W7zZs3h3WsipKsqItfUVzgysSigusUaxkWMdy11h27ceNG8/vvv0uWLi5dC9YWLD/jxo3zZT7jDsaShqXVctxxx4nFCUsKFpJYcc0112SKTbWhCVifgGOmnBP73r59u1h9eGHFw3X+448/ioUuEYin7LDAtWvXLqLffPjhh2I1xeqK5Q7Ls3U9YzXE4mktabyQL/tA3t4KEFhtsbx6wXJM7LOFvsTSafsPiDvEalqnTh3fvnhhAYfJkycHbAOWaqy9HFMk0BavBwHsOL/55pszfY411A06J5bk888/X5bdx42MsPZjxQ0GIQFW5owNjgl5Yf0O9dt4gyWcMAnvi7JpXqw1FG8F4NLHGkpfN2vWzOfWt9/ZcBEvti/8WW4VJZVQF7+iuCD+rVatWnLjxI2L4sYN0rJ69Wr57881jPJAfCNKHwoLmcGB1uNmhHuPWLxYUKlSJb83MVzHYBUTSjoFgjZ7FRHLpk2boj62cuXKRZw4FS/ZoaBGwsqVK0VxxL1MGIcbYnxRuu677z55BUr6cScXBdo/D0DeWFr64s8///S9pw+Jc7bxkv72Faw6BXHSjG3iXQknwJ0ejhsbvOWROA9QGqtXr57pc2+f0Ze4rymVZMslRXLcQH8///zz5uWXX5b+QEm1EEubmxCC4S8+l9AHL4SC0Mcon5dffrn8t+EVPEDUrVvX9xn/Gzdu7Dch0vaFv9hrRUklVEFVFBdYrazVAgseVg+sdsQuxrsGZHbwZ5Vz38ysdfSpp54yJ598st91g7UP62W0eJWbWBLoJu1WYtyQGBUJtJsXFkNiNt0WLStT4n4DWWVJZgpn/6H6z+4PhejZZ5/1uy5W/0AQ40miH8k1WKepUEHs6quvviqxpIGwCiAPOu4SSOFiZYSSH+jhKJSS/Oijj8oDAElWDz30kHguUI6x1rqt/pGOhZwGWWL9xgPAhAc8fBALbiEWle9INKPsFDHk/rAPnaVLl86xY1eU3EAVVEUJAEoDiSVkVr/44ouSBGOzzlFYvZDNzU2DsADcc2RjB1qPG2wwhSLWWEsXSUf+LD6hCJXtHUuwEIYrO2vxxUrnLk9kLd3ZhX4kOQo3OlZHErSs5daGH5DAFY1Mo+lDMtcJyYjGeoZiRygILxQklFaSp4IpqChUgOXSXb+T8wDlEKXXbTX19pnN8EdJjFZGJIxxDr711luZPqfP3Uqaeyy4CWcs5JQ1kgdePDM8JCATlFILy4ST2GoD/hKkbF/Q7kCWdEVJFTQGVVGCQNY4VlWmXKTkDtY0LJDvvPNOphshBbi56ZCJbpVb4tCwWLnL3pCB/MEHH8jNB2UxpyDWDQXn6aef9jtdZajpE1Euon1FSiSys4o3oRgWQizon1hBSS5CNyjxg/vVlhzjPeODuFRik73EekpKYl2JaX3jjTeyfEcliWB1VW0sqdtajnU3VHkqGyOJ9diNrSwwbNiwTJ97pyalL6ndSRwq50g0MmIbXis88bje+F5/YwElMFBogRseiPwpt7GGscsxcR5S8sutZKKgcm4SysBDmFt59VZWIGZVUVIdtaAqSgio0UkMInUWe/fuLW5ybtDcJCiVY8tMoci4ayc+/PDDYnnkpkR5IWaMQZlBKfBX4zKecMPDrctxYwHEikZsJDd5kmtQ+JgxKFEIV3YossTf0g/0E8oMFipu/LhJYwUWK3s8KN24YpEfMct8hnWRBCisqijSzI6Fq9ZbqzM7EDNKCSvGIH1GTCPKDlZlPrf1Xf1BfCPKNAonllQUTiyToWbvwoKMjCmtRhyrhYc0ynWhTBG7jDI1ceJEv7V3KYHG8VIaDBlxLCSYkeDEdlkOBrVr2Tdjlv1QgmnkyJGZEuiAcU05K6ZJZZu086OPPvLVqw0GoRcc16hRoyROl98Sq8srllirKOODREs37JdxxneMJ38TFhCvS2hA3759Y3pcipKQ5HYZAUVJBGyJmhkzZmT5jhI31atXl5ctEUQ5qubNmzuFChVyjj76aOf88893FixYkOW3s2fPltJORYsWdQoXLuy0bNnSmTp1aqZ1YlFm6uOPP/a7TbbhZs6cOc5FF13klCpVSsr0UGrn0ksvdSZOnOjkBoHaHq7sYNasWU7Tpk2lLFWlSpWcZ599NmCZqUhKLbnLTFmWLVsmJZMo60VpIqAUFuXFKAtFKaoKFSo4HTt2lDJl4Ywvf/vxVwoJDhw44DzxxBOyPv1XokQJp1GjRs6QIUOcf/75J2CZqYcffthp0qSJU7x4cRmzderUcR555BHZXig+++wzJyMjw1mzZk2mz/fu3evcfPPNMpYoqcQ5QDk2f+WaKIlE+ajjjz9eZISsKNH1+uuvZ1ovUJmp2267TeTOsXPeTZs2Lcu5YPuidevWIpuyZcs6d999tzNhwoSQZaaAsYUsGUehSk4FOu/c2/eWmbKUL19efuttO1xwwQXyXZ8+ffz+9pVXXpFzwZajUpRUJoM/ua0kK4qiKIkJVlqsi4QYkKSk5B6nnHKKWMJJcFOUVEcVVEVRFCUouL6ZaYmwiUSuZpHKMOUstZmpjUv8s6KkOqqgKoqiKIqiKAmFZvEriqIoiqIoCYUqqIqiKIqiKEpCoQqqoiiKoiiKklCogqooiqIoiqIkFKqgKoqiKIqiKAmFKqiKoiiKoihKQqEKqqIoiqIoipJQqIKqKIqiKIqiJBSqoCqKoiiKoigJhSqoiqIoiqIoSkKhCqqiKIqiKIqSUKiCqiiKoiiKoiQUqqAqiqIoiqIoCYUqqIqiKIqiKEpCoQqqoiiKoiiKklCogqooiuIhIyPDjB07NqXlcvXVV5tOnTqZVOTss882t9xyi+99lSpVzHPPPZerx6QoSmSogqooSsIpTiiIvI466ihTtmxZ06ZNG/P222+bI0eO5MgxbNy40Zx77rkmlRXj559/3owYMSKgUpcIxOqYZsyYYXr16hWTY1IUJWdQBVVRlISjffv2oiSuWrXKfPPNN6Zly5amf//+pmPHjubQoUNx33+5cuVMgQIFTCpzzDHHmOLFi5t04NhjjzWFCxfO7cNQFCUCVEFVFCXhQDlESaxQoYJp2LChufvuu83nn38uyqrb6rdmzRpz4YUXmqJFi5qjjz7aXHrppWbz5s2+7x944AFz8skni/W1UqVKst6NN95oDh8+bJ588knZR5kyZcwjjzwS0JKJksz7zz77TBRlFJ0GDRqYadOm+dbfvn27ueKKK+R4+b5+/frmww8/zGINvPnmm82dd95pSpYsKfvm+NxuaOjcubPsz7738sMPP8j3f//9t++z33//XT7jWAEZoXx+++235oQTTpB2W6Xfn4uf5SlTpohV1Vqv7bZCsWPHDtOtWzdRAgsVKmRq1qxphg8fLt+dc845pl+/fpnW37p1q8mfP7+ZOHGivH/55ZflNwULFhRr+cUXXxzymPi8SZMmMk6OO+44c9dddwV9cPG6+JHdDTfcIPtjv/Xq1TNfffVVWO1VFCVnUAVVUZSkAGUHxRBFEXD3o5z+9ddforBMmDDBrFixwlx22WWZfrd8+XJRbMePHy9K41tvvWU6dOhg1q1bJ7974oknzL333mt+++23oPu/5557zO233y7KYK1atUQhtUrRvn37TKNGjczXX39t5s2bJ+7kK6+80kyfPj3TNt555x1TpEgR2RcK8oMPPijHbd3QgHKHImnfR8uePXvM008/bd577z3z448/ijLP8fsDJbBZs2amZ8+esm9exx9/vE+5cyvSXu677z6zYMECkfHChQvNK6+8YkqXLi3fXX/99eaDDz4w+/fv963//vvviyJPf86cOVOUduSwePFi6aMWLVoEPab169eb8847zzRu3Nj88ccfsj/69OGHHw5LLowbwjd++eUXORaO/fHHHzd58+aNSL6KosSXfHHevqIoSsyoU6eO+fPPP2UZC9zcuXPNypUrfcrUu+++a0488URR7lBgrEKCBbVYsWKmbt26YgVFGRo3bpzJkyePqV27tiipkydPNk2bNg24b5Q7FFsYMmSI7GfZsmVyTChcbuXvpptuEuvl6NGjxdJnOemkk8zgwYNlGavhiy++KO0gxhYLJGD5xLqaXQ4ePGheffVVU716dXmPJRNFMJC7H6sm1l/vvvm9VTj9geJ7yimnmFNPPVXeuy2/F110kewX6zfWbWvdtXHG/BaFndAN+qdy5cqyrWDHhMWV/kZ2bAP5b9iwwQwcONDcf//90qfB+P777+XBAWWaBw2oVq1aSHkqipKzqAVVUZSkwXEcUUoABQNFxSqngAKKgsd3FhQmlB8Lbl3WcysyfLZly5ag+0a5tOBWBvsbQgYeeughce3jvseljoKKAhZoG3Y7ofYbLSh2VjnNzr5QoL1uejd9+vQxH330kYRSEL4wdepU33e4z7Ek84AAs2fPFgszCiqgmKOUoiCy3siRI8XyGwz6FsuqHQfQvHlzs2vXLrGKhwILeMWKFX3KqaIoiYkqqIqiJA0oJ1WrVo3oN1QCcGOrA3g/C1UhwP0bqxzZ3zz11FPiksaKhyUWJahdu3bmwIEDIY8l0soEVrFGWXdbS4Mdr92X+zexAnf56tWrzYABA8SS2apVq0zWZNz8hDGgPBK+gGsfpRR4cEBpJfQCBRoLKGEc7vjaWEOcrKIoiY8qqIqiJAWTJk0Sl36XLl3kPck/a9eulZeFeEKUGyykOQnxjMTDdu/eXRQsLIJLliyJeDsolVhjg2FDAdwJTyjE2QV3eqh9BzumHj16SEwnyUivv/667zusyrj/33jjDYlHvfbaazP9Nl++fKZ169YSk0v4BolQ9HWgY6LfSVBzK9vIH2UXy2gosGKjLEfTP4qi5ByqoCqKknCQVLNp0yZJiMHC9uijj4oCSKziVVddJeug1KD8kEHOOsQV8t1ZZ53li4fMKYgnxUqIexsrLxni7moC4UI4Ai512k52vD9q1KghYQ0kLi1dulQSs5555plst4F9k7yFgrht2zafZReLKPGegcDqSYwp8bjz58+XbHiUSDdYUUlEQqmkSoGFdYcNGyYKNlZYYojZL3HBgY6JKgw8lBDnu2jRItk3cb233npryPhTYHyQiMWDDn1GDLNNolMUJXFQBVVRlIQDZQGXLwoK5ZFwm6PIoIzYbGtc1rwvUaKEKBworFguR40alePHSxUAymHh1qecFEk90czShKKJ0oQCapOF/FlZcYmjnGENJMEr3Az2YOCWR7ZYn7GI2vhZqiCgHAYCK+egQYPkWOgHtkFMqhsqHmAp5T9xqRbihanKgNsfpZakLtpGAlqgYyIhjQQ3HkiwVvfu3dtcd9110gfh8umnn0oSHcfDtomdjdZ6rChKfMhw4hGUpCiKoij/DxZQEraoroAiryiKEgpVUBVFUZS4QPIWkxhgCcWVTqyooihKOKiLX1EURYkLKKSEamA5xX2vKIoSLmpBVRRFURRFURIKtaAqiqIoiqIoCYUqqIqiKIqiKEpCkS+3DyBZoP4es6RQDNo9xZ6iKIqiKIoSGgpH7dy505QvXz5k3WJVUMME5dQ957eiKIqiKIoSOUy2EWrmN1VQwwTLKTDbCcWlFf9WZgYdinw4M7qkIyojlZGOJT3fEgm9JqmMcnIs/fvvv/K91amCoQpqmFi3/jHHHGOOPvroSPosrUz3RYsWlZlfNAxCZaTjSM+33EavSSojHUeJeb6FoyOomStCVPEKLhuemlRGKqPsoONI5RQrdCypjHQcJe/5pgpqFCZsJbBsmCtbZRR8/KiMQp9jKqPwrkUqJ5VRdtFxpDJK1LGkhfrDhLgJ3Pv//PNPFhf/4cOHZUo/5b8BqvGnwVEZhUZllB5ywhWYL1++uHpdkl1GOYHKSGWUU2MpmC6VUDGoP/74o3nqqafMrFmzzMaNG82YMWNMp06dMq2zcOFCM3DgQDNlyhRz6NAhU7duXfPpp5+aSpUqyff79u0zt912m/noo4/M/v37Tbt27czLL79sypYt69sGGn2fPn3M5MmTJT6iR48e5rHHHpMLYzQxFm527dpl1q1bl+XzdAU5qItfZaTjSM+3cClcuLBMh5o/f/64XI+4YXJN0uuSykjHUXyJ9fmWqwrq7t27TYMGDcy1115rLrrooizfL1++3JxxxhnmuuuuM0OGDBFte/78+aZgwYK+dQYMGGC+/vpr8/HHH4tW3q9fP9kWc0Bb62aHDh1MuXLlzNSpU0URvuqqq8xRRx1lHn300YiP2a2Ism2UUy6wxx57bNpfAJENlmRkqzeDwONHZRT6HFMZpb6cOP4DBw6YrVu3mpUrV5qaNWvG3NLJPrhGY9BIRhnlBCojlVGijqWEcfHTGK8F9fLLL5eL73vvvef3N5iIUQw/+OADc/HFF8tnixYtMieccIKZNm2aOe2008w333xjOnbsKHVMrVX11VdfFassF8Zwn9r9maWx3nJhrVKliilUqFAMpKAoipJe7NmzR8r3Va1aNZPxQVGU1CMSF3/CBuZgJsYyWqtWLXHblylTxjRt2tSMHTvWtw6hAVgQWrdu7fusTp06or2joAL/69evn8nlz/YQEtbYQBAuwDrul7WaAnq9W7e3y+7PY7kcz23Hcpl+S7U2xbqfIpFRIiznxj7dMkqVNsVbTrl9LNEuuy0ttj122d3OaJb5jyHB7i/Q+u59xns5u20Kdznc4+KFjNwyS/Y2xbqf+I9O4L7/J3ub4rFs5RRqLIVLwiqoW7ZskfjOxx9/3LRv39589913pnPnzuK+Jx4VNm3aJBZQb+F8lFG+s+u4lVP7vf0uEMSoouXbl51FaseOHb7/PAEAsbF24HqXbUehSLuXbUe5l3F3uZeB98E+t8s2Scu9zP7cyxwPcHyBlgO1I5w22f15jzeZ2xTrfmLZLatUaFM8+omLXKq1KR79ZI8nmdvkXiZfgO24s4F5z7Jdl0LgwBhZv369LKNgEb5lLbKbN2+WZaZUXLp0qWwfI8O2bdvkc67df/31l+9abq/rfGav66xrDRN427gfAdtmH8A+2TdwLHbccoxWrrFuE8fB8UAs2oRsFi9eLCF3qdKmWPeTdV2nUpvi0U/IidBM275AbQobJ0HgUMaMGeN7v379evnsiiuuyLTe+eef71x++eWyPHLkSCd//vxZttW4cWPnzjvvlOWePXs6bdu2zfT97t27Zdvjxo0LeDz79u1z/vnnH99r7dq18psdO3bI90eOHHH27NnjLFiwQP7z3n4ej+VI1q1cubJTq1Ytp0GDBvL/sccey9b+77vvPqd27dpOkyZNnEmTJsl2Yd26dc4ZZ5yRI21KluXc3r+2Sfsp2ZbtdXTv3r3O4cOHfZ+zbNeN97J7n/Fe1jZpP6Xz2Pvnn39El+J/KBJ2JqnSpUtLlj1Z+26IL/35559lmcQnLAR///13Jisq2j7f2XWmT5+eaRv2acCu448CBQrIy4t1R7mz1LzL3nVjtRzJuqNGjTInn3yyPBEhw3POOcc0adIkqv1TaWHFihWSafvDDz/4Pq9QoYL56aeffOtbM38k8oinvHJrOdj30cgoEZZzcp9gLWqp0qacklMiHFd2lt1JUnY52LU21DJwj+BaHs4129/+47GcnTaFuxzusVhLu73fpUKb7DKWYfJE8MJ618FLS/7KLbfcErJN1nVtZRTpsf/+++/m119/Fetj27ZtJT/G3aYZM2aInmKL3F9//fWi/3AftxZWq7uQm1O7dm3Jr7HWT2uhbNOmjYRCUiFpwYIFvu/YRsOGDSW80XuM77zzjlg5bduYgrRbt26+dcjZ6d69u5k4caLoASSFIw/ixc8//3zR1QLJKVDfhEvCKqi47hs3biwDzM2SJUtM5cqVZblRo0aSRIXgunTpIp+xPubrZs2ayXv+P/LIIzIYiWOFCRMmSHCuV/kNh1AxFK+//rrPHB8PKJPVq1evsNdHiSQulySEkiVLmt69e4ssGCwPPPCALynt22+/NYMGDRL3XIkSJcwrr7wi8jn99NPF3M9J1bJly0zVFlatWiVKMA8IwDYffPBB8+WXX8qJeP/995trrrlGvsPNxoWAfTOAaQMVF9IRZMy4VVRGOpbiC9drrkVcB73KvZLaMsIQgCLHK7dlhHGHRG5rXHNDYvfcuXOlWhFKH6EWVpm77LLLfOuR6P3++++bGjVqyHuqE1nQOZ5//nlz4oknyvsWLVrIy95vnn32WcnFCQSKK3qCF1z06GIorYA+YJVr2kLpzksuuSRmckooBRWhLlu2zPeeJx2eNFCkSHS64447pIMQNMrR+PHjRfmxVjxiQ+nUW2+9VX6D0nnTTTeJUmqFiGKFonXllVeaJ598UuJO7733XtO3b1+/FtJQhHoKoE3EPSUKDP7t27ebs88+W6oZUNLrhhtuEIURGZ1yyilSgaBr164iVwbxyJEj5WQiiYzSXAw0LKVYqd0WVH/wdMWTIPvlAQO58/srrrhCTi5OAmJa2DdPeqyTTiCLeNR7TCVURiqnWMH12uYPKKkvI8pRoi+gV2DIwijFvQirI3D/Qhnk3m8VPcvMmTMlqZrrM/cp1h08eLB8RzzmpEmTxLiCEkb5S6sMhoP11vpT2rjHnnXWWb4KFkWKFPG7jdmzZ5uTTjpJJrfwgt5UvXp1MWB5of3oRuXLlzeRQh16f4qrtZR6q24EG0sYF7HU2xr2Ca+gMiBQPC0omkAh/REjRkhSFOZlEpZuvvlmeRKiSD+DwzJ06FARChZUd6F+C5351VdfSaF+FFc6n+1j6YuGUBZUfwMkloS7fRR76+JARgwkBritD0vNQeSI4omij2Jqn7Aw76PAEx5QsWLFiI4PRRQZMahxUfBAYCsm2IsEoMTjgkg3BdVmbXrdkIrKSMdSfM43PEBc//R8Sw8Zcd/r2bOnT3FzK0jcc/DeoYRS1tKCZ4/ka4w33GOxDFqQDToE3kPc2Xv37jWvvfaaKGIofsOHD/clKHlhX6GMWlgcsY7ayYioDY/xxg3JTPPmzfN5JL3QTtz7/pgzZ44YooKBB9UanwgFsOGA6A8XXnhhJmWafWFkYqx4jyfYWEJJp2RoJPf8XFVQseqFUviw+PEKBIJ46aWX5BUInqTGjRtnYkGo443E/R5PbAzq999/L3EixKB6icfFyD07Fw8HnHDIDAu3+2KRzqiLX2WkYyln4NqDmxIXayooX/Eg1WQUSBnDQ4s31XpOCRG02ex8h0XVGoD4jjhOIM6TGE5mq3SHZuGZREENpDRGEorA9q+++mpR7jDOEWZXq1Yt3zoo1qVKlcpSkQgI30NBxujkhfA72mjrxEfi4scbzHbZr8Xt4kfxHT16dCadx44lvLCB7n0ow4GsxEkTg5qoJNucztSIxXpMWANPRjzt8XSJC4QYkmHDhomLH7cHT2j16tWTE5EYEl6RwpOp9yKH5ds+adqTmf2jtPJKJ9R9rTLSsZSz1+tormPpRKrJKNwQqnCVcZQuJgQinNAf2bWgWg8m6xEih6JMSataLgU1mBWU77C6+tsPRiEUz2gmEiI0wH0MXtAVvvjiC4mZtQqnHUt33nlnlvWxutowP/JTwkEV1AiJtNBsInDffffJoMeKfM8995gXX3xRTs4333zTFw/CEw9TwNokKaaOjeZpmhpr1oXttqriIiFJinAD1sFVQgZlumGz+G22pqIy0rEU3/ONGyM3fj3f0ltG1apVkwRpQv1QYpnox8JskBhsrLKF0mfBlY8lEismVYSQEaFrKK14CbNrQUU5xWDDTGq48rGIYqm0YJEkBIDwOS8oxhwXoQn++hUF9YILLjDRgHvfHYLpxWb08wpnLJFUjZIdSdKaKqgpqKAyENygcOKOAFz+/qAMh7sUR6A2E5ZhXfWc1DaD31v0G2wRXyCAmwQ35T8lPtks8TmNykjlFAtsgX4sSKmsfGWHdJERLnDyKqi0402SwnVOctXbb78tyivf2VAA5EL+BAYe4kS5z2H1dOdUhIJ7JklWuPCxTBLLicJJWAUKMwYcwhSRP0qwOwFrzpw5mUIT3OD1JPnJ7YZ3K5BsD8U3UlB80Rm8iVU2BhVQzsngd4+ZYGPJVk2KpFh/BsVQIz76NMTf/LEMNmJXdA5pRVGU6NDrqJIIuOt3UrOUGZFIGE5H5s2bJ7Gr5513Xo7oUoFQC2qEqD4fXDbqvg49flRGKqNYoGMpPBmR7EHySypbB7ODysj4vIskRHF9pu4nZRnTVUb16tWTV6TEWk6qoEbRAUpgrPKlqIyyg44jlVMssDFxxBWmg2IRDSojk6XwvcooMcaSKqgRospXYBiQOkNScFRGoVEZhYfKKbzrtb/SPIrKKBJ0HOWOnFRBzQUL6vZd+82omWvNtOXbzb97D5qjCx1lTq9e2lx6akVTqmjks1slCsiG5BaCp9VaoTLScaTnW25jkzaIddNrksooFceR8//HRlxnqslJFdQoOiBa9h08bB78coEZPXOtOSwzCv3vu5+XbTPPfLfYXNb4eHP/+XVNgXxZpzNLBjQEQmWk40jPt0TBTsnoLX2nqIxSZRytXr3avPPOO6ZTp05SDzWV5KQKag65+FFOr3p7upm56i9zxI+Oi7J6yHHMh9PXmGVbdpl3r2uSdEqquhxVRjqO9HxLtOs187ErKqNUHUeVK1eW+qJjx46V97mppMZaTprNkkMWwoe+WhBQOXXD99NX/SWW1mSUjZ3aVFEZ6TjS8y234VpErWa9JqmMUnUcZWRkyHTmVkn9448/UkZOqqBG0QFRxZzOWBtSOf3fPoys/9fuAyY3i/2/+uqrcZEPBf5tsd/cgDmPn3vuOVl+4IEHZIarcNi4caPMQ0yGuWXnzp1SUsM7Dd4PP/xgTj755IhkxCxfzCrC73gx5WwgmFuZIspcnNyTJcBvv/0mT9FMU3fOOedIcWp/0HZmQ7H748WMJZZ+/fqZUaNGydzQxDfxPds96aSTzOeff27CYcaMGaZ58+byO35Psepw2uuVUbD2emG2GIpuM3PMqaeeapo0aSLFud3jj9lM7H6vv/76kGMBGXCsFNGmiPegQYPMgQMH/G6TgtQU3XZjZRlrqNdIf3BzYo5r3nOc9n04MHsOs+HwO6YhvOuuuzLJn2mQmaCDtvP67LPP5POZM2f62ouL0UIfe2e2uf3223Nl5jh9aFYZpcM4yvh/JZXzESX1zz//TA05UahfCc0///yDxOW/Ze/evc6CBQvkfzBenrzMqXLXV07lgeG/qt71lfwut5g8ebLToEGDuGy7cuXKzpw5c5zcokePHs7QoUNlefDgwU7//v3D+l2fPn2cd999N9Nnb7zxhtOiRQunePHizs6dO7Mlvx07dviW161b5xQrVszZunWr33UnTJjgbN68Wcak+3eHDx92qlev7kyaNEneP/XUU87FF1/sdxvB2n7kyBGnWrVqzr///usMHz7cufDCC33fTZs2zSldunTI9rCNChUqyLHC4sWLneOPP97Zs2dPzNrr5dtvv3WOO+4455dffvF9tnbtWuf+++8POf4CyeO1115z6tSp46xYsULe796927nooouc7t27+93mqlWrnKOPPtr5448/ssgy1vTu3dt59NFHA74Ph7vvvtu58sor5TgPHDjgtG/f3hk9erSvrVWrVnV++ukneX/o0CFny5YtstylSxdnypQpzq5du2QdoG/PPPPMLH1E39WsWVN+7yXc66iiKMHhHB47dqwzZMgQ3/UnGXSpQKgFNYonhEiZunxbpoSocMDayu+ifZp65JFHTNOmTcWywxPVY489JtYkpnvDugc86bRr104+Z2q1rl27ijUFevfuLXPx8kRm5/JlW/fee6/ME8z8xFhYhw8fLlO18d2HH37oe3ryWrpKly6dZQrWQGzdutW0bdtWLDpYh+xcx1ixWrduLVPEYbXhOJiHuHPnzmLZ4TcUCYaJEyfKcWFJom1vvfWWye5sN1jAunTpkulztjtw4ECx2IVjIQv2hFm8eHHfMu2whdj9gRz8xfowv3S+fPl8cyhjyWKKWY4/ErCOYRGkYLUX+pXpc0PBVHn0JccKWHRp4zfffBO0vf5kFKi9Xh588EFz//33Z5rLumLFimbIkCFhtDrwNp955hnflIHMM41F9tNPP5XZZvzFhCG7JUuWZJElfcGY5ryiEHY4lmjm/b700kvFEsw5wTkInNOMuRdffFG29/jjj2d6H8rSbMElyDTHNoa8TZs25r333pPvsHriNTjjjDPkPRU6sLoD61LzkLHF59YK3b9//0x9C/Qd0x1/9913JidhDDGXeaJavhIBlVHqyCgjI0Pu13isuO/j/UhmOWmSVA5AKamc/B3gdsbVi6J24YUXyk2LG+XHH39s7rjjDnG9clPhBsQ8vgyoG2+80bzwwgvi4kP5xN3pdcWjwDIf77Jly+RmiZt22rRpsj2mRWNu3uzy/vvvizJgb2YMeAv74aSrVKmSufLKK8WtwfFQe42ZP3A19u3b1zRs2ND8/PPP0kZ+j6KKMo6yEg3sl2NCObGgHDPzCNtFoUJB8Lr6LWeeeaaEA4A3wxGl0t7ghw0bJu7hdevWmTfffDPigHOmp0NBsqAUUfID1z0uby8jR470PbAgIx44YMyYMZIVapk8ebIoPSgkhAyEo4zzUMJc06NHjxYFCxny0ON+UPHX3uxc3GbPni1jOBSXXXaZzBcNgwcPloccf2zZskXay8OOG84ZHvbYH4qXG8Yn823bZAW3LFEuX3vtNdkeyng481L36NHD3H333eass86SccY45zzmPF24cKH024ABA2Rd9ks/2VAFPqfv/MFx8BDbqFEj2R4PXwcPHpQbm1VuGeNM/8g+6SOUa5R1lFQeBHgA4prw1FNPybWC+b+feOIJv/ujzVyPzj333JBtVhQle0qqvfYA9+pkRBXUCImmdAJ1TqMh2t/ZGzBgHeUGcvnll8t7rDBLly6VZRSBoUOHmq+//lpufMyN67Y8BdsucXgFCxaU2EC7HxRBLGFe60mkYLHhuG677TaxTGLdcd/kUE7tPrmh2sLAjRs39rUN6x3KIlYsLIq8Z37haBVUbs7eAsRYT6+66ipRLlHOuVmjMGDN9fLTTz+FtZ+bb75ZXli1unfvLlZhlKF4wVzTNh7XzRdffCHKhAWLrM0SRY5YNFHOiAsNBhZCLMxY+7BkY4mjP0K1171Odts3f/58sUIyFuzczyjYgWKEo8UqvTzEvP3226LAemXZqlUrsTBy3tDWUMfAuctvN2/e7PuMcwxFn2sRWbPBrkmcR6FA0eWFskqsMdcIGyvMdYEpIIltpa9RlPv06WM++eQTGec//vijrEf9Y9qD5RVPCt8j62effdZnbS9XrpwovDkJsilZsmSO7jPZUBmlnowy/j8mlXt8TiqpsZaTKqgREsjlGgyK8FPnNBLDUJ6M/34XLSiPYC1z7vfcdADrKTeiKVOmyM0Ea5Y7iSXYdu227HsGJq+9e/fKTY7vuGlZInExo4RijeHGSELGfffdZ+bMmRN0/962EaKA0ogbluPCohqpm9sNSof79yjG3Ixxc9rkD6yLKK1PP/101BZUC9a3ChUqiHXTG1YQDJR36uJZ2CcPHqEUSTcocjxkBJoRBNc0+/nll19CWsxpx/jx433vUWpQVP2tZ9t70UUXST+ipEb6QIg1cfr06fLfWoiB7URz7mLR5bjwEjCeLDzw8DDEuLL4U3q9skRhQ2HGqollFAX6zjvvDLh/a01GQXSPdfudDYkIRDgWVJTq559/3vc5ngDbR/QzDyfIAHiIwGPghYccxgJtfeihhyRJg/ODz214BeePtVrnFMiHB2dumjoLoMooncZRnjx5MllSuQZy7U4mOamCmgMWVGaIogg/dU7DJU9GhhTtjyc7duwQNyzKKYoMMZ7WOslnKDbRygcLKyEG3NRRMm1sazisXLlSboi4hbGeoiTY2NJI2oarm+PBypPd0hu4NrFaWbCK4TJHcbBgPSXbGWthIAtqsNm2sC4RWwvENqKU2/fhgrsW5RmlBMUCJYQnaa9yEwyve9+fNRnljJhSIKOd/iJT3V/lA9z88MYbb8gczVQWCNXeaIs88zCD5RyFF0s8RDL2/EEYC9Z8lGvCPHgQ6dWrl4QFeN37oWSJCx7ljxcKuA1jIQSHUALv2CFUh35EaSS+EwjX4EZglcZghGNBJcyAY+EhjHPvlVde8cXGcg7y0GVnhxk3blyWOov8hsoJxBazHg8X1rrrPm85P3K6RiPHEc2DTjqhMkpdGeX5fyWV+46tvhFPJTXWclIFNYoOiBSmL0XZpAh/OKWm2AXrlyyS38QT3NPciEjgIKYMK5+1vqGQcRNlMKOIoZCFgx2c3Bhx3RJz16FDh4jc1FjRsDRZiyjxbZFO48YNnZharDlYtbAUZQcUE6xgWL9s0hXWLzcoMCgNJMIEcnPYE9gfWNK42WOVZR2UFhsuQEwwigkJO4BMrdLN8djkNy5IxPASboDFCsupTXgJF1z53t/YGFRAAX700Ud9ygbHgWLsD5KJsGJygaQt9kk+VHuJRw2nvV54oKFviLPm94zr/PnzS1yqv4QvL/wW97Tl1ltvlRfHiKLPwwXlpbBqM7YilSUuch50OCYUQpRBq6z7ixEG5McxcC4iO5R8HjwIVwnl4g8H4kZRROkDXpy7tq95YOWYCf1hX4xvd8kuIGQBSynHwXlKsiXuRJRrG6tM/xOqQChBTsIxZTfkKNVRGaW2jPLkySN5KICSSlv8ebESUU4ZpPLHbGspjJ3rFsuc7QAUAG6wKC+hLFT7Dx02V74VeCYpC/eaJlVKJuVMUjb7OhmfNMOBRBKUIm+Ny1SSERZPXLjh1tFDYcNSibU8Vq6vRJdRPGRJbC4WyHCU6GSUE2EePDjx8hLJdTRSsDRv27ZNPEXJ4prNaVRG6SGjI0eOiEGKJE4esOOhpIYjJ6tL4aG1OQGBSE5J5yLR3ghQNt+9tom5okklky9PhsSYuuE9n3dtUikplVNLot8oswMxdlj4oollTBYZ4Y6PpMgzVm6y82N90U5kGcVDllSciEQ5TTY5cTN68sknc3y/yIcqBMkip9xAZZQeMsrz/5ZUPDHkZuANTHQ5qQU1TPxp/dE++TOz1OiZ66TOKaWkyNYnIYpYVcIB0gViYyiL5IaM30BJHYqipB7xtKAqipIZDCyEHlGNhWoikeY5ZJdILKgagxoh2bWeAUpon7OryyuViNTlGG5cayqRTG7Z3EJlpHKK5fWaySKIRU5W12y8URmll4zy5MkjiZtcZ4m3j6WSGms5qYIaITFRKnZvM2b2u8as/NGY/f8aU+BoY6qdZcwpVxpTJPrSUolAsp+8OYHKSGWkYynnrtcko+nDoMpIx1Hme5CdnMSWYvRXvzu3zzdVUKPogKg5uM+Y8XcZM+c9Y5wj/70sK6cYM+lhYxpeZUz7x43JVyApZeOt56mojHQc6fmWm9ekaGJ70wmVUXrKKI9LSbWW1OwqqbGWU66au6hPSekWSuHQMDtTjT8ovM463llvKApLuR9iGciupwait2YmiQqUUCK+iTnksxOsH7WLH+X0/c7GzH7HmCOHMiunwHs+nzXCmPc6G3Nov0k2cBlQgkcLQ6iMdBzp+ZYIcL2mmkIsQrNSFZVR+sooz/8rqSimKKnUKk4kOeWqgkoBbWophirbQ+1EO9VeoKkMKRT91VdfidJLEW13QC5T8FG0nRl7qKlJwWtvLb+4W1C/HWTMml+zKqZe+H7NtP8srXGEAOkqVarEfLtuCyoFzZmO1M6gBCivJEMw5aMb5mePtH4aU7RSf5OsQTv3uBtcF9RjJGuRl3sOeHeCBvE4FJ1nLLZp08YsW7bM9z2F9zle6kLyClT4nPJTzJJj1+PljrHl5GeKSI6B9ZjpiHXq1KljHn744Yjazfzw1GR1F4Ank55albhXvEX2g33nb9vUEqXOKDKzU1n6AzlR2QD50B7kR/3R/fv/e7i6+uqrpW6mWyZWVoGm+Jw6darInBIoFMG/4oor5IJncW8T2VHvlbqsXjnHGh6EmzdvLvt95JFHsrwPF+apJ96L31Gei1mvLFgw7MP633//7fuc0nYU62csU9vXQqwX49Xdfq6B7utfuoMsMV6oi19lpOMosJLK7H1WSWUykYQ535wEgUMZM2ZMls/XrVvnVKhQwZk3b55TuXJlZ+jQob7vFixYIL+bMWOG77NvvvnGycjIcNavXy/vX375ZadEiRLO/v37fesMHDjQqV27dkTH988//8i++G/Zu3evHAP/g7Jrq+MMKek4g48O/8X6u7Y58WLu3Lkiz3jyxBNPOA8++GCmzyZMmOCcfPLJTunSpZ0VK1b4Pl+5cqVzzDHHRLT9xYsXO7///rtzzz33OP3798/03ezZs6WP7Tj4999/nd27d2fZBn339ddfO0eOHJH3L7zwgnPWWWf5vmfZ37j0MnnyZKdBgwYBv+/ataszfvz4LO38+++/nbJly8r4DpdOnTo51157rXPhhRf6Plu7dq3z22+/Oa+++mqmz0N95+Waa65xBg8eLMvTp0+Xc+/AgQNZ1tuwYYMc95tvvun7bNeuXdLfW7dulfc9evTIdL6GktUff/zhlCpVyvn+++99nz3++ONOrVq1fH3n3iZ916RJE2fYsGFZ5BxrPvroI6dt27YB34fDnDlznEqVKjk7d+6U9++9957TuHHjTOfG5s2b5TqzY8cO3+eMySFDhshyy5Yt5dyF7t27O9OmTcuyn4YNGzpLlixxkoWwr6OKosSNw4cPO6NHj5Zr+MKFC+O2H3+6VCASOqMFM/GVV14pVhl/RWWZHxurG1Y6S+vWreWJgMLhdp0WLVrIzC0WimczmwuWiUBgBcL66n6Bnesdndq6skMuz3nPOKEspx5Y3yGRyjUfdzj7xGp52WWXiZUGixbWY7vO4MGDxTKG1fHDDz/0fU6JF+TIdI52Biks0jabGnkhYz5nlhgbQuHvGKyLnxez3WABc6/DTD09e/aUz99+++1M24i0rbSF4yUj3rvOM888I7PvUIuS98TFYLn0boewj3PPPde3f2acspZW73GFOp5A6yIT5q3HCub9HV4Ee3zh7Af5YfmmsLv7c2YVaty4sW+cu3+LxZHvsDSHkvHo0aPFKskyv8GiN2XKlCzrMusTls5rr73W9zkWWmYOo0hzpLLjP6E3bI+pUO04YrYpSpJ89NFHWbZJe8466yx54uc9lkQrZ6ZixcLJOYDlkelK3fsK1E/MdNSkSROxcDK7EpZSzgWuQXhx+Pz777/P9N6eK6HaBxwj5w/vsZLSb/Y7vApkv3p/y/hmnHA95LrErFYUvuecbdiwYZb9YNVmJq6IrlG5vGyhjfa9dRPyPtplJpJgal673UDru/cZ7+Xstinc5XCPi//ICFmlSpti3U9WRu77f7K3ybuM1RMPG54pJqWx7v5I2hTuWAqXhFZQcYdxcWbKTH9s2rRJ5ml3w/pMM8l3dh3coW7se7uOP5gTmxujfRG7CnZ+epRbu8ygtR3iXZYOXDEltGvfC+uvnJIlrpNl+fr/P7fL1s3HbDTcVJk6cfbs2ebdd/9Tcpl+k0FHmAM3VpRS4Fg5TtrClKf8xk7jyQ0Ul/0777wjvyEsAEVq2LBh8lv2aQeoXUb+LFPflG0iN3vsyJsbK8op06yOGDFCfmPb4W4fSrZ1C1t3uF1makbgt+4Lhl2mTYR9cAwoMPyGOdq5uQftJ2Mkxpn6rLZNgNKCksMxse9A/cFDj/t42T6fM986LnYrG0IeWIdt4h6//vrrTbly5bK0yfaNXUbpYspTpv+0xxuoHe5ldz+5LxJ87m4HM4DwmZ2mle+Y6tJOf+tuK+MIZd499tzL9mJFSI2VB0oix2qP19s+xl6zZs18c7nbdrAf9sey+9i3b98u44lt8zn1c3Gb22lTCVWYM2eOzJzSr1+/TOeNv/5jelymEWWs43qnf1C4GUPIHIWcz3kIJkyIz3///XdRiDnP3KEM7hchTBw7IRMDBgyQKU05LwgXYUpff/3k7hvGHeEUyJFj4KGBsAIeOG1IjbtNPEwyrWiga4S3n9zLgcaeeznQOeRvHAZqU6Blzlm2w29Y5j/vbb1k1l27dq0scz6vX7/eF6pjQ0F4SN+8ebMsW8We8YSRgTEOXJu4TtpruTVW8Jm9rrOuNUwQTmEfzNk2+wD2yb6BY7HhLRyjlWus28RxcDwQizYhG45n7969KdOmWPeTdV3bdqRCm/z1E/do3P0Yf3D3c0+LpE02UdqGKAVqU9Jn8XNDev755+WmlRvxQ4MGDRILnAXBclOhkDzwn8HB4OKGaG8U7nnWfcv7/zWRtoD1HX6XkSFWMf5zEbcWMvu5XcaqAtwQGVTEqmE5Pu+88+Rzbt5YhDjJ2A5JZ8T7cdx2Dm6sV7znJs9N0CaXMY/5uHHjfIosyhbYfbqX7bFwwvAg4LZcoyBjrUR2WHH5/ttvv81kwbTr2zm8bbu9y4Cl3JZscs9xTxs4CVFOUGA4KZlB44033vApKv76ifnlUUBtfDLtQPFASWMbKBodO3bMNAOHuw9Q8FFYvMdLrCyB6FY2KPkcGzB+sJxhteMY3W1yx/PyGZZNFC/mOLfreNvh73N3P7nnbnd/bseYt03u9b2fu/sbZYsHGS5IyA+rO+tgaWSudrc8bLvc7XMv22O3fWr3b5dRenm4YfvEbZIYaZMsubiyzNhn39x0UepszHOw84n4TcY3scuAcoe12ju2vTLg2Hng6tGjh9+xapd5KGQubB40OL8YT927dzc//fRTlv5g2bYbSyk3C7sdlNyBAwfKTcbG26L8W0Wd6xRWjEDXCPeye7wFGnuh+inYsr9rRLC2cq6xzItlO/5YtutaYwEWdLwDgCcEb4m15OMtAc41zherYNg+wehgl+01HXg4s8eCJ8AuY9m2y1y37DL7tMsci13mGOPVJtrDgxTEok283MebCm2KdT/Z7HSOM1XaFKif7HWV6yAeNTwy5GiE0ya2bY0tgdrkzklJWgsqF20SNhCkVaCw5OCGtsk9CIJ13KBEcZO0QuK/1f4t9r1bkF7oLDrA/XJjOz2sZeqcRkFGwWN82wl3nySWYD3FeoQCihUIJci7vlvB8LcdYJ0PPvhAlFvcvFiibr/9dt9Tm/e3YC02DGLWc6+DS3/SpEnSf1gOuWHzmXufdvnyyy/3Wd74717m5htKHowb5hvmgsFJheJC2Eeg9QkJQHnAAm1PQPeJjCxuuukmUWDtk6I/mfn7DAsqSri/9TiBSXRhnWBt4qTmgQFrGrJD+eI3WPMiGR/BxhMXEM4zzg/7OeEO7oucXZd+wJpoP0dpQjnHOmj73Z88gi3jriYkx21V43Msmnxn16Xt7IuH1/vvv983lnnY4YGM9eh73P24q1DqqRbiHave/bM/HsbYNi/OIx7MAsnO/Rnnib+xygtFlHUYX5yP9mZyzTXXyDFaa0c4ciLhDQsGD0oo/lhS8TS5HwKwhHCTjOgalcvLFvcDkfsaFe0yfcrDsrWiBlrfvc94L2e3TeEuh3tcyAYZWWUjFdoU636yrmtLKrQp2DL3AZRUjC4YlmzicKjfWjmFGktJr6ASe8oN2d4seGF14ObEjQhwB2JKxtpqQQFCSLgF7TpkIrszXYkZQ/Dup5dwiVTAAkX4MyIUNetXbRHxrqzlBDf1008/LQMFEz6KDAMNRYfPvFUMUOzfe+89WUbx2LBhg9xkUW5RXFDQ+S2Wq2BY6wny5eHBuo3oI26sbBelh9fy5culL63LwA0WVHffu1/2iS8YxMqiwFm3JcvEI/oDNysxuYwLdyUBfud+uOGJkifYUqVKmXBBlmRH2idvLygTKCnIy1aswBrnhSdUXNpWdvQt8cW4cmMJT8uEEVhliBsXrmwvffv2lX27xwOytg8v0cDDD+ElbNeOI+JSGYOEhUQiZ6yU9BWyZBsouXY9bwUJC/FXWIKtC43/4c5XTUhMoPGKrADlnb627jostlgm3F6GYHANw3LKeLXuaywgXPjdpfWIHQs01tMNroVuC5SiMtJxFB54S3jQ5xqFJXXJkiU5fr7lqoufi6q7pA8WNS7oWJWw2ngVAS7GWD3tzZwbEpZCkm64qXIBx4WL9c2WpEJRGTJkiLgBubgTR0noQKByQaGISvDMEEUR/kjiUDPyGnNKVkUlFFg5CU+wMZko+iQS8eLmjCUKZdPtVrcKELLhxsbvsAjh0uAG//nnn4vMGXi4/G1MYpZDdj0N4vZAgeKBoUOHDqJ40C/uWZRQBrEeohhj4YwUFBncqoRf0F7coC+//LIo5+wLCxuJXZxoHLe1MlH+iReJJCj0WOVRHogltNZzrK0ojxw7/zluFPVIp2dF4XSXdkI+NgYV2Db7ta5aFKtQ8xP7g7AOFC+UKh4KSL65++67JdQj2HczZ84UKySWQsAax5ghBgnF6f3338/kjrVwfuHlYDvEY3Ku2qQlZB0KrJMch4UHSR6gGGuMX+TBOCT0gbJUWMIjkTNjgWOnDSjOVum2Zb78wfWB/uDh1o5jPvOXoBkNhHmg9BMjiqyw1HOeWRhrf/zxhyyzT/qAtlsIbeB8tDH0xMViSbXfWQhrwfqh/He+cS1SAqMyCk26yihv3rxyLeF6ipKKB4/rUo7JyclFKDfDIXhflJLxh7fMFGzfvt254oornKJFizpHH320lMmxZVzc5WvOOOMMp0CBAlI2h9I10ZZGcJd/iag8ype3OM4DxcMrMcV6rJ9DRFPiyR+Uatq3b5+vZBOljTp06OCkM3Xr1pXSQYFk5IUyUPRHOhNKRuHIORA33nij89NPPzmpKidKfNWvXz9TWb10LjNF6ZxVq1bJf0VlpOMoOg4dOuR8+OGHzkMPPRS0hF0451skZaYy+BM7dTd1wUqHlZGQAv4D7kysvsQEhnxqYGao9zqFLtaPa79SM2OuHJNj051iVcKd7y4OHg22ZIbbkkqMKW7jVJsmLpYyUlRGsRpLWP5JELSJjMlARNfRCLEVC9yJWIrKSMdR5HBdsfGogSyp4ZxvVpciITWUt1AV1DDxJ9SIL6xMd8qMUtQ3RUl1K6ooprwaXmVM+8dzTDlVFEVJVQVVUZT4KKmE0dWoUSPibUSioCZsklSikq05Zo8qaEzHocbcttiYVvcbU/0cYyo0+u8/7/mc75NUOeXpiRg+NcqrjHQc6fmWKNdrPESpNod6LFEZqYwiiUnFI0q1ICZPcecQxWMsqQU1p1z8aYBbMVV3mspIx5Geb4ng4sfqw41Vr0kqIx1HsYEEViypVOJxW1LDOd8isaAmbKH+RCUWF7m/9v1lPlv6mZm+cbrZeWCnKZa/mGl6XFPTuWZnU7Lgf7P4JKtsbEycojLScaTnW25j6zPqNUllpOModlAGEEsqmf1YUikDiFU11uebuvgjJDum6/2H95sHpz1oWo1uZYbNHmambZxm5m2fJ/+fn/28fP7QtIfMgcP/m/ozmfBOI6mojHQc6fmWm7ineFRURjqOYqukMjslJRpRUrGmxvp8UwU1UoG56nhGqpzeMOEG8+mST80h55BxpKLW/+A9n3+y5BNZLxmVVJ6a3FNmKiojHUd6vuX29dpO8aiojHQcxUdJJTwHJdXOPBir803P2giJ1jr45PQnzZzNc8wRE/zJgu9nbZ5lnpj+hElW2agFVWWk40jPt0SAaxHWHL0mqYx0HMVXSWUKc2ZkxJIaq/NNFdQIiUbwNuY0lHLq24dxZP0d+3aYZIN56rPz9MTMOcyEYyEp7fHHH4/R0f03vWTv3r0zfTZ58mSx+tqpXi3MkHTLLbeEvW2mIqWerH0xRRwnLzJxQxiEnbWpbt26su5pp50mM31ZqGfJrF5s45xzzpEpR/3BMTLDl3u/TCdrYWY1po1lSlIC0/me7TKzGLM2hcOjjz4qM4nRr2PHjs30HTMjNW/eXLbJtpk5zMIsU3Xq1JHvmD3JTlHsL0mGWaBoK+syAxnTdQaCzFHin3hqZ0YufsMUyFSQgKuvvlrmu3fLxI4tu+xl6tSpMgsWtf1wWRFTtXHjRt/37m3SphtuuCHT9MnMtGJnA4sljB3ky34feeSRLO/tWAoGcnfLglnAmFHOwrhHhvXq1ZMZx3DRAe2jX/iOmd5IjLD91aJFC5mC1sK01N7Z6RLleu2eG1xRGek4ij3c56iNWrlyZbnfrFixQj4nYcp9nYiYKCcWSDv8zX4Q7gwob/75plN/RH2n3oh6Yb9Yn98lG8zilZ1hNXjwYKd///4xn+XKUq9ePZnpwk23bt2cVq1aOWeddVbQY4mUp556yunYsaPf7+bMmeNUqlTJN+vZe++95zRu3FiWmYWjevXqzqRJk3zbufjii/1uJ9gxMsNQtWrVnH///dcZPny4zFJlmTZtmlO6dOmw2sGMYMuXLxf5jBkzJtP2mZltwoQJ8n7x4sXO8ccf7+zZs0fejxs3zrf8+++/y0xvu3btyrJ9zp+vv/7aNyPSCy+8kKUvLBs2bHDKli3rvPnm/84Ntvnggw/KLErATHTeGefszHUNGjTI8jkzzZUqVcr5/vvvfZ8x21ytWrWc3bt3Z9kmx9ukSRNn2LBhvvW7du3qjB8/3ok1H330kdO2bduA76OB2d2efvppWV64cKHIE7nacXjeeefJ8pdffikz8wH/eQ933323M2rUqCzbZXxNnDgxoWaSUhQl5zh48KDz/vvvOw8//LCzYsUKOa9ZtveBSGeSUgtq5Ap9xA8Bv238LUvMacj9GMf8tuk3Ew1YA++9916xLmGVGjlypO+7bt26iTULCxpzf2/atMn33WuvvSbrY1156KGHMsWSYinDksdv2S4lJty/w/LE588++2zI45s7d64544wzZD9YEB9++GH5/Pfff5c50zleLD3MNY61k7nrec++4eyzzza33367zPlO5qDXIhoI5o4vXry4POW5LbRff/21zNvO/PDeum7Z4a233jLXXXedX5ejtVDt3r3bdxx2bvpZs2bJE2nLli3lPda6L7/8UixXkTBz5kyxfPqbxYv9lShRIqztNGnSRKyK/izGW7duNa1bt5b3jB3k+80338h7LGp23vv69etL21nfC6WFzjvvPN94a9q0qcQy+TvXXnrpJel/t1yZ0/6+++4zpUuXNtHw5JNPmmuvvVash5aBAweKxZm4Kn/Hi7V18eLFvn785Zdf5PxYunSpz6JMmzkPQ8Hv77rrLpEz4xx3GVaH77//XizDv/76q3zufT9hwoSI3ddY1ydOnGiuvPJKeT9v3jy5Fhx33HHynn6g/+hbZoPZs2ePfM5/4suxlC5atEiO0QtWZ64FiYQmbqqMdBzlHJSX6ty5s9xjP/jgA7k+4Xmx18pIUQU1BxRUSklFw64Du0y0cLOfM2eOuMtvuukmueHDc889J4oLNxoUPFzE9kbF8o8//mhmz57tc+dZZaZXr16iOPJbboy33XabuJ353eDBg32/27Ur9DETq8JNkvVRxj799FPfTRdlEyUaZfX+++8XhRUFi/fs20KcC6559o8Lc9q0aSH3i4sX5ccNJ1G7du1MuXLlTPfu3WVqVn9wgrndpO7XNddc49dljJLRsWNHvwoJCsyAAQPETY1iOnToUPPCCy/I97hY3Uo07adenNt178Yq9N5jGTNmjLhoLcjLhh506dIlrIeJYKAQothQasQ+xCAnO9bcDB8+XJRcd7sCMWzYML9yA8aMtw/98dRTT/lkcs899wRdl202a9Ysy+d8xvj0Qr9yXjVq1MgnV6YWRaF78cUX5dj/+OMPeRC79dZbwzpWlGxCPBjnVrFF8echjQcVPvf3/t1335UHQ3/jEmXeC6EeKKFlypSR94xD2r9kyRJ5z4Ma17jVq1ebNm3ayNhjHZR1FHDa8/zzz/ttB/LivE4kaAuhGuriVxnpOIo/nGdbtmyR+w7XekLCuNZg/IkGrYMaIdHEV1LnNBqK5i9qouX666+X/ygFxIuhQKIYopARc4Y1jpe1OhE72L59e1HUoGfPnnIztMoWMSXeGDOUERREPrcWGJRhbrjB2Lt3r7nxxhvlJos8165dK8vEYYYL8S5YGXlxM0Zh9adkuCEWzTs1G1bOxx57TJaxoqGsYj3mSdANlkiOMVzY7lVXXSXH531wKFCggBQm/+yzz8RiS0wgig1t+vnnn02koNDz4OHliy++yKQwoNjYGFL6DQUH5YT9RwtxrFgbkeGJJ54olnFvmzmGIUOGyINNqAoPxLsiE34TTjUIFPt33nlHYjNff/11GcOApTGS+OFwYFyj4DFmL774YolLBWSK1QA419g3D2pYWa11ORj8nqLVPKgBcaWcq6FAPhyDPY5wbh48gPEAYMHzwUMgY5WHUrwqWMHpQ9r5xhtv+NZljHHjYb2uXbtKzG/fvn1FcQWuHVheua4kysQltCGch6J0RmWkMorlWNq8ebM8OHPecS3Ba7Zt27aorguqoEZINE/iFOH/deOvEbn5M0yGaVoutKUo7O1lZIjyw80JayNPNSgwWCkDre9uM8oHiqoXFB33euHIh+QZFGMsvNwIScCI1H3tHugok26LbyAKFy6caT8onFiSUcZtezmRcHF6LXgo4yiQ/sCChYXQgnKCVRGLohcrI5JqsJRZ5RDLJ8o9ygllOrBgWQhxQIGJRJHEIsbFoWzZsn6/JyGG/eCaJuEoWrCuuZPaTjjhBBkrlilTpkjbCFFAyQ/G008/LUo7iiz962/SB2TtTibDCs0Lt3+kY8hCqAnnhFUyLXxGeIXFn9LLMWLBJ0wAsExjTaUNPHSg1I0bNy7o/tkG1nOSwyKB32HxfOaZZ/x+z7hGgXT3BTLiIcwNyjYvIOSH5D3vgxzjkXbQ1z169BCPChZkHirnz58v67BtzkVCARJt+mUeCrX8ncpIx1H8zzfC9rgOYDXlgdXe8/CScp2OBHXxR9EBkcIMUXkzMlvkQpE3T15zUc2LTLRYhQl3K7GXuPNxTeKyK1WqlChC7ngxrGvcaDHPWwughRsuFj9i4NzKHdvAesJNy8ayvvLKKyGPjePArY1yiuLHzdyCKxtlzP0ei2s42cqhINbOHQtDGwlV4OaLnHihULjb7rWg+nu5lVMgixHFjWxvf6BMY9lGObQhEVQXwPXOzZ0bP2EAuI6Bfjr//PMjevr0uvf9WZOJl2SfMGjQIFGoIsWd6Y61DVe1tahhtSfWESsr8ggG4QaUKGEsoFgHeuBA4cK6iiXTQpxTtMopEM9Mn7utzSicjFPiKoOBsoxSXrTof94OZMpDARZJtsFF2a7njnF1Qz9hCXbHe1qlLxQ8NPGg529cupVToI1YW73eAduHZNxiDed3PMy56d+/vxwjFhLipu2MMTaGGqi8wINPItUctXHP6uJXGek4ij+cZ4QE8tDPNZD7K14t7uPe6044qAU1QqK5+DJ9KcomRfjDKTWF9fSiGheZEgXDS2LxBzcbrE3cQLCa4jKkTA4WF5QtlFTcj7Z8kY17I8EDJZZBRdwZkExDIhE3cgYcyhPWN1yT3JCIXUUB5iaNNTQU7AfFBdcsSU5WoQGsWIQg4LZnW1h4Gegol2zfHYcaKVhFCVtANrSB2E2sSm5I/qCduCmiBUUA65UX2oIVlDhb2kZbSPzCuoNiR/iFHWP0E9Y7FC9+4y2BFQr6xvsbG4MKtB93ulUciZm0MZVeSGLDDcyNHos5patQiihvhVsdOXJhQlFDMbaWKhKZsF6542I5JsYa1nteb775pijLjCuUdpsYhkwoteUFWfDAhRWeccc4Zl3c6YzBUPBUb5PRgLAQEv5QolHS6RuUYxKWiFn2KmqhHgSwjNN3PGigOCM34OHHJox5QSlETsTWWtnxmdsSHWxijHDgoQ/rNHGxXght4SGNY8DFz7hww7hknNjjIaGL8c1DI8lpFh5UrSU2UeBcOv7443P7MBIalZHKKF5jifsa1zV33oC37GIwMkjlj9nRpTD//vuvKGw8HVjFDeUByyKJLqGsW8wM1WtCr5DF+lFOG5VtZF5r85rJnzc6Vxk3Lqw/WKIiAVeyzfgmEYIbjs3IDgdrymf/iepOwzqEmyE7bu3skBMywiKGG5fwhXBAYcdVi0KYCNavZBhHFpQ2FH+bdBRs3GGNJUY3FeWEssrDFrHskVZTiOQ6GinIx8a+5baMEhWVkcoo3mOJ6wPGAQwbhJ9R25yHZiyrwVALahQdEA0omyidzChFEf7DzuFMMakopoQBYGkd2GRg1MppdsAygtsZ6xqWqmhKxmB9Ips5UcGCGonSHQ/iLSMS1sJVTgHXi7942dwk0ceRJVxXvL+M+lSSEwomN51oS33F83qNxYZzQhVUlZGOo5w73wAPLYm4XCejCdNTC2qEFlS31h/tkz8zS41ZOkbqnFJKimx9EqKIVSUcIBUgltVf0gela0Jl+SuKkj7E04KqKErOQlghIWPEwfure43bn4TTcCyoqqDGwMVPfGeg+LJ0whahx02s1gqVkY4jPd/CgaQwYmDj5eJn+8QS6zVJZaTjKD5w36c8oHXh28loLMTKk69CXgxhhIQfxs3FjwuYrG1OfBIlSpZMDatfpC5+XGtc9HhKQA7pfgFENowNKxdFZaTjSM+3YNcL3H5cP3mojUd5KvaBcQEDgl6TVEY6jmIL7nyUUiym5LB4IZkapZTSU/b85nwMl7AtqOyc7FSm/qNkChcWG6BPVizuXGrjNW7c2KSLix8oE0QWsuaaKYqiRA7WTWLWEql+qqIo/sEIZROe3PW6LVTboeoHiilVVsLVpaK2oFKj8JFHHpGSQNRjpMQLSTQ8laJBU3qG0i8oqZQToOg0M5SkIl5FlM6grXRauqPuNJWRjiM93yKBBD3qIcfLusk1CSMC12m1oKqMdBxFfx4x1TZKKfoeJenccG5RU5syhjxsonjG4nwLS0Elw5ei24Hq8lEzkFp61PyjaDnKarooqPYiG00R2lSDuBOejqhLmQjlihIRlZHKSMdSzj80k5ihCqrKSMdRZHDuUBEGxdRO4uMGCymWUiymPARyfyNkhzjTWJxvmiQVJpGYpRVFURRFUZKNI0eOmBUrVohSumjRoiwJT+SYYKxEMaUof6SKaMxd/KF2RnFmZidiJplUR2NNg8uG8RAr834qojJSGelY0vMtkdBrksoImNzHTpPsL5GJXCOUUpRTvKQ5MZYi9sMyFaSds5s50pk9hM+YivLTTz+NaFuEDRDTSjwrjWF6RgsxnUz3x7SIuGdYhykviYNwQwxst27dRCCULmB6RTu/uQUTNdMgUsIEjZ85sqNFFdTgsiE2RWWkMsoOOo5UTrFCx5LKSMdRYNCzmP743XfflSnR0cncyim6F9NB33jjjaJbNWzYMKByGo/zLWILKg245557fPNQcyDUBmVedebs7tKlS0QFXYldIH7VO4c7sQ/MQMBcz6yDdt+/f39zwQUXZJqPHeWUqR0nTJggwmbeb6oJ2HnNETbJW8w7T4wsncH+UGZZL1I0tjK4bEJN+ZjuqIxURjqW9HxLJPSalH4y2rhxo+hXJDxRz90NxkJyiLCW8j+S/JpYyyniGFQy9ynEiiUSiyaWTaa4W7NmjdS68lovwz6QjAxReDt16hQ0WYuELEobUF9r4cKFsk8+x5ILzB9/3nnnSeknju2VV14RhZq6rbaMCVN6Yq0lviI7hfqVzDCUiCtBPuri94/KKDQqo/BQOamMYoGOo/SQ0d69e8WbjAsffcgL9ezJwudFklO85BTXGFQU02nTpkljUAapiwpYOOM9TR0NotFYP4HjYNkqp4ClFC3+t99+M507d5Z1WrRokanGXrt27cwTTzwhx1yiRAm/+8JM7S6lYM3ehw8flv9Wr+d4CCLmfzyXaRP75BXP5ey0id8zNzgy4qkrFdoU635CNsjI/i4V2hTrfkJGeEPs96nQpnj0jVdOqdCmWPcT27AystftZG9TrPuJdZER77lup0KbYt1PgIw45yiLlixtOnz4sMx2SSF9DHpWf7HQFox8uO7R7SA7bbJyCjaW4hqDesstt4hbnYBZLJRnn322z/VPvGi8wAxNTOoVV1zh07p5CvCakxE4yrN9QuB/2bJlM61j3/t7irA89thjouXbl+08lGRAueVl42Dt59u2bfMps5RbsBblzZs3S9iCNa9bs/r69et9ivDatWt99VSxSDOY6FSW+c97loH1WB/4PduxcmL7wP7YL3Acdl5cjo/jtO3h+GPRJiZvKF26tCynSpti3U9sExkhq1RpU6z7CS8FmaJc+FKlTfHoJ7xE9gE7VdoU635i2SobqdKmWPcTsuGh2bYjFdoU635CRugBth2J3qZt27aZH374wQwdOtSMHDlSXPlu5ZR7UMeOHc3NN98symnlypXlnpTdNiEnFFPbjkBtimuZKWJAEUKbNm2k9hV8/fXXYs1s3rx5pJsL6eJnABHbygUZoVsF9dFHH5XY18WLF2daH6V1yJAhpk+fPhJ/yhzPr732mu97ZkEgE43/gSoP+LOgoqQicG4K6f7U7W8ZbAgE20uFNsW6n1iHE9Z6AVKhTbHuJy6kjCMeNPk8FdoUL+uIW06p0KZ4WFBRAOx03KnQplj3E9j7mpVZsrcp1v3EZ8iI6zYKWCK26fDhw6ILUR6KMlH+ZmwjmR0XPlOzx6OfrJyCjSVmJY25i58s+AsvvFBeuNTdbnXo0KGDiQcop1QJIO6UclbuBpUrVy5L8VieBBEQ39l1rPZvse/tOv4gU81fthpCB3tiuz+L97Lt6HguZ+cY7clmldNUaFM0y8GOJVbtTqQ2xaOfwh0/ydSmeCx75ZQKbfIua5vi20/uh0DtJ/9jz8ooHmMyu+fHpk2bRCklAZw4UzdsnxlASXiiFKg34SnW51a4YylcwlZQe/bsaT7//HOxTOLeJ5ue1+mnn55JyPFQTpcuXWomT56cZV5Xyh9gQZg1a5Zp1KiRfIYSi6bOlKt2HZKk2BZuQyDjn84KFH8ajHi1NRVANtZSoaiMdBzp+Zbb6DVJZZSK42jfvn2ikKKYWle8G3Qbm/CUkxMLxVpOEbv4cXtPnDhRlNUvv/xSzMpYT1FWST4iyz9ciGdYtmyZLKPhP/vss6Zly5bSQOZzvfjii6UUwldffZUpjpTvbdLTueeeKxZRSkjZMlNYd22ZKczIKKO4+olhJRaDMlPEZkRSZspmnuEusu5ZJTM8GGC9pn+ieVpKB1RGKiMdS3q+JRJ6TUoOGTmOY1atWiVKKQlPeIv9JTyhlFapUiVXjGnhyCmSLP5sT3VKtvwXX3whr+XLl5tzzjnHDBo0KKxYVOJJUUi99OjRwzzwwAMSO+oPrKk2OQth9OvXT5RlBEKsKgVnbWwsUFqhb9++Uo6K4OCbbrpJlNVI0DJToUmFUhzxRmWkMtKxpOdbIqHXpMSW0T///CNZ+JSHsglVbkhWRyklST3elZRiIaccVVDdoKCiqJJMhPUzlYhEqIqiKIqiKNHgTnhavny5L7/DgqcahRTPc7BcmkQkbgrqqFGjRAGlHEGrVq1M7969TbqgLv7wzPuUksBKrS5+lVG06DhSOcUKHUsqo2QaRyR9E9ZIfOme/y8n5cad8IRLPxnlFJdC/czIhJucqa/Q3j/77DPR7J966imTTqjrOrhsqHygMlIZZfcc03GkcooFOpZURok+jkh4IjcGF76tQ+rmmGOOEaWUKd8TPf8l1nIK24JK3VAy6gcPHizv33//fXPDDTeY3bt3m3RAXfyKoiiKomQX1C5KZ6KUzp8/P0vCE+WgTjjhBFFMycVJJaNPXFz8WE3JHCM7zJpy+YysMjLuUx118YeGMcEsE7YIsKIyigYdRyqnWKFjSWWUSOOIIvUopbzsbFJuiCdFKSW+tFAEFZGSSU5xcfFTXqpIkSK+9+ycUk/ewrCpTio9ycRDNsxWoTJSGek40vMtEdBrksoot8cRCU9LliyRhCfKanptgmTe24SnZDf2ZcRYB4goyva+++6TnVtIlnrkkUdEG7ZQyzSVUeUruGyKFSuWg72RfKiMVEY6lvR8SyT0mhQfGWFJRCmlzKW/UEhc9yilderU8U0ilOxkxFgHCFtBbdGiRZY575lFyj3nazoob3bOecW/bJg0gUkV1MUfePyojEKfYyqj8K5FKieVUXbRcRQ7GeFpJqYUxXTdunVZvselbWd4imYmy3QbS2ErqBTVV9JDCc+ObDgBVUYqIx1Her4lAnpNUhnFexzhsl+7dq0opSinzGjpTXjCSopSWq1atZQ23mTEWAeIupAWta6AelfphCpfwWXjjlNWVEbRnmM6jlROsUDHksooXuOIqdqZ4QnFdPv27Vl+U6ZMGXHhn3TSSZlCI1OZjBhfuyNSUP/++29zzz33SMF+O+UWZurLL7/cPPzwwwlfoysWqIs/uGw2btwogd6p/JSYHVRGKiMdS3q+JRJ6TQpfRiidhDWilJL45E14ogZovXr1TMOGDeU+mG4GrSMx1gHCVlApidCsWTMpJNutWzep0QULFiwwI0aMMBMnTjRTp05NybgKN+k24CKVTcmSJVVGKiMdR3q+JQR6TVIZxQIspCQ7oe9gOfVC+U2spehFqZLwlAjnW9h1UG+55RZRQr///nsJgHWzadMm07ZtW5n+dOjQoSYV0UL9iqIoipIeUKXIJjwRY+qFbHWb8IRSpuRioX6eEF577TXTrl07v9+PHz/e9O7dWwr3pyJaqD888z4W9goVKqiLX2UUNTqOVE6xQseSyigSUIfIvrcJTyipbnBb165dW6yl1atX1/tcFOdbXAr1E1fAdKeBIO4CS2qqoy7+4LJhBgmVkcoou+eYjiOVUyzQsaQyCgfqlNqEJ5sA7obrkY0tLVq0aEzGZiqSEeNrd9gKKtn6WEcrVqzo9/uVK1emhZlbla/gsmFWDEVllN1zTMeRyikW6FhSGQWz9jGzk0148iZAM1MmSinWUiyCeu/P+fMtbAUV1z4Z/BMmTJCO8xanZZap9u3bm1RHs/iDy4ZYneOPP15dHyqjbJ1jOo5UTrFAx5LKyF/CN0opFtOdO3dm+b5SpUqilNatW9en6zCO1qxZo/e2HD7fwo5BJS7j1FNPlTIKffv2lcKz/HThwoXm5ZdfFiV15syZcmCpiI2boNSWe2pX5X8wHihSTBajPm36R2UUGpVReKicVEaxIB3GEe0jAx/FdPXq1Vm+x23foEEDUUxLlSqVljKKBeHIKS5JUtaNf+ONN5rvvvvOV/+Lg2jTpo158cUXTY0aNUyqoln8iqIoipIcoKNs2LBBlNJ58+aJEc0NukutWrVEKa1Zs6Z6/XKIuCmoFor0L126VJZRSok9xbI4btw407VrV5OKaBZ/aKwbBBeJFupXGUWLjiOVU6zQsZR+MtqzZ4/ULEUx3bJlS5bvsZCilGIxDTfhKdVkFC/CkVPcFVR/EM9Bhtvhw4dNKqIu/tAwlOh/5h5WN4jKKFp0HKmcYoWOpfSQEYqRneFp0aJFWXJFcDlThQgdhUTvSNuZCjLKCcKRU1zKTCn/oYMzuGx4alIZqYyyg44jlVOs0LGU2jLCm2sTnlB8vJATQyF9lFPyZ9JRRjlJrOWkCmqEaBZ/cNmoGyT0+FEZqYxigY4llVE6jiOScEjO/v333yUvxkuRIkXMSSedJG58anKmo4xyi1jLSV38YaJJUuEPUD2BVUbZRceRyilW6FhKfhnhOmayIJvwtG/fvkzfY7Ej0ckmPOFiTjcZJQqh5BQXF/+wYcOCfs/0VulAjEJ2U1Y2DE4uFuoKURnpONLzLbfRa1Jyy2jv3r2+hKfNmzdn+Z4EbZvwVKxYsbSUUSIRazmFraAOHTo05DqYdVMdVVCDy4Z6uYwDPYlVRtk5x3QcqZxigY6l5JMRx+NOePImXpPwRBF9FNOcOuZEk1GiEms5xczFHw0//vijeeqpp8ysWbPEfD9mzBjTqVMn3/cc2uDBg80bb7whZayaN29uXnnlFTHhu2eFuOmmm8yXX34pZuUuXbqY559/PlP5CJ7AmFxgxowZEpPC+nfeeWdEx6oufkVRFEWJD9zjiSvlhfvXC9ONopQy/Wh2Ep6U3CVpsvh3794tpvlrr73WXHTRRVm+f/LJJyW04J133jFVq1aV6VSZcpUZIex8r926dRPllilYCZ6+5pprTK9evcwHH3zgE0bbtm1N69atzauvvmrmzp0r+ytevLisFylqQQ0uG51tI/T4URmpjGKBjiWVUbKPo0OHDomVFGspVlMvhQsX9iU8lSlTxuQWeq7ljpzCtqBismUQ2WnAmDnqqquuCqkBh30gGRmZLKgcVvny5c1tt91mbr/9dvkMjbts2bJmxIgR5vLLL5dMPkz9WEaZhhXGjx9vzjvvPDEz83ssrvfcc4/ZtGmTb17du+66y4wdO1ZOjHDRQv2h0XmvVUaxQMeRyilW6FhKTBlxP0afwLvpL+GpevXqopTWrl07LglPkaLjKHZyisSCGvZoROFzx4LcfffdZtu2bSZeUD6CQYzl00KjmjZtaqZNmybv+Y8l1CqnwPoI5rfffvOt06JFC59yClhhFy9eLDXUAsG0aAjS/XKDAm11ezol3st2n/Fezs4xcmGpXLmyb1up0KZY9xMgI2SVKm2KdT+BLVOSKm2KRzu8ckqFNsW6nzjP7M0yVdoU635CNsjIWrzi1SYU0enTp5vXXntNXiy7ldMSJUqYli1bmv79+5srrrhCjE/esZ1b/cRxuHNs0vV8ckIsWzmFGkvhEvXjUqQ7ihSUU8Bi6ob39jv+e83++fLlk8w+9zr+tuHehz8ee+wxUYjtixMYrFLLf7tMHKyNmUFpt8rs1q1bza5du2SZDESmYANCEuyJSfUDO0cwTx6Yx4FaYjwQ0Kks85/3LAPrsT7we1tFge2yfWB/NvOR4+B4gOOzDxccN8cfizaRccn+U6lN8egntomsUqlNse4npijkGpNKbYp1P61evVrCpGw7UqFNse6nnTt3yjqMpVRpU6z7Cdmwf8ZSrNvEtpcsWWJGjhxpnnnmGfPNN99kuu9iHcWFf/HFF5tLL71UjEn2OBOpn2gH203382lXiDYhJ9a17QvUppi7+NGM3QohJR2YvaFatWoR7TBcF//UqVMlKWrDhg3muOOO863HIGbdUaNGmUcffVTiU7GGuuEYhwwZYvr06SPxp8Sv8sRmIYaVmSX4f8IJJ/g9HjrLdjggWJTU7du3iwJsxWYtYbasQryWrQXAPvHGazk7beL3tr/sVGfJ3qZY9xMXB058wk/srBvJ3qZY9xNxaYwjpiS0nyV7m+LRN145pUKbYt1PnG/cdO30lqnQplj3E+viISUJiet2LNpkE57QEVj2wvXPzvBEnGmijz2wYYMYwdL1fHJCLFs5BRtLPDTGJUnqzTff9GXHc3EkFrR06dKZ1rn55ptNLChXrpz8Rxt3K6i8Z2DbdbC0uOG40Nrt7/nvrZ9m39t1/EGWoL9MQQYnIGiLO9Yinsu2o+O5nN1jtJbmVGpTpMvBjoXx45VRsrcp1v2EjPyVrEvmNsWjb/zJKdnbFOt+4ibpllEqtCnW/cS6bhlF2yYeBjAWoZguW7bMeClUqJAv4cnr1UyGsecdR+l4PmWEsRzOWAqXsBVUdkq5JwvK3XvvvZdpHQ4wVgoqVk/2MXHiRJ9CihWT2FIso9CsWTN5OqNMVaNGjeSzSZMmiaZOrKpdhyQpm1kGZPwTfE3MS6TYpwTFv2xwDVBhwX3iKSqjSM8xHUcqp1igYyn+MsJINHv2bEl4InTJizvhyRp4kg0dR7kjp7BHy6pVq0ysIZ7B/aRFYhRPX7jQUYhvueUW8/DDD0vdU1tmChO7DQPAPd++fXvTs2dPKSGFEtqvXz/J8Gc96Nq1q7j7r7vuOjNw4ECZJo06qeFMPOAPVVCDywbrNRZvVVBVRtGi40jlFCt0LMVHRigh3EvJxCfMxAvJyxiWeOHOTXZ0HOWOnHK1UP8PP/wgWXteevToIeEDtlD/66+/LpbSM844w7z88sumVq1avnURBkqpu1A/tVMDFeonJIFC/SirkaCF+hVFUZR0hfsxiXkopeRvEE7nhnAKjEZYSzEoqZFCya4uFbaCiuked3vHjh3l/aBBgzIlETE4H3roIV8B/VQVKopyKjwRxgOGEhl/BL3rxUllpONIz7fcRq9J2ZcR9z6SnfBu2uxsN4TioZTWr19f4kxTER1HsZNTXGaSIlv+66+/9imoFOonA88OSIre41YfMGCASWXUxR9cNgw+xoQqqCqj7JxjOo5UTrFAx1J0MiLhifJQWEsJw/Pe9zBEoZCimLqTmFMVHUe5I6ewLahnnnmmzF9//vnn+y0z9f7775uXXnrJV0Q/1VAXv6IoipLKUOMSpZR7u6236QbXPUoprvxkTXhScpe4WFB5iuKJyf0E5S4b0KRJE4nzTHXUghpcNiS+Ef+rFlSVUXbOMR1HKqdYoGMpvIQnsvCJK7WF2t2gRJDshGJK8lM6ouMod+QUtoJK7KU75tTOJmChtJP7+1RFFdTgsuGpu0iRIqqgqoyydY7pOFI5xQIdS4HlwgxCWEvnz5/vm3nInVNSp04dX8JTNDUsUwkdR7kjp7AVVGbioKwEtcz8Qaa8ndEklUn3EzWUbLwFmBWVkY4jPd9yC70mZQbrFslOvJgV0QuzMKKUUlCfRBdFx1Funm9hK6jnnXeeuf/++02HDh2yZOqT4U+tUb5LddSCGlw2xJfgElIXv8ooO+eYjiOVUyzQsfRfwtPSpUtFKSXxyXsPY8ZESjcyuY2dglnRcZQI51vYCurdd99tRo8eLRZU6o7aWqRMbUZGPzXRWCfVUQU1uGwI8+C/XuRURtk5x3QcqZxiQTqPpW3btvkSnnbv3p3l+ypVqvhmeCJhhRrh6SajcEnncZSbcoqoUD8zPTHNKFOF2p9xEG3atJEC+jajPxXRLH5FURQlkTlw4IDElKKYEmPqheo7doYnZmxUlJTI4geCpcePHy/Feu0UpTVq1Eirga4W1OCyYdAx+PQpU2WUnXNMx5HKKRakw1iijevWrfMlPKGkeuMCsZJiLa1evXqWPIp0kFF2URnljpyiKmSGQkpZqXREFdTgsiHUQ90gKqPsnmM6jlROsSCVxxJue9z3KKa4870ce+yxvoQnsqrTUUaxQmWUO3IKy8Xfu3dvc++994aVpT9q1Cg5wG7duplUQl38iqIoSm5COUe8lyilJDzx3k3+/PlNvXr1RDGtUKGCKpxK6rv4eRJjWtPmzZvLTFKnnnqqZPuRzb9jxw4p8Pvzzz+bjz76SD5//fXXTaqiFtTgsmE8lChRQi+MKqNsnWM6jlROsSBVxhIlocjCx2K6c+fOLN9XqlRJlNK6deuKkpqOMoonKqPckVNYCupDDz0kmftvvvmmJEOhkHoDr1u3bi2Kafv27bN9UIqiKIqSzlA8n3st1tLVq1dn+Z7Zeho0aCCKaalSpXLlGBUlnkSUxW9BQ16zZo3UP6U0BYHXqf7kpS5+RVEUJZ5wO96wYYNMPcrEOP4SnijxSBZ+zZo1deIYJemIWxa/BfMtr3TEG/OjZJYNFR5IotMZtwKPH5VR6HNMZRTetUjllBoyYnpI3Pe48bds2ZLleyykWEqxmGI5TUcZ5SYqo9yRU1QKajqT6pbi7MomX758KiOVkY4jPd8SgkS+JnEzX758uSilixYtymL8OOqooyT3o2HDhpKgHK82JLKMEgWVUe7IKSoXfzqiLn5FURQluxAiZ2d44r7i5fjjjxdrKcpppAlPimLS3cWfzqiLP7hsqMdHXLK6ilRG2TnHdBypnFJpLJHwtHDhQlFMV61aleV76pTivie2lKo56SijREZllDtyUgU1QtQNElw2BQoUUBmpjLKFjiOVUyqMJZyTGzduFKV07ty5Mke599hIdMJayv+8efPm+DHa49DrtsooEcdSVC5+CvH/8MMPEj/TtWtXKTNF5iHm2lgHcCcK6uJXFEVRwkl4QiFFMd28eXOW70kgsQlP3DsVJZ34N54ufuqxUeuUMlM8EbZp00ZOsieeeELev/rqqyaVURd/cNls3bpVXFTqKlIZZecc03GkckqmsYSdZ8WKFaKUkvB0+PDhLAlPFNFHMaWofiJ54vR8Uxkl6liKWEHt37+/zCRFgLe7OHDnzp1Nz549TaqTSBeWRJRN4cKFVUYqIx1Her6lxTXp77//lix8XliEvDDdKEop04/i+kxE9LqtMkrUsRSxgvrTTz+ZqVOnZskurFKlilm/fr1JdVRBDS4bdVmFHj8qI5VRrK5FOpZyXkaEuGElxVqK1dQLN+iTTjpJFNMyZcqYREfHkcooUcdSvmhMuF73Baxbty4tLpbq4g8uG2KuypYtqy5+lVG2zjEdRyqnRBtLmzZtkhmeiC/dt29flhtzjRo1JAu/du3auZbwFA16vqmMEnUsRaygtm3b1jz33HPm9ddf952Yu3btMoMHDzbnnXeeSXXUghpcNgQ9q4xURtk9x3QcqZwSYSwxnTdTjmItJSPfCzMqopTyCpXwkajo+aYyStSxFHEWP5bSdu3aSVD40qVLJR6V/9S9+vHHH5PCpRENmsWvKIqS+nBvo1YpSim1S3Hpu2GmHJvwVLlyZX0gV5Q46VIR22CZco0EqXvuuccMGDBATtLHH39cTuZYK6eEEtx3332matWqplChQqZ69ermoYcekguIheX777/fHHfccbJO69atRWF2w9yw3bp1E2EUL17cXHfddWL1jQZ18QeXDXHIKiOVUXbQcaRyyo2xxA1zypQpZtiwYebdd98VV75bOS1fvrzp0KGDue222yQpmLyLVPAW6fmmMkrUsZTQU50++uij5tlnnzXvvPOOTPs2c+ZMc80115hHHnnE3HzzzbIO5a0ee+wxWQdFFoWWC8uCBQtMwYIFZZ1zzz1X3DOvvfaazOjBNho3bmw++OCDiLV+sjb5r2SFoURsFnJPhQt3PFAZqYx0LCXO+YYCunjxYjGwUNfbC0YPm/BEXF0qotcklVFOjqVILKgRK6gog5yo1157babP3377bal/NXDgQBMrOnbsKPt66623fJ916dJFLhrvv/++CIOnWp5ob7/9dvmeRvObESNGmMsvv1xcNLhjZsyYIeEIMH78eImXJVyB3/uDmq7umT8QKnMkM48yVlgrNjqBpwX+x3OZgGP2ySuey9om7Scde3o+pfo1goQnSkP9+eefEmfqBW8dhfTr1KkjNUyToU2p2E/apoyU66edO3fGz8WPFZKT1gsWzlgX6T/99NPNxIkTzZIlS+Q9oQU///yzWERh5cqVcqHBrW+h4U2bNjXTpk2T9/xHobTKKbA+gvztt9+CKuJsy75QTm24AKCo8rKf2Rp4zEOLMgso7DaUgMw2ZhgBrLk2CxRzuFWE165dKxZeYCIEQhzoVJZt9QSWgfVYH/i9LfHFdm0wP/uzM5lwHBwPcHwcJ3DcsWoTyxwTin+qtCnW/YRseM8+UqVNse6n7du3yzlv53VOhTbFo5+YNIUXVsBUaVOs+4ljwptmC4jjwn/jjTfkPsb1362ccp9o0qSJeNi6d+8uhg577InUplj3E8czf/58X/tSoU2x7ieWiUu27UuFNsWjn9g+Jdi4hgdrU7hEbEHFdItVEne6G+rBYan0lt/IDjT27rvvNk8++aSU7UCwuPcHDRok31OPtXnz5jLNKjGolksvvVQ09VGjRkmYAO5/3DhuiJcdMmSI6dOnT0QWVARO5qY+oWZ9OoIDBw6IxYEHgGR4mstpSwLrcFGwdYRToU2x7ifOc8YR1xo+T4U2xaNvvHJKhTbFup+Q0bJly0RJ5eVNeOK+csIJJ0gWfrVq1eI23hJ57AGKOuOI36ZCm2LdT3yGbsN1mzGTCm3KE4dlKycmpQg0liKxoEZcZgol7ZdffsmioPJZIHd5tIwePdqMHDlSYkWx0OKSueWWW2Q/PXr0MPEEAfub+cPWt7MnNtARObFsOzqey9k9Rhv3m0ptinQ52LEwfrw1EpO9TbHuJ+RDGE+825rsY8+fnJK9TbHqJ26CeNyILbUWKjflypWTuNL69ev7ZJiT7Uu0fmJygVRrU6z7yTtOUqFNGXFYdssp0LGES8QKKtOZoiRiBTrnnHPkM9zwd955p8SCxpI77rjD3HXXXRJLClxMcGnhfkdB5SIDmJ/dFlTe80QMrLNly5ZM2+UpGkuo/X0kWEuh4l82uAt4iIlmMKYDKiOVkY6l+IC1lNAQlFKsptY6ZeHhmXsIiqn7fpHu6DVJZZSoYylfNEoj8QU33nijuJfsiU9ylHW9xwpiH7yNxGpglUSsuCiZKMhWIcUVT2yRdd03a9ZMMu9nzZplGjVqJJ9NmjRJtkGsaqS4n3iUrLLhwq8yCj5+VEahzzGVUXjXIpXTfzF6KKVYTG18nhvKQTVs2FBc+dQwVXQcRYqea7kjp6jLTBEsSywq5tyaNWv6dYdnl6uvvtp8//33EtCOi5+LUK9evaSCAOWlgP/UYXWXmSIz01tmCqsqSVy2zBRJU9GUmQonbkJRFEWJH+QHkNjDPYHEQy9cozFaYC0l+UlRlMQgrmWmchLiiFA4x4wZI256Yk+vuOIKKcxvk0w4fKZZZepVLKVnnHGGefnll02tWrV828Gd369fP/Pll1+KRZZSVRRjLlq0aMRCtWWmlKzYTMFKlSqpiz8AKqPQqIzCI93kxLUe9yFKKcqpzVR2e9eoMINSirHCJmmkk4yiQWWkMsrJsRRXBXX37t1iscStjtLojckkmz8V0UL9oWEoEQfGjULd/CqjaNFxpHJyYxOeSJK15WvcUA7KJjy5k310LOk4ihV6TYqdnCJRUCMOyLn++uulltyVV16ZlvFP6dbeSGXDU5PKSGWk40jPt+zATY4pq7GW8t9rRyGkzJ3wFOiao9ckvW7HAh1HuSOniBXUb775xnz99ddSfzQd0Sz+4LJRd1ro8aMyUhnF6lqUamOJYt424Qlvnb+EJ5RSEp6ot5yOMoo1KiOVUaKOpYhd/MT2jBs3Ti4Q6YQmSYWHLQasqIyyg46j9JET1WBswpOd1cZNsWLFJOGJV8mSJdNSRvFGZaQyyqmxFFcX/0MPPSRJSmTNe+N90oEEzilLCNm4Z45QVEY6jvR8C3StIPveJjzZkoUWbnC1a9cWa2n16tWjVjD1mqQyigU6jnJHThErqM8884xZvny5BKbjbvG6WWbPnm1SGVVQQ990MO+rgqoyys45puMoNeVEeULKAKKY2nm83Rx77LGilJ500kmmSJEiaSmjnEZlpDJK1LEUsYLaqVMnk86oqyi4bHhoUVRG2T3HdByljpywqDCzE0opMz154/gpGVivXj1RTCtUqBBTRTJZZJSbqIxURok6lhK6DmoioWWmQsNQojYhVnW1VqiMokXHUWrIiZJQNuEJy6mXypUrS1xp3bp1fXWt001GiYDKSGWUk2MprjGo6Y7q88Fls3HjRpmHV28GKqPsnGM6jpJTTsSSMosfNUtXr16d5XsmR2nQoIFYS0uVKpWWMko0VEYqo0QdSxFbUKlPN3ToUDN69GgpJ+ANbmfWplREs/gVRVGywi1kw4YNkn8wb948vwlPzOyHUlqjRg0Nk1KUNObfeFpQhwwZYt58801z2223mXvvvdfcc889ZtWqVWbs2LGS3Z/qqAU1uGyYI5si2mqtUBll5xzTcZT4cqJOqU142rp1a5bvS5cu7Ut4imRa6VSSUTKgMlIZJepYilhBHTlypHnjjTdMhw4dzAMPPGCuuOIKKQPCRejXX381N998s0llVEENLhtuVLFOdEglVEYqo2QeSyQ4UcUFpXTx4sVZEp6IPbMJTxUrVsz164CebyojHUfJe75F7OKn9MfChQuljABTzDGrVMOGDc2KFSvkooTZNhVRF7+iKOnKjh07RCkltnTnzp1ZvifmjOv/iSeeGLeEJ0VRkp+4uvh5KiYIFgUVy+l3330nCuqMGTPErJvqqAU1uGz27dtnChYsmOuWk0RFZaQySpaxRDYuxggUU8K4/BkrbMIT7vxERM83lZGOo+Q93yJWUDt37mwmTpxomjZtam666SbTvXt389Zbb0nC1IABA0yqowpqcNmQJIdlXRVUlVF2zjEdR7kjJ5uFi1I6d+5ciSdzw35q1qwpSin/8+bNaxIZHUsqIx1HyXu+ZbsO6rRp0+TFxer88883qYq6+BVFSVX27NkjCimK6ebNm7N8X7JkSVFKsZgWK1YsV45RUZTkJ0froDZr1kxe6YJaUIPLhhtd4cKF1YKqMsrWOabjKP5y4vfkDqCULlq0SEoIehOeiCmlmH6yThWqY0llpOMoec+3qBRUat79/PPPZsuWLVmyODWLP70HJ09HhQoVSsqbWU6gMlIZ5fZY+vvvvyXZiZe/pFYycLGWko2f7HkFer6pjHQcJe/5FrGLf8SIEeaGG26QTE1mAnEfBMs8kaci6uJXFCVZOXTokFhJsZb6u0Zj8aBUIIppmTJlcuUYFUVJff6Np4v/vvvuk4L8gwYNSssZQdTFH1w2zLlNUW61oKqMsnOO6TiKjZw2bdokMzwRX0p2rRt+w8xOKKXM9JToCU/RoGNJZaTjKHnPt4gVVOILLr/88rRUTkEV1OCyYXxQfkYVVJVRds4xHUfRy2nv3r2+hCcUVC8lSpTwJTyFsmAkOzqWVEY6jpL3fIvYxX/nnXdKRuddd91l0gl18SuKkqhwGV+5cqXElS5YsCBLwlO+fPlM3bp1RTGtXLmyPkAqipLwulTECioXvo4dO8pTev369SXT082zzz5rUlmoJBjwXwkcIM2gUwuqf1RGoVEZhS+n9evXy9SjKKZcm7yUL1/el/BE8ex0Q8eSykjHUWKdb3GNQX3sscfMt99+a2rXri3vvUlSqY66+IPLhsLe/E+HsRANKiOVUSwSnhYvXiwufJRTL2TQ2oSnsmXLmnRGzzeVkY6j5D3fIragEr80dOhQc/XVV5t0Ql38iqLkJhTQRyn9888/xYPlhamnUUoxHuDSVxRFSTTiakGlLl7z5s1NuqIW1OCyYdAx+NSCqjLKzjmm4+g/yLyfN2+eKKbUn/bCBR6llJeGHulY0vMtPug1KXfkFHEqfv/+/c0LL7xgcgpirLp37y41V3FdEfc6c+bMTAKh7BVzv/J969atzdKlSzNtg7lhu3XrJhfz4sWLm+uuu05KIUSDKqjBZYP7UWWkMsoO6T6OaPeqVavMmDFjzDPPPGO+/vrrTMop5aCIKeW6yKtFixaqnAaRZTqPpXBQGamMEnUsRezi79y5s5k0aZIojEyD502S+uyzz0ys2LFjh1gGWrZsafr06WOOPfZYUT5xZfGCJ554QuJi33nnHVO1alWp00qJFTJZbVLAueeeazZu3Ghee+01c/DgQXPNNdeYxo0bmw8++CDsY1EXv6Io8YRrzB9//CHWUq59XsqVKyfXQx7SeRhXFEVJNuKaxY9yF4zhw4ebWEEpq19++cX89NNPfr/n0MlSve2228ztt98un9FoEgOY8Yp6rQsXLpTyKjNmzDCnnnqqrDN+/Hhz3nnnmXXr1snv/UGgLy+3UI8//nixxhKHa8WGGZvpXvkfz2XqzrJPXvFczk6bwFY5YHup0KZY9xPrMEax5EMqtCnW/USlEMYR5exssH2ytynQsfDAzEM3WfjLli3LYnngIRuF9OSTT5Zrlfu3XjklSpsSqZ/YBso+MrL3jGRvU6z7Cex9zcos2dsU637iM2TEdRsPRiq0KU8clq2cgo2lnTt3hq2gRuTix3SLNROLJYqov1cs+eKLL0SpvOSSS2T6PawHb7zxhu976v5RiBq3voWGN23a1EybNk3e859BZZVTYH2E99tvvwXcN21kW/aFcgq2lAsXPWvloEPsnNbbtm0TZRa2bt3qCyUgwYECtoA1187qQgiDVYTXrl0rNyxYs2aN3IDoVJb5z3uWgfVYH/g92wG2y/aB/bFf4Dg4HuD4OE7guDn+WLYJd2SqtSlW/WRdtanUplj3E//tsadKm7z9xLWLaiiU5fv4449FSXUrpyijlPPj4RsF1SpY3jbRjkRpU6L2kz3eVGpTrPtp+/btKdemWPcT+g9GrVRq08E49BMKaKg2hUvEFlTmbMYqSbHneGNd9LfeeqsoqVhBiYF99dVXTY8ePczUqVMlYYubPjGolksvvVQ09VGjRplHH31U3P+UZXGDwjtkyBAJHYjEgorgUXhT7cknFZ/mtE3aT4k09g4cOGDmz58vLnx7I3DDgzCzO/EgbusI6vmk1wi97um1PCOFruWRWFAjzuJv0qSJXGBzQkGlQVg+UTKBCzcZrVZBjSdUK+AVCOsaATolJ5ZtR8dzOTvHSH/xJI61x24r2dsUzXKwY+Hk5UkSGWVHBonUplj3E9hxlOxtor9Xr14tLnyUU2vZsOAurFOnjlzbiKF3H2eodviTU7qdT6GWkT9WHCujVGhTrPuJ67aVEb9LhTbFatnu3y2jVGlTPJbDHUvhErGCeuONN4rbCVN3o0aNZM5VNxSIjhVYRYkfdXPCCSeYTz/91Jc0AJif3RZU3hOzZdfZsmVLpm1gqkeI9veR4L2RKpllQ/1FlVHw8aMySn0ZYSWwCU/W9eWGOHmb8IRXKl3lFG9URiojHUfJe75FrKCSeAQ333xzpoOyAbLeOaCzA+57r2t+yZIlPustFgeUzIkTJ/oUUlzxxJZa132zZs0kbnTWrFmiUANVCND0iVWNFL0ZBJeNTf5RVEbpNo649hFLilLqjSkFPDIopCimPFBn91qSrHLKSVRGKiMdR8l7vkWsoBLcn1MMGDDAnH766eLiJ650+vTp5vXXX5eXFcYtt9xiHn74YVOzZk1fmSkSDDp16uSzuLZv39707NlTQgNwsfXr108U7UAZ/MFAsVUCywb3denSpaMy56cDKqPUkxHHilKKxXT37t1Zvq9SpYoopVyLvGX50klOuYHKSGWk4yh5z7eIFdSciD21UKuUYtWDBg0yDz74oCigzz33nBTdt9x5551yU+jVq5dYSs844wwpI2UTrGDkyJGilLZq1UqE1qVLFzNs2LCojkktqMFlg5VIZaQySvVx5E54slmwbooVKyZeHV42bi0d5ZTbqIxURjqOkvd8iziLH5YvXy6KItn8QJwo2fW2eH4qooX6FSW94VJJ7P3s2bP9Jjzx8EvCE0op10K1aiqKokSvS0VsQaV23wUXXCAXYWJEgWL6zCr15ZdfmjZt2phURl38wWVDjTRm/NKbs8ooVcYRtf9w35OJb+v+ueE4ceGTIOpNGk0nOSUiKiOVkY6j5D3f8kUzuxOxoY8//niWzwcOHJjyCqq604LLhoxklZHKKNnHERdaZnbChU9ipvfBNH/+/KZevXqmYcOGEsueG8eaCHJKdFRGKiMdR8l7vkXs4ie2k7nuSUpyw0UcC4Kd2SDVUBe/oqQ+1BW1CU929hZvDL5NeEJJVRRFURLExY/pFleXV0HlM2ZnSnXUxR9cNtSgpcajuhxVRskyjkh4WrBggSimdgpAN0WLFvUlPJUqVcokCnq+qYx0HOm5lkjE+poUsYJKuSYy5lesWCEloGwM6hNPPCFTkqY66k4LLhs7RaOiMkrkcYTjiOlGUUqZnQ4l1Q0X11q1aom1tEaNGgn5wKXnm8pIx5Gea6l8TYrYxc/qZPA/88wzZsOGDfIZMVh33HGHFO9PVeVEXfyKkvxQku7PP/8UxZRgfi/U77MJT1hOFUVRlNzRpcJSUL/44gtz7rnnZikyzXR+tuZfugh1x44dOntLEPP+xo0bZZacRLQ4JQIqo5yXEdujNB5KKTPT+Ut4ogoJimnFihWT5iFbx5LKSMeRnmvJdk2KeQxq586dzaZNmyT+NG/evHIAxJumg2LqJVluXrklG4qSq4xURokwjniYRCklPt4+TLs5/vjjRSlFOU3GhCc931RGOo70XEvla1JYCiqK6a+//mrOP/98cfGnswKSzm0PRzaFChXK7cNIaFRG8ZURxfOZQATFdNWqVVm+p05pgwYNRDHFnZ/M6FhSGek40nMtla9JYSmovXv3NhdeeKHsnFe5cuUCrnv48GGTymgWf3DZkHhSoUIFdfGrjHJsHPHQjFcHpZQSePv378/0Pdcsqo6glPIfL1AqoOebykjHkZ5rqXxNCjtJatGiRVK4mlmkhg8fHjAOE0U2FbFxE3///bf8V7LCUEI50PnBA6Myip2M9uzZIwopiimlTbxQEqpp7fKmwT/fmvyt7zGmeKWUOm11LKmMdBzpuZZs16S41EFljunatWubHj16mC5duqRthqu6+IPLhokcFJVRvMYRT+grV64UpZSHZq/HhkROm/BEjGnG9mXGjH3ZmEOZraqpgJ5vKiMdR3qupfI1KaIyU9wc2Pn8+fOzFOpPdTSLP7zxsXbtWlEMNItfZRTLcYTnws7wxJO3F7LvbcITT+/pgJ5vKiMdR3quJds1KW4zSbFDFFOmA0w3BdWiFtTgsqG8hMpIZRSLcYR1lIdhsvCZGMQLcz5TrxTFNB1msfOi55vKSMeRnmupfE2KeCapxx9/XIryv/LKK6ZevXom3VDlK7hskrFcT06iMgoNJe1swtO+ffuyyI+ZnVBKmekpZMLTprnGjOhozNVfGVOuvkkldCypjHQc6bmWytekiBXUq666SpITKNXCgXhLCvz1118mldEs/uCyYS7zSpUqqYtfZRQRe/fu9SU8oaB6KVGihCilXHdCuYUyUbSsMWfe+t//FEPPN5WRjiM911L5mhTxVKfvvPNO0O9JokpFNIs/NAwl3LJYtdTSrDIKZ7zYhCdql3oTnvLly2fq1q0rimnlypV1TOn5FjF6TVIZxQIdR7GTU9xiUFNZAQ0XVbyCy4anJpWRyigYXJiIK+VF8pOX8uXLm5NPPtnUr18/+xmh+3cas+F3Y8qfbEyB1Jr5Ts83lZGOIz3XUvmaFLGCCsxrTS1U/j///POSoPDNN9+IWZcs2lRGXfzBZaMu/tDjJx1ldOjQIbN48WKxlnLd8EKokE14YuY6ZBSTWKbty415p6Mxvab8p6SmEOk6liJBZaQy0nGURi7+KVOmmHPPPdc0b97c/Pjjj+Kaq1atmiRPzZw503zyyScmFYnELJ3uA1RvliojCwX0UUr//PNPiTP1Ur16dVFKqbGMSz9m42j3NmNmv2vMih/+Wy5S2pjqLY055cr/llMEPd9URjqO9FxLpmtSXF38d911l3n44YfNrbfeaooV+5/L7JxzzjEvvviiSXUi1OfTCmTD4LRT4irpKSMy7+fNmyeK6YYNG7J8zyx0uPB5+ZuVLVsyOrjPmPF3GTPnPWOcI/+9LKt+MmbSw8Y0vMqY9o8bky+566Wmw1jKLiojlZGOo+Q93yJWUMm0/eCDD7J8jpt/27ZtJtVRBTW4bNatWyfmfb1hppeMaNfq1atFKV2wYIG49N0QNE/CE0pp1apVg7Y9ahmhnL7f2Zg1v2ZWTH0b/n+FddYIY7YuNubKMUmtpKbqWIolKiOVkY6j5D3fIlZQsX5s3LhRbjJuuDFVqFDBpDrqvg4umypVquRgbyQfqSYj3DU24WnHjh1Zvqdos0148paki7mMvh0UWDl1w/drpv1nae041CQrqTaW4oHKSGWk4yh5z7eIFdTLL7/cDBw40Hz88ceiIWPO/eWXX8ztt98uNVJTHbWgBpfNwYMHZT50teikrowoI0LCE0rpsmXLspwTZN6jkDZs2NCUK1cuZ2RkY05DKae+nRz5b/2W9xpTpJRJRlJhLMUblZHKSMdR8p5vESuojz76qOnbt6/MtcqNCrcd/7t27Wruvfdek+qoghpcNljXGRt6w0w9GW3dutXMnj1bEp6YrMMLyZIkPNWpUydTwlOOyMjGnEa0oyPGzHnXmDMGmGQkmcdSTqEyUhnpOEre8y3iLH7L2rVrJR51165dclOqWbOmiTdUChg0aJDp37+/ee6553wJGbfddpv56KOPzP79+027du3Myy+/bMqW/d/MMZQ96NOnj5k8ebIpWrSo1HJ97LHHIrqJaha/ko5wTtmEp/Xr12f5niQnm/BE+E+u8W4nY1ZMjvx31c/5LxZVURRFiTtxyeLHlf/UU0+ZL774whw4cMC0atXKDB48OOy4suwyY8YM89prr0mtRDcDBgwwX3/9tYQc0Oh+/fqZiy66SMIOAOtuhw4dxNU4depU0e4JRcAEjTU4UtSCGlw2KDQFChRQi04Sy4hj5KHOJjzhsvEmPGEl5cGUWPRYx2VHJaP9/0a3s33/mGQlGcZSbqMyUhnpOEre8y3sO8sjjzxi7r77brFAkgxFgX5c/TkBVtpu3bqZN954Q+bktqCBv/XWW+bZZ5+VMleNGjWSCQRQRH/99VdZ57vvvpOb7Pvvvy9WHmq4PvTQQ+all14SRTsQCBlN3/0COx0jHWGVVZT3eC/bfcZ7OTvHyAs3MDJKlTbFup+QDTKy8kqkNjHGf/75ZykXN2LECPPHH39kUk6p1NG+fXt5KOQhkBqmNg49lv2EjLZs2eL7Pqx2FIi8NjG/tr9LxrHnlVM6nk+hlvlvZZQqbYp1P/FCRm6ZJXubYt1PVkbu+3+ytykey+GOpZgrqO+++664zr/99lszduxY8+WXX5qRI0f6DiSeoAhjBW3dunWmz2fNmiU3UPfnWHYocTBt2jR5z38SNtwuf8IAuBnPnz8/4D4JAcAia1/EVFilGMhYtlnLf/31l+9zSm1ZZRZFBOXaFiy3cXtYcQlNANymKMM2bMIqBFiwOBmQL8v85z3LwHqsD/zeul/ZLtsH9sd+gePgeIDjsyXBOG6OPxZtQuFHTiynSpti3U82PgdZJUKb+HzRokXyYEfYzMSJE337ATwNPPhde+21opw2bdpUPotnPzH9Ka4fLLPhtunQ8acbkxGhJTcjj9lR4qSkHXuUc2FaWEjX8ylUm1jGmsNYSpU2xbqfkA3ntG1HKrQp1v2EjPDC2nakQpvi0U/ICSOmbUegNsU8BpWTnIxdq6jZbF0+q1ixookXxJZivcXFz/7OPvtssYRyM6Ue6zXXXOPrGEuTJk1My5YtzRNPPGF69eol9RlRrC0IvEiRImbcuHFiUfUH23RvF8HSdgSOFdeKzVqQbGHaeC3T8fZpK57L2WmTlRtTVNr5eJO9TbHuJ9ZBOeV8gtxq0/bt230JT7t3784y/ikVYmd44lhzsp+4gDKOCB/i87DatGe7yXi2jjFHMtdfDYaT5yjj3LrQ5Cl6bFKOPa+c0vF8CrXMNpjBrHDhwv/1eQq0Kdb9ZO+JjCMrs2RvU6z7ic8YR1wLCXFKhTblicOylRO6WqCxtHPnztjHoFJ4m5264anLG58WS9DsSYiaMGFCln3HGwaiVSLc2BPa/gd3DF48l21Hx3M5O8fIAESBp/al3Vaytyma5VDHZWWUHRlEc1woxngNiC21T81uuFg0aNBAFFN3KE20xxhtm1jGqmAvcmG1r+ix/80QRRH+cLL5M/KYjIZXmgx+l6Rjz5+c0vF8CrZsLfJW+UqFNsW6n7huWxmlSptitWz3j4w417hup0qb4rHslVOgYwmXsBVUtOOrr746k9KGGbh3795ijbR89tlnJlbgwieegXqKFqwGP/74o8TJYRXlpsvJ5c4gxhxt6y/yf/r06Zm2a83V0dRojEbI6QKySYfJGpJJRpy3uIKxlqKceh8oOR6b8ESZqEQY31HLiOlLty4KXayfUIBKzf5bP4nR801lpONIz7VUviaFraBSmslL9+7dTTyhUgClrNzg0ueGymQBuNyx4hI316VLF/meAuLEVzRr1kze858QARRdkjwAiyzWImq4Roo1ySv+ZYOrCHea+8lQyXkZEStEkhPF9P1NQcy5gFJKfLb7ATOpZcS0pd3H/DejlC3a71ZUUUx5YWlFOU3iaU5BzzeVkY4jPddS+ZoUtoJKEkVOU6xYMVOvXr1Mn3EzLVWqlO/z6667ztx6662mZMmSonTedNNNopSedtpp8n3btm1FEb3yyivNk08+aTZt2iQTCpB45c+FHwpVUIPLhlhdXEWqoOa8jHCvLF26VJTSJUuWZElgJDaY8waPBMk1idpH2ZLRUQX/m7605T3/Fe9f+eN/paQKHmNM1RbGnHKlMUVKm1RAzzeVkY4jPddS+ZoUdaH+3MKdJOUu1P/hhx9mKtTvdt+TJEWh/h9++EEUXKzBFP3XQv1KKkDCE3GlWExttqebypUri7WUBzU8DoqiKIqS6IX6k05BzW2hEu/KfyUrDCUUJMpMJKp1LlVkROw19X1RTG3JEDds387whMchmdBxpHLSsaTnWyKh16TYySkuM0kp/+sAJfDgtCW8VEGNvYz4LXXqUEqZftQ70QQB6rVq1RJraY0aNRIi4SkadBypnHQs6fmWSOg1KXfkpBbUMIlE61eUWEKdUuqVopjaIsluSpcuLUop0wDz5KooiqIoiYhaUOOIWlCDy4bBhwKvFtTsyYgEp+XLl4tSSmUKfwlPJ554oiimTJSRSvLWcaRy0rGk51siodek3JGTuvgjRBXU4LIhUc3OKKFELiOK+JOFz4sZN7xQWg2lFOUUJTUV0XGkctKxpOdbIqHXpNyRk7r4w0Rd/Eq8oHj+woULxVq6atWqLN8Tz2NneMKdryiKoijJiLr444haUIPLhhhdYnXVghpcRrhAqMnLDE8kPPHU6Qb5kfBEFn7NmjVl/ud0QceRyknHkp5viYRek3JHTurijxBVUIPL5tChQ+riD5HwxBS+FNJndjMvlIRCKcViykQV6YiOI5WTjiU93xIJvSaFR6zlpC7+MFEXvxItJDitWLFC4koXLVpkDh8+nOl7iufbhCdiTNX6rCiKoqQi6uKPI2pBDS6bHTt2mBIlSqiSZYzIwiY8cVJ6IfveJjxFM+1uqqLjSOWkY0nPt0RCr0m5Iyd18StKDMG9YROeVq5cmeX7woULm9q1a5vTTjvNlClTRmWvKIqiKH5QF3+YqItfCcbGjRtFKZ07d67Zt29f5pMsI0NmdsJaSuJTOiU8KYqiKIpFXfxxxFswXcksG+p4lixZMmmn2YyEvXv3ikKKYkpGvhfcHCilJDzZ2ceQ0bZt29JGRtGQbuMoWlROKiMdR3qupfI1SV38EaIJLMFlky9fvpSWETE2uO5RSnHlexOeaH/dunVFMa1cuXIWWaSDjLKLykjlpGNJz7dEQq9JuSMndfGHibr40xtqu9mEp7///jvL9+XLlxeltF69eqZgwYK5coyKoiiKksioiz+OqIs/uGxwXzPbUSq4Zkl4Wrx4sVhLly9fnuX7QoUKmZNOOkkU07Jly6aljOKBykjlpGNJz7dEQq9JuSMndfFHiLpmg8uGcknJLqPNmzfLDE/ElxJn6oWEJ4rpk42POyMdZRRPVEYqJx1Ler4lEnpNyh05qYs/TNTFn9qQeY9Cigt/w4YNWb4vXry4KKW8mMZNURRFUZTIUBd/HFEXf3DZbN261Rx77LFJ4b4m4Wn16tXiwl+wYIG49N1QDsomPFWpUiUmT4XJJqPcQGWkctKxpOdbIqHXpNyRk7r4I0Rds8FlQyH6RJcRT3A24YlZL7wcd9xxvoQn4kzTUUa5icpI5aRjSc+3REKvSbkjJ1VQI0QVi+CyKVasmElEKAflTnjyTllL5r1NeCpXrlxayihRUBmpnHQs6fmWSOg1KXfkpApqhKiLP7hsSDAioz1R3NdbtmwRpfTPP/80e/bsyfJ9tWrVRCmtU6dOxAlPqSKjRENlpHLSsaTnWyKh16TckZMqqBGiFtTgsmHGpNyW0f79+828efNEMV2/fn2m7w5mHDQHSx40Leu2NKc1PE2Sn9JRRomMykjlpGNJz7dEQq9JuSMnVVAjRBWL4LIpUqSIyQ1w2a9Zs8aX8HTw4MEsCU9YSY+uebS57ffbTI8GPXJcOc1tGSULKiOVk44lPd8SCb0m5Y6cVEGNEHXxB5fNxo0bJckop9zXO3fuNH/88YcopswB7AVXAy78irUqmm/WfWPGbxhvapWoZZ6d+axpVr6Z6VyzsylZsKRJZRklGyojlZOOJT3fEgm9JuWOnLQOaoS1u5jmUutgBrZiUk+UhKN4WppJeFq6dKkopfz3JjxRKLh+/fqimJYsU9I8OeNJM2bpGHPYOWwc8791M0yGyZuR11xU8yIzsMlAkz9vfpMqMkpmVEYqJx1Ler4lEnpNip2cIqmDmvAmnMcee8w0btxYMsPKlCljOnXqJNnYbhBI3759TalSpUzRokVNly5dJFDXDe7fDh06SAkEtnPHHXdkqXsZDqpUBJcNZZniJSOmUPvuu+/M0KFDzahRo8ySJUsyKafUKu3cubO57bbbpK9LlS1len/f23y65FNzyDmUSTkF3vP5J0s+MTdMuMEcOHzAJLuMUgGVkcpJx5Keb4mEXpNyR04Jr6BOmTJFlM9ff/3VTJgwQWIL27Zta3bv3u1bZ8CAAebLL780H3/8sazPTEAXXXRRJosbCsuBAwfM1KlTzTvvvGNGjBhh7r///oiPR138wWWzdu3amMqIhCemHX377bfNSy+9ZKZNm5ap73kCO/PMM83NN99sevToIaWijjrqKPnuyelPmjmb55gjJvjx8P2szbPME9OfiNlx56SMUg2VkcpJx5Keb4mEXpNyR05J5+JnlgIsoCiiLVq0EDMxsxZ88MEH5uKLL5Z1Fi1aZE444QRRZk477TTzzTffmI4dO4riSkwivPrqq2bgwIGyvfz5Q7t21cUfGoYSCmV25+JlOwxyXPjz58/PkvBEbAsJT7jwKRPlL9blr31/mVajW4mFNFzyZeQzky6dZEoULGESXUapjMpI5aRjSc+3REKvSbGTU0q5+L3QKChZ8r/EllmzZokC07p1a986KC+VKlUSBRX4T0yiVU6hXbt2IigUIH8gZL53v8Dq8/y3yzwtxHvZ7jPey9k9RmJPwt2Od/8kPP3888/m5ZdfNsOHD5eZntzKKQ8mWM9vueUWc8kll5jq1av7vvO247Mln0nMaSSwPuEA8ewnXsgou/2aymOP//YClyptikc7vHJKhTbFup8AAwQySpU2xbqfkI3bSJMKbYp1PyEjzjX3uZfsbYrHspWTJdCxhEtSKag0EOWkefPmMg0lbNq0SU4ub8kglFG+s+u4lVP7vf0uUOwrWr59HX/88fK5zRRnikw7TSafWcWZOEmrzGKd3bVrlywTE2sLxZPlRtwsUKcTZRiwGlqFjJhZQhNoM8v85z3LwHqsD/ze1vtku2wf2J+NxeU4OB7g+DhO4Lhj1SaWmdt+3bp1YbeJ73755Rfz0UcfSWzpxIkTfccGDPYGDRqYCy64wPTu3Vtc+Hb/wdr0y9pfssSchoL1f17zc1z7CdkgI/aRW/2U6GNv+/bt4gVhv6nSpnj0E+No5cqVEkufKm2KdT9ZIwTbSZU2xbqfOJ65c+f62pcKbYp1P7G8YsUKX/tSoU3x6Ce2v3DhQrmGB2tTSrr4+/TpI+56rGwVK1aUz3DtX3PNNb7OsTRp0sS0bNnSPPHEE6ZXr15yMf/222993yN06nWNGzfOnHvuuVn2xfbc20SwKKkIvESJEr4nAWu94H88l3Fj26eteC5np03AzZKao2wv2PoMcspD8bInn5vKlSuLYsqDCDM8RdqOrl93NfO2z4t4jNUrVc980OGDuPWTvUDYWatyo58SfewhH8YRD57WwpPsbYpH33jllAptinU/sQ1yD6xVJxXaFOt+svc7xpGVWbK3Kdb9xGeMI67b3N9SoU154rBs5UQeSKCxhKc0XBd/0tRB7devn/nqq6/Mjz/+6FNOgXnTEQjln9xWVDR+O6c6/6dPn55pe/aJINC861zQ3KZqC4MT7IkN7hjIeC7bjo7ncnaP0RvP616HmylF9IkttU9wbqjAcPLJJ/9XHur/QzgskbajWP7o5gMuVqCYbzvx6CfGjx1D7rbldD8l8thzyyiebU2G8ynYsj85JXubYt1PbMOG1ASTUzK1KR795JZRqrQp1v3k1gdSpU0ZcVh2yynQsaSMix+tHOV0zJgxZtKkSaZq1aqZvm/UqJFo67iGLZShQgFq1qyZvOc/LgzmZbdQEQDtvW7duhEdj7UUKv5ls2rVqkwyov9wa1Nl4ZlnnjGff/55JuWUQUvM8BVXXCHVGFq1apVFOY2Gpsc1lTqnkcD6Tcs1NTktI0VlpGNJz7fcQq9JKqNEHUsJ7+K/8cYbxY2PYlO7dm3f55iIqbdlXf+46ikdhdJ50003yeeUlAJcYVjmypcvb5588kmJO73yyivN9ddfbx599NGwjkOz+EPDUELWWHUIofjzzz/FWmpjVtyULl1aLKW48eMx9WdUWfx58plJl8Q/i9/KyP30rKiMdCzp+ZYb6DVJZZSTYymSLP6Ed/G/8sor8v/ss8/O9DlZ3ldffbUsk1yDJY4C/cTSkKFPJrgFYREegCKLNRWFiJqZDz74YMTHo0pF8MG5fPlyiSvFiu19isL9f+KJJ/439WjFinGVJdOXMkMURfhD1UG11tOLalwUV+VU9pORIWNVx5HKSMdS/NHzTWWk4yh5z7eEt6AmClbrJ+POWzEg3SFxDEspiikB0F4o+YUFG+U0nJqzsYKZoXpN6BWyWD/KaaOyjcxrbV6L+3SnNpsSmUQTk5MOqIxUTjqW9HxLJPSaFDs5RWJBVQU1TCIRajpAeQoSnqhVSsyJF6zUuO+xluLOzy32H94vM0p9tvS/uqju0lMopnkz8oqldWCTgXFXTi02m1JRGelY0vMtEdBrksoop8aSKqhxQGNQ/3PhMxsX1tJ58+ZlKe2FWb9GjRqmYcOGpmbNmlmy1XMTYlLHLB1jftv0m9l1YJcpmr+oJER1rtlZwgFyCo33UhnpWMo59HxTGek4St4YVLWghkk6u/jdCU/uSgiWUqVKiaWUmqXIR93XgVFXUWhURuGhclIZxQIdRyqjWKEu/lwi3Vz8duYMlFISnngqckNpL5vwxAQGmvSjKIqiKEowUiqLP9FI9ZwyLKDElfLyNy0Z2fcopSin3okMkA2xqSivqrD6R2UUGpVReKicVEaxQMeRyihRx5IqqFF0QKKzfdd+M2rmWjNt+Xbz796D5uhCR5nTq5c2l55a0ZQqmnV2LGZ4Yv5crKXM7e2lcOHCvoSnY489NqhsmL9XLaqBURmFRmUUHionlVEs0HGkMkrUsaQxqCnk4t938LB58MsFZvTMteawzI37v+8YK3kzMsxljY83959f1xTIl1cGEkops2zt27fPb8ITSmmtWrUSKuFJURRFUZTkQ138cSRRLagop1e9Pd3MXPWXOeLnEDnsQ45jPpy+xsxZvtF0KLrSbNu8Kct6TDNKzVIsppEq4siGzH5c/+riVxlFi44jlVOs0LGkMtJxlLznmxZjjKIDEpGHvloQUDl1w/cLth0wX6z9X83PfPnyiULK7Fr9+vUzZ555ZlRWYmTDtKaJKqNEQGWkMtKxpOdbIqHXJJVRoo4ldfGngIufmNOmj040h0Jppy4yzBEzoOoWc3qjBlIeqmDBgnE9RkVRFEVR0pt/I9Cl1IIaIYloHRw9c53EnEZERh5zVO2zzamnnhoz5RTZ7N27NyFllCiojFRGOpb0fEsk9JqkMkrUsaQKahQdkGhMXb4tU0JUOLA+v4u1bP7666+ElFGioDJSGelY0vMtkdBrksooUceSlpmKkESaQ53MezLwl63ZYIyJfB55SlDFWjYVKlSI6TZTDZWRykjHkp5viYRek1RGiTqWVEGNkNy2DrL/VatWSXkoapdSwzTjYE3mdpLI0kigPmqsj41pUambqln8KiMdR/FFzzeVkY6jnEHPtdyRkyqoSaKgElhsZ3hitic3x+XZaTYeOdpEcmR5MowU74+1bDjOQoUKqYKqMtJxFGf0fFMZ6TjKGfRcyx05aRZ/AmfxHz582CxevFispcuXL8+iHJPcdNJJJ5kqteuZ89+cG1EWf748GWb6Pa1NySKRhwYoiqIoiqJEihbqT3IL6pYtW0Qp/fPPP8Vc7qVatWoyw1OdOnWkhilc1vhvKcIfjo7Kgw0zSsVaOUU2u3btMkWLFlULqspIx1Gc0fNNZaTjKGfQcy135KQu/gRRUJl9Yd68eaKYrl+/Psv3WG+Z4YlX8eLFs3zP9KVLt+wKWayfMdOkSklZP17xJ0WKFFEFVWWk4yjO6PmmMtJxlDPouZY7clIXfy66+OnMNWvWiFI6f/58SXhykzdvXrGSYi3Fahqqw5nulBmlRs1Ya444TiZFlZjTPBkZYjlFOS2QL29M2qAoiqIoihJrXUoV1AiF+vfff8v/7LBz505fwhM1w7yULVtWlFLiSwk2jmZmKYr3U+eUUlJk65MQdempFU2pogVMvAOkGXSaxa8y0nEUX/R8UxnpOMoZ9FyLnZw0BjUBXfwkPC1ZskSU0qVLl2bZToECBUz9+vVNw4YNTbly5bKl4KGE9jm7urxyEtpEqAL/VUFVGek40vMtt9FrkspIx1Hynm9qQY2zi3/r1q2+hKfdu3dn+b5q1aq+hKejjoptXVJFURRFUZREQS2ouWxB5QmCmFIU03Xr1mX5HgW3QYMGopiWKFHCpJJsUOBR5NWCqjLScaTnW26j1ySVkY6j5D3fNIs/ig4I9PnatWt9CU8HDx7MMgWYO+EpkaZMjRXIgEQvdfGrjHQc6fmWCOg1SWWk4yh5zzd18WfTLE3Nrz/++EMU0+3bt2f5XZkyZXwJT0z/pSiKoiiKko78G0G4ZFpZUF966SXz1FNPmU2bNomL/YUXXjBNmjSJaBs8GRw5ckQSnVBKSXzyl/BUr149UUzLly+fNu5u5MA0rIQtpEubI0VlpDLSsaTnWyKh1ySVUaKOpbRRUEeNGmVuvfVW8+qrr5qmTZua5557zrRr106mEsXKGS6TJ0+WaUexnHqpXLmyKKV169bVhCdFURRFUZQoSRsXP0pp48aNzYsvvijvsYIef/zx5qabbjJ33XVX2GZp1i1YsKDvc6b0YnYnFNOSJUvGtQ2KoiiKoijJirr4PRw4cMDMmjXLDBo0yPcZSUqtW7c206ZNC5iJz8tCvIT9nN/WqFFD4kqrV/+v1ijmbASP4ssyr1gus0+eJXjFc9m2JZpj5Pd2IgNmwUqFNsW6n6iHy1hiulp+kwptinU/EWTPOLIPfKnQpnj0jVdOqdCmWPcT5xsuR2TENlOhTbHuJ9Zlwhjcsly3U6FNse4nQEZct/Ply5cSbcoTh2Urp2BjiYmKwK5v0t3Fv23bNrlQMUOTG94vWrTI728ee+wxM2TIkCyfDx06NG7HqSiKoiiKkuqgqIaalTMtFNRowNpKzKoFSwUxpmvWrMn2VKepChZkwiYotxXJZAbphMpIZaRjSc+3REKvSSqjnBxLWE5RTkkgD0VaKKilS5cWc/PmzZszfc57phX1B5n4vLygnKryFRzkozJSGWUXHUcqp1ihY0llpOMocc63cI18qVct3g/58+c3jRo1MhMnTvR9RjwE75s1a5arx6YoiqIoiqKkoQUVcNf36NHDnHrqqVL7lDJTu3fvNtdcc01uH5qiKIqiKIqSjgrqZZddZrZu3Wruv/9+KdRPaajx48dnSZwKBO7+wYMH+3X7KyqjcNFxpDKKFTqWVEY6jnIGPddyR05pUwdVURRFURRFSQ7SIgZVURRFURRFSR5UQVUURVEURVESClVQFUVRFEVRlIRCFVRFURRFURQloVAFNQxeeuklU6VKFVOwYEHTtGlTM3369Pj3TJLwwAMP+Obata86deqYdOfHH380559/vsyWgUzGjh2b6XtyE6kocdxxx5lChQqZ1q1bm6VLl5p0IpSMrr766ixjq3379iadYMrlxo0bm2LFipkyZcqYTp06mcWLF2daZ9++faZv376mVKlSpmjRoqZLly5ZJiVJdxmdffbZWcZS7969TbrwyiuvmJNOOslXQJ363998843v+3QfQ+HKKd3HkT8ef/xxkcMtt9wS8/GkCmoIRo0aJTVUKZ0we/Zs06BBA9OuXTuzZcuWiIWdqpx44olm48aNvtfPP/9s0h1q7DJWeLjxx5NPPmmGDRtmXn31VfPbb7+ZIkWKyLjixE4XQskIUEjdY+vDDz806cSUKVPkQv/rr7+aCRMmmIMHD5q2bduK7CwDBgwwX375pfn4449l/Q0bNpiLLrrIpAvhyAh69uyZaSxxDqYLFStWFEVi1qxZZubMmeacc84xF154oZk/f758n+5jKFw5pfs48jJjxgzz2muviVLvJmbjiTJTSmCaNGni9O3b1/f+8OHDTvny5Z3HHntMxeY4zuDBg50GDRqoLILAaTZmzBjf+yNHjjjlypVznnrqKd9nf//9t1OgQAHnww8/TEtZemUEPXr0cC688MJcO6ZEZMuWLSKrKVOm+MbNUUcd5Xz88ce+dRYuXCjrTJs2zUlHvDKCs846y+nfv3+uHleiUaJECefNN9/UMRSmnEDH0f/YuXOnU7NmTWfChAmZ5BLLa5JaUINw4MABeZLC/WrJkyePvJ82bVrkTwMpCq5p3LTVqlUz3bp1M2vWrMntQ0poVq5cKZNFuMcVcxMTPqLjKjM//PCDuG1r165t+vTpY7Zv327SmX/++Uf+lyxZUv5zfcJi6B5LhNhUqlQpbceSV0aWkSNHmtKlS5t69eqZQYMGmT179ph05PDhw+ajjz4SCzMubB1D4cnJouPoP/BadOjQIdO1B2I5ntJmJqlo2LZtmwxS72xTvF+0aFGuHVcigVI1YsQIUSBwdwwZMsSceeaZZt68eRITpmQF5RT8jSv7nfKfex+3UNWqVc3y5cvN3Xffbc4991y5yOXNmzftRHTkyBGJ82revLkoWcB4yZ8/vylevHimddN1LPmTEXTt2tVUrlxZHqT//PNPM3DgQIlT/eyzz0y6MHfuXFG0CCMiLnDMmDGmbt265vfff9cxFIacQMfRf6C4E/KIi99LLK9JqqAq2QKFwUIcCgorN4LRo0eb6667TqWrRM3ll1/uW65fv76Mr+rVq4tVtVWrVmlpseDBT2O8I5dRr169Mo0lkhMZQzz4MKbSAYwIKKNYmD/55BPTo0cPiQ9UwpMTSqqOI2PWrl1r+vfvL/HeJI7HE3XxBwF3EJYab/YZ78uVKxfXjklWeGqqVauWWbZsWW4fSsJix46Oq8gghIRzMh3HVr9+/cxXX31lJk+eLIkc7rFEKNLff/9t0v0aFUhG/uBBGtJpLGHVqlGjhmnUqJFUPiBB8fnnn9cxFKac/JGO42jWrFmSJN6wYUOTL18+eaHAk/TLMpbSWF2TVEENMVAZpBMnTszkQuK9OyZF+R+7du0SqwQWCsU/uKw5Ud3j6t9//5Vsfh1XgVm3bp3EoKbT2CJ/DMULN+OkSZNk7Ljh+nTUUUdlGku4rokDT5exFEpG/sBCBuk0lrxwL9u/f7+OoTDl5I90HEetWrWSMAjabl+nnnqq5J/Y5ZhdkyJKqUpDPvroI8muHjFihLNgwQKnV69eTvHixZ1Nmzbl9qElBLfddpvzww8/OCtXrnR++eUXp3Xr1k7p0qUlkzbdMxznzJkjL06zZ599VpZXr14t3z/++OMyjj7//HPnzz//lGz1qlWrOnv37nXShWAy4rvbb79dsj4ZW99//73TsGFDyRrdt2+fky706dPHOeaYY+Qc27hxo++1Z88e3zq9e/d2KlWq5EyaNMmZOXOm06xZM3mlC6FktGzZMufBBx8U2TCWOOeqVavmtGjRwkkX7rrrLqlqQPu53vA+IyPD+e677+T7dB9D4chJx1FgvNUNYjWeVEENgxdeeEGEnT9/fik79euvv0Ys6FTlsssuc4477jiRTYUKFeQ9J3K6M3nyZFG6vC9KJ9lSU/fdd59TtmxZeQBq1aqVs3jxYiedCCYjlIu2bds6xx57rJQsqVy5stOzZ8+0ezD0Jx9ew4cP963DQ82NN94o5XAKFy7sdO7cWRS0dCGUjNasWSPKaMmSJeVcq1GjhnPHHXc4//zzj5MuXHvttXIOcZ3mnOJ6Y5VTSPcxFI6cdByFr6DGajxl8Cf2RmBFURRFURRFiQ6NQVUURVEURVESClVQFUVRFEVRlIRCFVRFURRFURQloVAFVVEURVEURUkoVEFVFEVRFEVREgpVUBVFURRFUZSEQhVURVEURVEUJaFQBVVRFEVRFEVJKFRBVRQl13jggQfMySefHHSdVatWmYyMDN+814lAlSpVzHPPPRf172nP2LFjTSr0T3Zo0aKF+eCDD0yqsGDBAlOxYkWze/fu3D4URUl6VEFVFCUmTJs2zeTNm9d06NAh7N/cfvvtZuLEib73V199tenUqVPC9MiIESNM8eLFs3w+Y8YM06tXr6i3u3HjRnPuuedm+zjiTTz754svvjCbN282l19+eSbFH+Xd/ULhC/fBYO3atebaa6815cuXN/nz5zeVK1c2/fv3N9u3b8+03tlnn+3bfsGCBU3dunXNyy+/nGV777zzjjnjjDOy/IZX2bJlzSWXXGJWr17tW5/tnHbaaebZZ5/NtnwUJd1RBVVRlJjw1ltvmZtuusn8+OOPZsOGDUHXZYblQ4cOmaJFi5pSpUolXQ8ce+yxpnDhwlH/vly5cqZAgQIm0Yln/wwbNsxcc801Jk+ezLehBx98UBR4+5ozZ05Y21uxYoU59dRTzdKlS82HH35oli1bZl599VVRsJs1a2b++uuvTOv37NlTto/V89JLLzV9+/aV37n5/PPPzQUXXJDlN4xvvkMh7t69e6bf0KZXXnlFxreiKNnAURRFySY7d+50ihYt6ixatMi57LLLnEceeSTT95MnT3a43IwbN85p2LChc9RRR8lngwcPdho0aCDrsMw67hfrrFy5UpY//fRT5+yzz3YKFSrknHTSSc7UqVN92x8+fLhzzDHHOF9++aVTq1YtWadLly7O7t27nREjRjiVK1d2ihcv7tx0003OoUOHfL/bt2+fc9tttznly5d3Chcu7DRp0kT26T5m94tjBLY3dOhQ33Z27Njh9OrVyylTpoxToEAB58QTT5RjCQTbGjNmjCyHal+w4wh2/G65jB8/3qlTp45TpEgRp127ds6GDRsy9U3jxo3l96x7+umnO6tWrfL1Saj+admypdO3b99M7duyZYv08ffff++3/XyfkZHhzJs3L9PnXrl6CfZ9+/btnYoVKzp79uzJ9PnGjRulbb179/Z9dtZZZzn9+/fPtF7NmjWdyy+/3Pd+7969Iq+FCxcG/M17770n23azf/9+GQOB2q4oSnioBVVRlGwzevRoU6dOHVO7dm2xKL399ttiJfVy1113mccff9wsXLjQnHTSSVncyViy2rdv77OenX766b7v77nnHlmHWNRatWqZK664IpOVas+ePWKV++ijj8z48ePNDz/8YDp37mzGjRsnr/fee8+89tpr5pNPPvH9pl+/fhKawG/+/PNPcdmyf6xw7Bt38tFHH+07Hvbv5ciRI+Ku/+WXX8z7778vFjnaSLhDJARqX7DjCHb8brk8/fTT0n6s22vWrPH9nu3jsj/rrLPk92yL0AVc2F4C9c/1118vcaT79+/3rYscKlSoYM455xy/bf3555/FAn3CCSeYWIB19NtvvzU33nijKVSoUBZrdbdu3cyoUaP8jkkLvztw4IDvPZZX2sC4DrRPxn3Tpk0zfU5oAXG7P/30U7bbpShpTZiKrKIoSkCwuj333HOyfPDgQad06dKZLHnWCjh27NhMv3Nb6KBHjx7OhRdemGkda2F88803fZ/Nnz9fPrPWLSyFvF+2bJlvnRtuuEGsW1h3LVgP+RxWr17t5M2b11m/fn2m/bVq1coZNGiQb7tYFYNZ8r799lsnT548zuLFi8MeIf4sqKHa5z2OcI/fK5eXXnrJKVu2rCxv375dvv/hhx/8Hmc4/YOlsUSJEs6oUaN8n2EBfuCBBwK2H9lVq1bNr1zz588vlkv7ev7550NaUH/99ddMMvXy7LPPyvebN2/OYg3Foo4llO9ffPFF32969uzp3H777b73/AarMMfEuGJ9rPX0n5fOnTs7V199dcD2K4oSGrWgKoqSLRYvXmymT58uFj/Ily+fueyyyyQm1QsxgtHitrged9xx8n/Lli2+z7DIVa9e3feeJBaSaoijdH9mfzN37lxz+PBhsVayjn1NmTLFLF++POzjwuJJIg/byQ6h2ucl3OP3yoVt2+2WLFlSEp/atWtnzj//fPP888+LZTQSSDK68sorxWoOs2fPNvPmzZPtBmLv3r3yO3/ccccdIlP7uuqqq8I+lmAWUi8kRSEvLKfElg4YMMD06dPHt50vv/wyU/wpYInlmP744w+xAteoUcO0bdvW7Ny5M9N6bBPLtaIo0ZMvG79VFEURRRRXMZnTFm7wJAG9+OKL5phjjvF9XqRIkagldtRRR/mWrQsa97q/7+06/j6zv9m1a5e44WfNmpXFHe9WakPhdSnHq31ewj1+fzJwK3LDhw83N998s4RF4Aa/9957zYQJEyQbPVxw8+PWXrdunWwP1z4Z9IEoXbq02bFjR8DvUPwigfVpF6EjhHV44fMSJUpIcptb2SSsgv5DaXcna/HAZcMr3DCW7bHxn7HPb5EbMnC7/90PBYqiRI5aUBVFiRpu4u+++6555plnMlm9sDChsHqzokNB/B5WwZzglFNOkX1hTUTZcL+IWwz3eLB8opgtWbIkbsfq7zjCOf5wYVuDBg0yU6dONfXq1QtYmzSQPOrXry/W8TfeeEN+S6mnUPvbtGlTQCU1Uqg00KZNG7GKYp11w35GjhwpVn13bK1VNokz9VYSIEOfcmmh4ojt9959YkGmjYqiRI8qqIqiRM1XX30lSsZ1110nio371aVLF79u/mDgkidZh7CBbdu2mYMHD8atd3CNY0XDhfzZZ5+ZlStXiuXsscceM19//bXveLBUkjDD8fhz25JgRMF52ovlke188803YpGMFf6OI5zjDwW/QTElOYp6nt99950kWAVKXgrWP1gQSQ7DOuvPiukG5Q1LKYllkbJ+/fpMD0O8GINY60nUIlyBZDBKQNEHKK4ooY888khENVq97n1A7ii8vHgIIySAUAXc/O6JJTjG1q1bR9w2RVH+hyqoiqJEDQooN2K3G9+CwjZz5kxRaMKFWEAqAWCNwx0bjQITCbijUfBuu+022S8Z7RThr1SpknyPi7d3795ifeN4nnzySb/b+fTTT03jxo0lDpdi7XfeeWdMLcGBjiPU8YeC+NRFixZJX6HwksFPPdAbbrgh4v6h7cQf8z9QfKnb8ki9UCybkUJFAhRc9wuFvGbNmjLeqlWrJtUGcLHTnpYtW4oCTrxtOBC/Sw1VFF0vWIhx6fNiuyjpVIhAJha8BiiswUIcFEUJTQaZUmGspyiKoigBwXKIUoiC3LBhw5CSwgp54oknSlJVIilzzAL1/fffi+IZKZSpQlEmzKF58+ZxOT5FSRdUQVUURVGiBjc/U4lSJ5WQgUis3mPHjpX40TPPPDNheoDaplhIozkmLK+EYQSyQCuKEj6qoCqKoihRw4QIuLsJEWASBBKmFEVRsosqqIqiKIqiKEpCoUlSiqIoiqIoSkKhCqqiKIqiKIqSUKiCqiiKoiiKoiQUqqAqiqIoiqIoCYUqqIqiKIqiKEpCoQqqoiiKoiiKklCogqooiqIoiqIkFKqgKoqiKIqiKAmFKqiKoiiKoihKQqEKqqIoiqIoipJQqIKqKIqiKIqiJBSqoCqKoiiKoigJhSqoiqIoiqIoSkKhCqqiKIqiKIqSUKiCqiiKEgUZGRlm7NixKS27q6++2nTq1Cmu+1i1apXI8vfff4/5ts8++2xzyy23xHy7iqLEH1VQFUVJSsUJpYbXUUcdZcqWLWvatGlj3n77bXPkyJEcOYaNGzeac88916SyYvz888+bESNGxFXhO/7440WW9erVi+l2FUVJblRBVRQlKWnfvr0oNljgvvnmG9OyZUvTv39/07FjR3Po0KG4779cuXKmQIECJpU55phjTPHixeO6j7x584os8+XLF9f9KIqSXKiCqihKUoJyiGJToUIF07BhQ3P33Xebzz//XJRVt9VvzZo15sILLzRFixY1Rx99tLn00kvN5s2bfd8/8MAD5uSTTxbra6VKlWS9G2+80Rw+fNg8+eSTso8yZcqYRx55JKAl07qpP/vsM1GUCxcubBo0aGCmTZvmW3/79u3miiuukOPl+/r165sPP/ww0zaxUN58883mzjvvNCVLlpR9c3yWKlWqyP/OnTvL/ux7Lz/88IN8//fff/s+w4XOZxwrICOUz2+//daccMIJ0m6r9Ptz8bM8ZcoUsapa67XdVih27NhhunXrZo499lhTqFAhU7NmTTN8+HC/Ln577BzXKaecIuufc845ZsuWLdK3HCv92LVrV7Nnzx7fPnbv3m2uuuoqacdxxx1nnnnmmbCOTVGUxEQVVEVRUgYUGRRDFEXA3Y9y+tdff4lyNWHCBLNixQpz2WWXZfrd8uXLRfkZP368KI1vvfWW6dChg1m3bp387oknnjD33nuv+e2334Lu/5577jG33367KFu1atUShdRac/ft22caNWpkvv76azNv3jzTq1cvc+WVV5rp06dn2sY777xjihQpIvtCQX7wwQfluGHGjBnyH+UORdK+jxYUvKefftq899575scffxRlnuP3B4pps2bNTM+ePWXfvHDPA4qyW5H2ct9995kFCxaIjBcuXGheeeUVU7p06aDHxvZefPFFM3XqVLN27Vp5sHjuuefMBx98IDL87rvvzAsvvOBb/4477pC+4iGF71B0Z8+eHbVsFEXJXdSnoihKSlGnTh3z559/yvLEiRPN3LlzzcqVK33K1LvvvmtOPPFEUe4aN27sU2SxoBYrVszUrVtXrKCLFy8248aNM3ny5DG1a9cWJXXy5MmmadOmAfeNcodiC0OGDJH9LFu2TI4Jy6lb+bvpppvESjh69GjTpEkT3+cnnXSSGTx4sCxjaURJox3E2GKBBCyfWFezy8GDB82rr75qqlevLu/79esnCnEgd3/+/PnF+uvdN78PpnCi+GINPfXUU+V9IMuvm4cfftg0b95clq+77jozaNAgeZCoVq2afHbxxRdLfwwcONDs2rVLHiref/9906pVK5+iX7FixbBloShKYqEKqqIoKYXjOOIiBqx1KKZWOQUUUBQ8vrMKKgoTyqmFpCtiI1FO3Z/hZg4GyqUFNzPwGxRUQgYeffRRUUjXr19vDhw4YPbv3y8KX6Bt2O2E2m+0sG+rnGZnXyjQwejTp4/p0qWLWDTbtm0rYQOnn3560N+45YDsOVarnNrPrPUZxRV5uh8eCJHgwUJRlOREXfyKoqQUKJ5Vq1aN6DdUAnBjqwN4PwtVIcD9G6sk29889dRT4ibH4ofljzCAdu3aiWIV6lgirUxgFWuUdbe1NNjx2n25fxMrqHawevVqM2DAALNhwwaxcgYKJfB3bNH2h6IoyYsqqIqipAyTJk0Slz7WOiChhvhFXhZiIUkewpKak/zyyy8SD9u9e3eJk8UauGTJkoi3g6KGNTYYNhTAnfAUizqjuPhD7TvYMfXo0UPc8MSSvv766yZWYAVGLu4YYRKzopGvoiiJgSqoiqIkJbjHN23aJO5yXMe4z1EAKTNFNje0bt1asuXJIGcdXMJ8d9ZZZ/niIXMK4klJdiLpByvvDTfckKmaQLgQjoBLnbajhPmjRo0aEtZAotHSpUslqSgWWe3sGyWQzPtt27b5LJhYRImVDcT9998vyUvE486fP9989dVX8vAQK8jcJ06VRCkeUkhCo+qAO0RDUZTkQs9eRVGSEjLuiZlEaaI8Em7zYcOGiSJE/Kh1A/O+RIkSpkWLFqKwYrkcNWpUjh8vVQAoh4Vbn3JSJBpFM0sTiiaKLgooiUf+wJpINYJFixZJLCcJXiQdZRfc8sgW6zMWUZKfbAwoCmswyytJThwL/cA2PvroIxNLCKE488wzzfnnny/9fMYZZ0jVBEVRkpMMJx4BR4qiKIqiKIoSJWpBVRRFURRFURIKVVAVRVEURVGUhEIVVEVRFEVRFCWhUAVVURRFURRFSShUQVUURVEURVESCp3qNEyo98cMKEyHaGeIURRFURRFUcKDwlE7d+405cuXD1mnWBXUMEE5dc/nrSiKoiiKokQOs/tVrFgx6DqqoIYJllNgPunixYtH0R1Kblq/ORl4wNCZZZIP7b/kRvsvffrvn3/+kZnSTj/9dHPMMcfk2DEqyXP+/fvvv3IsVqcKhiqoYWLd+px0Rx99dPZ6SMlxlwJTITJ7jYZnJB/af8mN9l/69B/rFi5cWO6Rep9MDJwEvf+Fcyy5r04nGYnUwUr4fcaTo/ZdcqL9l9xo/yU32n/JTUYS3/9UQY3CXK4kX58xZ7j2XXKi/ZfcaP8lN9p/yc2RJL7/ZTjYf5Ww4iZw7xNj43VdHD582Bw8eFClmMBwciZC/I0SHdp/seeoo44St19OoP2X3ITbf6gT3A8TzZ2c7hxJoPtfMF3Ki8agRohXn9+1a5dZt25dls+VxIL+0Qtm8qL9F3s4H8iiJT4t3n3HDZL96TmYfETSf3yfL5+qFYmEk8Tnn46kCHErojwpopwSFH7ssccmXeenU59h4cZipH2UfGj/xUemW7duletXzZo142pJZV/sp1KlSnr+JSGR9N/u3bvN3LlzTf369U2RIkVy7BiV1Dz/VEGNELeZHKWHzkc5LVSoUKz7Rokh2j/JjfZf7OG6tWrVKrmOxVNB5ZpZpUqVuG1fiS+R9N+hQ4fkwYf/SmKQJ4nPv8QISkgi/Lnyk+2pJF1dHBqGkZxo/8WHnLpu0X8HDhzQ8y9J0f5LbpwkPv9UQY2QZOxk5T9rt5K8aP8l9zVz48aNeu1MUrT/khsnic+/pFdQMV3b4F/3q2/fvvL9vn37ZLlUqVKSDNClSxezefPmqPeXKJlwoWRSu3Ztc/LJJ8v/xx9/PFvbGzx4sKlTp45p2rSp+eGHH2S7dvrXM8880yQ6jIcCBQqopTtJ0f5LbrhmVq5cOSmunUpWtP+SmzxJfP4l3xF7mDFjhjwd2NeECRPk80suuUT+DxgwwHz55Zfm448/NlOmTBGl6qKLLop6f8nyFDJq1Cjz+++/m0mTJpnHHnvMTJ8+PeptPfnkk2by5Mnmt99+y/R5+fLlzU8//WQSHXURJzfaf8nffxgKkuXaqUTffwULFpQEKf4riYGTxOdfvlQI9HeDtbB69ermrLPOkjpbb731lvnggw/MOeecI98PHz7cnHDCCebXX381p512WsT7C9XJr7/+upSeihdYgXv16hX2+hUqVBDr5+rVq03JkiVN7969zZYtW+Rp6oEHHjCdOnWS9b799lszaNAgCW4vUaKEeeWVV0zdunVlTmUGd9u2bU3Lli0zKfckWGBN/fvvv32WrkceecSMHTtWAuXvv/9+c80118h3S5cuNbfccovse//+/dKGfv36mZyCdpHFryQn2n/JXzGAa5HG66d2/+GpStaEnFTFSeLzL+kVVDcEAr///vvm1ltvlY6YNWuWxK61bt3atw7KGuUWpk2bFlRBRYni5S4u6+10q6zaZfaJcrpz5864tM+7f2Cf/pbtOosWLTLbt28Xhf3888831157rSiHKIzNmjUTBZMM6a5du4qVlKdfFPqLL77YzJs3z0ydOlW2++OPP4riyjreY3Avc4HC0sp+mzRpYrp37y6/v+KKK8x7770n8t+7d6/InpCBU089NWg7YrWcP3/+TP0Ur33Fux25sZzb+49H/yVCm3K7nyx2hhkrXx5egy3b7bhrK4ZaPv74432JipH8NtSxxGo5mjZFu5yMbQrVf3af3DO3bdsmhiMMAoncplTsp4wQ/RfJeR6vNqWVi98NljuseVdffbW837Rpk9zYihcvnmm9smXLynfBwC3ObAf2RQfDjh07fP+x0FrrDjVRgdpvxYoVi9vL1pZjEKCQ22WbRGIHx2WXXSYW0BNPPNHcdNNNIofZs2eb6667To61atWq5owzzpCwB5RQFFPW57tu3bpJKATTo1ls++x/b+KKXea3LBP7SsFmtoGyOn/+fHP55ZebU045RayyKPx8Bu52BGqTXWaQu5dtOROOK9AyL7uuPX7vsj152bZ72crTvezOiPQee6DP49Emf+1I1TbZbaRSmxKln1AogIdrLC3A+Wk/5zr3119/+a579hrIZ/YayLr2IZ5tWC8S8f7UxuShlBAsvDGwfv16nwFg7dq1vuPhemH7207PyHt7LWI91gd+z3aA7bJ92LNnjy/PIF5tYh+QDm1imf4Lp03Lli0zc+bMkX0kcptSsZ/2B2gT1xjOQbyoidKmsHFSiLZt2zodO3b0vR85cqSTP3/+LOs1btzYufPOO4Nua9++fc4///zje61du5arv7N9+3b5/siRI86ePXucBQsWyH/e28/jsRzJupUrV3bmzJkjy999951TsGBB548//nDy5cvnHDx40Lf+hRde6Lz77rvO559/7px11lmZtnPMMcc4a9askWXa/ddff8nypEmTnAYNGsjyihUrZD27X9bbsWOHbzulSpWSdebOneuUL18+W23K7vL+/ftzZF852aacWs7t/cej/xKhTbndT3v37pXr1+7du32fHz58OOSy3Q6fhbN86NAhZ926db5rTyS/jeS4srMc6XFlZznZ2hRO/9l9cp/44osv5D6QyG1KxX46Ekb/JUKb0KfQFfgfipSxoPJ08P3335vrr7/e91m5cuXEgmBjJC08DfBdMHBVM0+s+wV2Gjdrts6p5UjXtctt2rQxffr0Mffdd59p2LChxODy+fLly83PP/8srn9c/cz+gUWT7z766COJV2EaRPe2/G0/0LJ7fdz6yG/EiBG+z9k/T1c5JUcsyInWT8mynNv7j0f/JUKbEqGfwGb38lk4y/a3fBbOMpMAcD3h2hnpbyM5ruwsR3pc2VlOtjaF03/J1qZU7KeMMPovUdqUdjGoKF5lypQxHTp08H3WqFEjiYOZOHGilJeCxYsXi3kbpSwarBstmUA5rVGjhhk3bpy55557zIsvvigD5c0335R4XBg5cqS56qqrfElSVD2IdDAFghPjq6++kiSpoUOHiouhdOnSEuuaE9BnNqYoVm1Scg7tv+TvP9yETAmt51/yof2X3DhJfP5lYEY1SQ7KBzGVJOJ4a35iPUQxw3qHFY94TCDuMhKInSAWldgKG9NKnMbKlStl31pWI3GxMXc8rCTbCapo/8WLnLp+cX3Ga0Xsv7WyKMlDJP1HjCLlDUm+peKMkvscSbDzz+pSxKZaz3RKW1Bx7WMVJUPdCxY7OgULKkHA7dq1My+//HLU+0qEDlYiw7qIleRE+y+54Zp53HHH5fZhKDnQfyilJN8qiUOeJD7/UsKCmpNaP/Gs/Ae1oCYH6iJObrT/4kNOXb/oPyxrKC/qwUg+tP+SGyfBzr9ILKhqDowQ1eeTE1u+R0lOtP+SPwZOr52p338oHczcaEsLKbmPk8TnX0q4+HMSdfEnHzw16ixSyYv2X/JfM4l/U5IT7b/kJk8Sn3+qoEZILJ5Ctu/ab0bNXGumLd9u/t170Bxd6ChzevXS5tJTK5pSRQtke/tK1j6jcgDlNhLBxaFEhvZf8vcfbj3ceXr+JR/af8mNk8TnnyqoOaig7jt42Dz45QIzeuZac1imBvvfdz8v22ae+W6xuazx8eb+8+uaAvnyRr0fJSvJ6N5Q/of2X/Jip8C002QqyYX2X3LjJPH5pwpqDrn4UU6venu6mbnqLyNzLnlAfzrkOObD6WvMsi27zLvXNVElNUaoizi50f5L/msmNaqV5ET7L7nJk8TnnyZJ5ZAl56GvFgRUTt3w/fRVf4mlNadgtq2OHTua+vXrm759+0rN2EWLFplE4pJLLjHTpk3L9FmPHj3EbcE8w26qVKkitfjcfcYEBMH67q233jI1a9Y01atXNz179vTNZeylc+fOUuPPvjj5v/jiC9/3n376qcixXr168lq1alVApYv17Hbuv/9+33dbtmwxJ554oq8ttWvXlnVOOOEE07Vr1yzt9Qf7PfvssyVbkt+6QY52v+znhhtu8M3j7A/KsrFvjrdBgwa++Z+9UGuPUm/VqlWT9U466STTu3dvs337dvn+gQceMMcee2wm+W3YsEGO1dYW9rJw4UKZfIN+4cU4dY9N9zY5xssuu8w3DzTMnDnTnHvuuSbe54z3fbh4x8FPP/3k++6dd97xfXfKKadIPWdgbHbq1ElkfNFFF8nYBvqlRYsWmdr/559/xqX9kcB5R/UTtYInJ5H0H5ni55xzjtZATSCcJD7/VEGNkGg6WWJOZ6wNqZz+bx9G1v9r9wGTE8yZM8csXbpUpjt96aWXEk5BnT59ukyL6p79i5gaskW5STPrVXb6jVI7zLaFcrBs2TJRtF5//XW/644ZM0aUX17MxFWyZEnTvn17nxyZqevbb7818+bNE0Uw2JMr+7PbevDBB32ff/755+aCCy7wvR81apSsw1S0ZMfSP6FAcX/44Yf9ztaFzGbMmCHbpM9RiAPVBuZYmGXs119/lXWpOewv4YwsUZQjFGrG0h9//CHKIftav369b71u3br52syrfPnyAduA8spUvCjljEf6ht+jeG/atCnLNpE5yhvtdvcXyly8zxnv+0hwj4MzzzxTPmO8M6nIhAkT5PMXXnjBXH311fId44txh4xR7MePHy+fP/TQQ6Zfv34yE5yFhwSmbZ40aZLJLcJ5QFQSl0j6jzj/IkWKyH8lMXCS+PxTBTUHXPyjZ66TmNNIOOI4oqRGyt69e8WKVLduXVEO2rZt6/vuqaeeEosZVhlu6ig7CxYskGUmOsBSg6KEYjFgwAB5b2fhat26tczUxXZPP/10+R3WRKxW7IM6a8C0siiSWHzYF5ZJac+RI6LIPf300/J++fLlpmLFijL1bChee+01UVLcfPjhh3JMt956q28foVzEgeJvPvnkE1EIy5UrJ+tg9WP7oWC/3bt3900C8Mwzz8jxWKWrWLFiMr1cpIwdO1Zk6wUrHYqgWwEJBAoMBbO5WXjhmKySyTYZM4Fkw5gZPHiwr/Yv1kp/Nx8UYY4LS7D9HrkwkxtKUjSgNKOMMj5t/zEGUYT9KdTslzHhHlNYty+88EKzdetWGaeMfY7nmmuuCesYGK9NmjQxDRs2lPG7evVqv+eM+/27775rsgvnCzeUnTt3ynssIJwvgCwYB8B/5IylFCX+0ksvzbItZMY5lJvXTKY21gooyUkk/cd45GHNjk8l98mTxOdf8h1xLhPNU8jU5dsyJUSFA9ZWfhcpWFO4mXETxcLy0UcfyefffPONefvtt80vv/wiVh4Ul7vuuksUTiyBuJGx1KBgnHrqqTIDF+/PO+88+T0WtyeeeEK2i6v1/PPPN6+++qq4YLlB4o4EbuQ///yzXKSwDHHzXrdunZwc77//vliXfvjhB7mRovyw31CwftOmTbMoh7iTcatiuQqk6LIPlAaUdbdrmRfWNUCxqFy5su83WAH5LBgodSix1113ne8zZMPvsPqhoGOVpXpAILCW2WP57bff5DMUEhSNxo0b+9bjgYN1UKCRoz8lJFJwqyMTLlwonzfeeKPf9WgTDyzNmzeXcTFs2DC/6/1fe+cBJkWVvf0z5KgkyVFylhwVEAFz3FWMGFYUQcUsZldd1F0VA8YVMIuughmULAwZRHLOUYK7IJnp73mv3+1/9TA9dM1Md9Wpen/P03RT06Gq3rp1zz33nHPnzZt3nEZZAW+sPeYTGYn4Tgx2MnsAsG3u3LlZagLjvlWrVub/uC7gScZ5w7WHgvS49mHMYTBxImB047qCJxz7AiMU5ymrNuP8/3XXXScTJ0487nqzD3jZnXTv3t1ogcGNDd+ALmhfaE+4NnGtW895jx49zOAHn4F2mFLFZ19++eUsjwPnCwNHr4Bu8Ahr9OAQd/phBgP3+3ghUiT1RBS3PyZJpQCUkkrV59BpwWhERwpDyRqYmJqFoWNj/eDZQlxnoqCTq169unkNQwU3IFtbDcYUjAGAeEMYbStWrJACBQqY/2PqFd4fdLowFLp162amK+HZSQTc8Jx13GBkbN261XjEYLDBiwnjGwZ0Zu677z65995787zMFLyu9erVMx45C4woGOYYJMADBq/sG2+8YaZdswIGfObYSwwk4Klz7iem+GHY4PsRL/rAAw8kZGBlB4xwDGDg+cb5+/LLL6V3797HvQ+/iRCIKVOmmNhGXFOIMcXAIDuwz4MHDzZe+oceesjE9QIYeUOGDJG8BEbv5MmTzWvsHwZemaf327dvbwZd99xzj/HA2rCM7ICxi4GZNXizG2xkBte4Mw46HvDIol3BMIXnHtcrvMM4bzA4Ed6CWQqEs8CrbgeE77zzTvQ7cD5xnNAKMw2IJ0YcLAxXAAMd7RAxqslcMYoQQvISelBdkhMDB3VOc0JOPgfjAV4vdMDwliJRx5k0kdPjcHZsMPQy/98maqCTxdQyjEh00DDinEk1MODKli1r4hITHdFhStr5HfCewtOIY4WhBU8mplXtPmT2oMKbCaMaz1l5UGEgwFBwehetMR4P7IPTe2q/57LLLpOiRYsaDzUSWBC76YbsYiZh8OP7bcxhXoCkBhimMPKyAseEgQQ0xgADA56sjgnnFsaUBYMh6A+DMZGkrqyA9xDeS1yrOHZ7zWIb/maB0YvrCg8Yazj/1sC05xIDLOwPvLwwxjGoOpHBietz0KBB0fhQXNN4JEKiHlR7neF6waDSJkkh9hSDFxinADMWiLt2XqcA/0cYDj4Lj33fvn2NpxXxqxa0HehnQ1FSDXRDyIm2EjfkT6ifbtIUtz8aqClYchFF+N1eG/nS/vycW+BtxIUI7x3i59DJbty40cTmffbZZ6aTA4hJc8anOsG0aE6XqoMxjClJ7AO8bvDSWTBNin2CIQGef/75hL4TMYN2Ch8xk/DCwkiCIYkHjF109N99991xn4VHCr8HTxienQk6Ns4TRh9iFZF4g/OFqdWsvIkWJOtg2juzBxjeqx9//NFcIzCW8Roe7UTBscH4QtxlPJDsYsMicNwNGjRI+Pud+2+n4PCbMIrjxYnimKxBjCl0hFtkdUx4386dO+WZZ56JMfxyE4sGLz8MPRjP2F9og8EI9iFeSIIFHnZ4h1GZAcALDGMc4RFIOIKHH3/P7hzCuMW1gOkxgH2w126iHtSsHjhHtq3Y84NrBl5nGPoAgy+81yaD4brANVWtWrWY37nzzjuNZxgzCRgIoN3Z1xZ4XTFQ9SoGDceGa4PL1eqE+ukmQ3H7o4HqkpyMQrBCVH6Xn8uXlmaK9rsFHh7EC8KIQGd37bXXGuMDpWYQ8wdPEqalYahiCjYr4IX5xz/+EU2ScsOzzz5rpljxWUy727hE/B6MPmzDlCM8nsiUh5f3RPzlL38xmcvWKwYDOLNRAS9adslS2ekGY+DJJ580561OnTomEQhT6TaTPHOZJhwDjFoY8k5wfAhlQHIYPoNkKRgQiQLjE97nzFnyNgYVRgaMDRtrCOMKnsWsgOGDfUEYBzzqeA1voP0dXBv2GkH4BLxvWR0vYhtR1QBxl/BC4zrKKjQEHkAMSBDqgXOI70UyHbyu8CSfCFwf2Ef7wHVapUoVY4xiQAKjHN/7wQcfmOn8SpUqZft9mSsh4HswVY9jw37Bs474zezOIa4phKLA2LQxzHmZDY9YY4Qe4LvRJjENb8Mf4CGGpxXT9Pg7wkQwwHTOXCBGFn+zJcnQ7u644w6jk9UTYICBNuQVmT3gRBdu9EPFCMya4Zn4gzTF7S8tojFy1gPQgaJDg2fRGiaYOoNnBskXJ4rtenjUQlOEP5FSU7iOrmpbXZ655P/iG8MMPF0wKuBFyiorPSggPAKe7kSNCRhZMNQQQ0piQYgLyk3BWAvzOYSHHOcAhjUGC07c3L8IISRZtlQ8aKC6PKmYlrOJLW5u8IeOHpNr342/klRUkDSRtjXLcCWpTCALGZ4+eBHdYrPAtY4iww71yzkIjUFJN5ss6YWBaqcYtZa6CTtu9MN9FiExiHmMNzNBUkuGz9qfGwOVV5BLcmrgFC6QX96/sa1ZUerPov2RGEMVMad2Wv+xCxpxmdNMoBRPbqBhqhvqlzMQGpFIKbdka4cpX2qoEzf6YdGP9PR0k4SIUmjEHwP8AwcOGOeaH9qgzYNJBBqoLslK4ESjJIoUzG+m7e/uUc8U70edU5SSQrY+EqIQq1q2BGN3khWDQ3RC/ZJDqqK7oJ9d6IHoIxH9sBAGKk/YcoNY9Y6QrIi3VHZWsNd2iTMTzq5ug8aJxJpERyfFC4jc0L6KecQScSUeSQxOEeuG+iXnnOK+ZVdZS/Y9094j/TDFSPJOPyRjIgERVU2YzkLyGhqoLnEaoagtiIxjlHZCuSPi75ssO0e9UL/k3Mtw/0r2uun4HdQy9sP0Iskb/VBKDnWPUbnD6VRBKTfU24Ux61XdXXI8KJGX7IFoorgpPUgD1SWZb7JokKi1yKXdCCGaQIeVbOPU3jMZj6gXp37wkiLxDtP5tj6wvZZQIg9JrKjfyxhUEg/GoCaRrIrd4iafihs9yblmqOWJKgD0ouqD+umG+gVDPxinMEwzzxaiPjDq9Voj1i6xS/xBhuL+jx5Ul3CaSqdmKGdB7XRC/XRD/fTXoUZm/qJFi2K2Y5lprEZ4okUziLekKe7/aKC6RKPIYQeaBbnAf9ChfrqhfjpB2BoWR5k6dWpMCFvp0qWNYYryZZn7Q0zf4jNYCe5ENS5JakhT3P/RQHWJxvVsww40w9rsGOlrm+Ig1E87bH+6wFQ+vKVYHAXF1C2ohdqlSxdp27Zt3JA2fBarlzGj3z9kKO7/aKC6hB5UnZphZRNqpxPqpxvqpwdUpBk7dqx5duqHOFMslqLVExdm0hT3fzRQXaJR5LADzYoWLer1bpAcQv10Q/38Dzyl48aNOy7OtE6dOmY6H2WjiE7SFPd/NFBdwil+nZpt3rxZqlSpom6Kg1A/7bD9+RdMxyPGFHGjR48ejW6HQQrDFAYq9Nu4cSPvn0rJUNz/0UB1CT2oOjVzs9IX8RfUTzfUz59Gy4IFC2TChAkmS9+Cgvxdu3aVVq1aRY0ZN/ohBAD1UBkK4B/SFPd/NFBdolHksAPNihQp4vVukBxC/XRD/fwF6pgiznTbtm3RbTBG27VrJ2ecccZx90o3+hUoUMBk+RP/kKa4/6OB6hJO8evDTlFVq1ZN3RQHoX7aYfvzB1j5CYX2ly1bFrO9YcOGctZZZ5lEmtzqd+DAAVmzZo2ceuqpauMeg0aG4v5P197GAfEV11xzjZQtW9Y0iqZNm8qcOXOif0fJi8cee8yUWcDf0RhXrlyZo9+iB1Uf0AzaUzudUD/dUD9vOXjwoPGYDh06NMY4rVixovTp00cuv/zyuMapW/0Q0woDFc/EH6Qp7v/Ue1D37NkjnTp1km7duskPP/xgYi1gfDqnGZ5//nl55ZVX5L333pNatWrJo48+Kr169ZIlS5a4dn1rFDnsQLNChQp5vRskh1A/3VA/7zxncNRMmjTJeDYtJUqUMCWjmjdvnlB/Rv10k6a4/1NvoD733HPGdT18+PDoNhihTu/pkCFD5JFHHpGLLrrIbHv//ffNurSjR4+W3r17Z/m9hw4dMg/nChnAZjraQsQQHzcCPCfzNVzz+E08kvk6iMdkpziqVq1qCkwH4ZiCqFO8Y8Lf8lo/r48piDrFe50b/fx6TH7XacWKFWY6f+fOnTHxoVjhCQ4dFN234Wp5oZ/zXmv7x2Qca9B0SsUxRRz64Rrw+phCNcX/9ddfS+vWreWvf/2rlC9fXlq0aCHvvPNO9O9r1641weCY1recfPLJJiAcpTXiMXjwYPM++4ARDOzKGvDc4mFje+x23BCsMfvbb79FMyS3b98u+/fvN6+xqgOmXWx4gjWEcRHZJeU2bNggx44dM6LiNZ7xf7wGeB/eD/B5fA/A9+L7AX4PvwuwH9gfgP2zNy7sN/Y/yMf0+++/m8aJ56AcUxB1indMe/fuNfrhdVCOKYg6xTsmeO+gH14H5Zj8qhNmDz/88EP55JNPYoxTLEs6YMAAadKkSXR/Ez0mTNdDP7w+0THZfadO/rn2MjIypHLlyma7X9pToqRFrLmrFDtFf/fddxsjdfbs2XLnnXfKm2++aeJr0tPTzYhxy5YtJg7DgrgbWPMjR45M2IMKIxUnvlSpUhzNKRuhOkd1HHX7V6d4+5LX+vnhmMLk8cmpfn4+Jj/phEEApvLnzp0bPR4AwxL1TPGcm30/kX52X2DMIAa1du3apm+mTv649iL//3f80J7gcIDTD4brSSedFGwDFbEV8KDCELXccccdxlCFhzSnBmpmYKDipFoDlejBjvKrV69uGhDRBfXTDfVLHgg5mzVrlkyZMiXGoYK+CrOGjRs3dj2tmhnqp5sMn/V/1pZKxEBVH4MKo7NRo0bHlc344osvopmKAC5qp4GK/2N9Ybf4QWDiXjO/NE7iHuqnG+qX98CvhIx8xJna6VTrsEGh/Pbt20vBggVTrh+mjzENjEQsxKsS78mnuP9Tb6DCO7p8+fKYbQgQr1GjRjRhCkbq+PHjowYpLPiZM2dKv379XP+ecodzKIFmzqkGogvqpxvql7cgNhBlo9avXx+zHfkXZ555pjEOvdIPxim8uSj4Dy8Z8Z6I4v5PvYF61113SceOHeUf//iHmbbHdMfbb79tHgCCDBw4UJ5++mmpW7dutMwUgoYvvvhi179HA1Uf0GzTpk1mFKmtgRLqpx22v7wBsXtYmvSXX36J2V6zZk1TNtHOFuY11E83EcX9n3oDtU2bNjJq1CgZNGiQ/P3vfzcGKMpKXX311dH33H///fLHH39I3759TSY3pkDGjBmTo+W/NLrJww40w02c6IT66Yb65Q5kWiOXYtq0adHsbIDi+j169DAZ+sk0PKifbvIp7v/UJ0mlOrAXBi6nLnSBSxw3dsRkaRtBEuqnHba/nJ+3hQsXmvA0Z3keOFYwhd62bduUxHm60Q+JL5zi9xcRn/V/oUqSSjW053VqhrgtlAnzQwMl7qB+uqF+7kFtSsSZ2rqUAPcuVKzp2rWrFCtWTPyqH4rBE/8QUdz/0YOaBKufEEIIcQtm6MaNGyeLFy+O2Y78CUznYylvQjRDD2oSoQdVp2aoEYjl/bSNIAn10w7b34nB/Wnq1KmmdjdKNVlgkCIBCoXvvYL66SaiuP+jL94lNFB1aobl2apUqaKugRLqpx22v/ig/A+y8pGdj0ReC6bwu3XrJi1btvQ8MdeNfqg0gNWsWrVqJSVLlkzZPpJgtj8aqC7x+mZBcqYZ4m+ITqifbqhf1qxdu9bEmdp1zgGSntq1ayenn356jqrMeK0fDG4YqXgm/iCf4v6PBqpL6EHVqdnBgwfNDV/bCJJQP+2w/cWya9cuswJU5gVmsAIi4kxLly4tfoL66SaiuP+jgeoSGqg6Ndu9e7dZ6lZbAyXUTztsf39y4MABmTx5ssyePTvGw4j7EuJM7eqHfoP66SaiuP+jgeoSTvHr1AzxN0Qn1E83YdcPSU9z5swxximMVAtiNLE0afPmzX1tOIRdP+3kU6wfDVSX0IOqU7P9+/ebxAM/dwQka6ifbsKqH4575cqVZjp/586dMXVCsTx3p06dpFChQhIk/fAerO6YyjqtJLjtz1MDFasbbNu2zZw8lNPA0m1+hwaqPqAZaq8VLVpUXQMl1E87YWx/O3bsMAlQa9asidnerFkz6d69u6pa2m70w2pFFStWTNm+kWC3v5QX6keG34cffiiffvqpzJo1Sw4fPmxOIE5c1apVpWfPntK3b18zCvMTLNRPCCEkO1AqauLEiTJv3rwYZwayqBFnqnWqNVFQb3PDhg1SvXp1U3eTEDWF+l988UV55plnTNHhCy64QB566CGpXLmysewRxLto0SL5+eefjZGKUhuvvvqqWUHDT9CDqg9otm/fPilRooS6ESShftoJQ/s7evSozJw50/RfMNIspUqVkrPOOksaNWqk9tjd6Ids8WXLlkn58uVpoPqEiOL2l1IDFdmLU6ZMkcaNG2f597Zt28qNN94ob775pgwfPtw0dhqoJK9icIoXL66ugRLqp50gtz8c29KlS02cKZYptSC2FLVM27dvr35t+iDrFwYiivVL+RS/VjjFTwghxLJlyxYTZ4opbQsMgBYtWphVoOCxChuYtoUT6owzzjDTuISomeI/0U5jubf69eubgsV+hfa83iBxNAZtI0hC/bQTtPZn+6oFCxbEbD/11FNNeFqFChUkSARNv7ARUayfZwbq5ZdfbkZZAwYMMLXhWrduLevWrTMnEwlUl112mfgRGqj6gGaIC7PJeEQX1E83QdEPVWemTZsm6enp5rWlbNmyxjBFOJrm48sL/ZDFj4LweCb+IKK4/XlmoGIa4OGHHzavR40aZU4eYnjee+89efrpp31roLJQvz6gGYL2iU6on26064e+6ddff5Xx48ebKjQWLB3ZtWtX41zJnz+/BBU3+qHWJs4H8Q/5FLc/zwxUxB/YuqdjxowxBiku7vPOO0/uu+8+8Sv0oOoDmuF6Q9yLthEkoX7a0dz+EF+KOFPEmzo7fJRB7NKli6lAE3Tc6IclXOGtQ4kpOnP8QURx+/PMQEVduOnTpxsjFQYqpvXBnj17zMjUr9BA1Qc0QxkYjVMchPppR2P7Qz80btw4WbJkScz2evXqSY8ePaRcuXISFtzoBw8zk6T8RURh+/PcQB04cKBcffXVJtOxRo0aZqoE4OJu2rSp+BWOCvUBzcLUoQQN6qcbTfrB+4fyhjNmzJBjx45Ft2OKFIX2kQgVNjTpR4Kln2cG6m233Wbqnm7cuNGMSK3hhxsAYlD9Cj2o+oBm8IiULl1a3QiSUD/taGh/mJqeP3++WQUKq0FZUDsSJaNQOiqszgkN+pFg6pdyAxXFiy+66CLzQDB15oBqxKASQgghqWDNmjUmznTHjh3RbUh6QpF99FdcspOQkBioN998s3z11Vfy5JNPStWqVeXCCy80j44dO6qw7jXsIzleM5uQR/RB/XTjV/127txpVoBasWJFzHYsS4rlSeFxIv7VjwRfP89WkkKsD8p2wFj95ptvTLwPvKcwVhHr47fsSLv6AVzlWF+Z6AHTd7t37zaNNKzTdJqhfrrxm36ouz1p0iSZM2eO2TdL5cqVTd9TvXp1T/dPs34wJ2wyDp05/iDDZ+3PzUpSvlnqdObMmfL111+bx+rVq+XMM8+UQYMGSadOncQP2JOKWq1cwk0XmstsEOqnHb+0PzhBZs+eLZMnT5aDBw9Gt5csWVK6d+8uzZo14/3Bx/qRYOin0kB1AgMVhipKUf3lL38RP+DmpBJCCPEH6OIwjY/p/F27dkW3Y7UjhJbhUahQIU/3MSjs27fPLGoAYx8VegjJjS3lSRb/yJEjjQF6+PBhM3K99dZbY/5eu3Ztueuuu8SPOKeEiA6gGeLNUGrDD1McxB3UTzde6rd9+3aTALV27dqY7c2bNzezdHQ25K1+8FJjEOAs0UW8JUNx/5dyA/WNN96Q/v37m3WLEWf65ZdfGo/pP//5T9GAH1zkxL1myMSldjqhfrrxQj948lAyCqWjnJOEiC9FnCniTUlisP3pJk1x/5fyKf7GjRvL5ZdfLo8//rj5/4cffii33HJLTO05P8IpfkII8TdYMQdF9lFsHzN0FiS2ot52w4YNVXbUWsC0LVeSInllS+XzouZcnz59ov+/6qqrzE1l69atogFO8esDmmGqj9rphPrpJhX6wc+yePFiGTp0qKkOY41TxJaiZBRm7VA+isape9j+dJOhuP/L50V5KazOEd2BfPnMTQSlP3LCE088ES1pYR8NGjSI/h3Zmrg5lS1b1gRtX3bZZUasnMIbnD6gWbFixaidUqifbpKt3+bNm2X48OHyn//8x1RZsb/ZqlUrueOOO0wlmAIFPFs0MVT6IWwP8b1+KxMZZtIU93+etNpHH33UnDALRrvPPPNMTPmmF1980VXYwLhx46L/d96MkGz13Xffyeeff26+f8CAAXLppZfKtGnTcrTvGkUOO9AMpWSITqifbpKlH6YK4S1F1rgTLJfds2dPqVChQp7/Zhhxox+cTawj6y/SFPd/KTdQzzjjDFm+fHnMNpT5wNR/To1AGKQVK1Y8bjtiHN599135+OOPTcYmwEgbcUiIU8JSdtl5evFw3gwBwhGADd3FvsJ1br23yXoNT7MtgpzM10E8JvwWljE85ZRTzBKGQTimIOoU75jwt7zWz+tjCqJO8V7nRr+sfh/35enTp0t6enr0fgwwSwbDtE6dOtFt1Cn311Ui+jm1wXsxOEAZL6+vvSC2p7Rc6Adbyetj8vUUP1bwQHZldo8JEya4+s6VK1earEyMnK+++mrZsGGD2T537lw5cuSIiUGyYPofIzzc4LJj8ODBxuNqH6jJao1egBWl8ABYpcFuRzkHa8z+9ttvJpsUIKxg//795jXibW2haExPWUN448aNZn8BjgGlOiAqXuMZ/7fHhvfh/QCfx/cAfK+N58Xv2XAG7Af2B2D/sJ/2eLD/QT4mTPshGBvPQTmmIOoU75j27t1r9MProBxTEHWKd0wI34J+eJ2bY0LHh3v6q6++ahJxrHGK6WSUK7zoooukXr165veoU95de5jhhH54fSKdVq1aJQsWLDC/4YdrL4jtab/LY8JxILwR2/1yTInieaF+e4Co0ZUTfvjhB3PS6tevb07ok08+aU7yokWLzBKqN9xwQ4wnFLRt21a6desmzz33nCsPKoxUu9QpR3McoQZ51M1jok5+uvbWr18vP/74Y0wyLf7Wpk0b6dKlixQpUoTtyQc6wQkwdepUOf30041Ry/se7+Vpma4ZOBx8XagfF/HDDz9sCvZbS7t06dLSu3dvefrpp12tdX/OOedEX2P1inbt2kmNGjXks88+y1WgNuqG4REPp6vaWfw2ma+t0Ml8HcRjQsPYsmWLVKpUKbpd+zGlQhu/HFOy9KNOqbn2cqMf+gesALV06VJxAocEykZhWt/C9pSce0Si+uFv8V7zvufdvTzDoZ9fjilRUm6gwuXboUMH4+XEdDziQcGSJUtkxIgRJugdsUUwWHMCjFtM82CqATcwTE/AIHYavXBXZxWzmgjOk090AM3KlClD7ZRC/cKnH6YYUct05syZMasSIbYRhfZr1aqVpL0lmWH7002a4v4v5Qbq3//+d5Pph9WjMmdZ4m8IcsfzSy+9lKPvx3Q/vvvaa681ZUYQqA2jF+WlABK0EH8BIzknaBQ57EAzlj3RC/ULj37w9sybN8/kIthYO4DShEh0Pe2003LkiSGp0Q9JVPBq45n4gzTF/V/KY1Br1qwpb731lhkFZ8WYMWPk1ltvlXXr1iX0fffee69ccMEFZlofbmysUPXLL78Yjyyy1vr16yfff/+98c4i3uH22283n4OXNierH9gYVKIHdHrw2FepUoWdm0KoXzj0g2Nh7Nix0SQMAEMHzoTOnTtnG3JFkgfbn24yfNb/uVlJKuUeVAS5o25pPJo0aSLbtm1L+Ps2bdokV155pezatcsYpLiRoYQUXgN4YiEKPKhIeoJh/Prrr+d4/+lB1Qc0w/VA7XRC/YKtHxJlkQCFaixO0E+gAgsdAnran03UcsYkEm9JU9z/pdyDCiseyVEwJLMCcUdXXHGF8Yb6CTdWPyGEkOzBFD7KDs6ZMyeadW77CDgSbGk/ogf0jygBhnrnzoV3CMmJLZVyfy9uPMjgt2slO4GHE6tMnX322eJndznRBTRDmRpqpxPqFyz9kPSEOtSoZzp79uyocYrO6pJLLpGbbrqJxqmPYPvTTYbi/s+TJKnWrVtL3bp1pX///qZwPm5QKCOCqXcYqR988IH4FY1u8rADzZwlUoguqF8w9APLli0zZaNsUW+ARNZOnTqZFQXxmvgLtj/dpCnu/1JuoFatWtWMnm+77TYZNGhQTEFhlIV67bXXfD161ihy2IFmqBxBdEL99OsHgxRxpmvXro35G7LykZ2vda3wMMD2p5s0xf2fJ4X6UcMOK0AhI94GxmP9ZNTqQs3Sjz/+WK666irxIxrd5GHHLl2HJW79kMVI3EH99IKyfyjzh8oqTlB1BeFe1rNK/Avbn24yFPd/ni91mhms49uyZcuY4sx+CuyFAc3gb13gEsf1hJI19IDrg/rpA2t8o5oKlr105htgARbMlCG0i20xeO0PxhDC9FASTJsxFFQiPuv/fF1mSjt+EJi4wy67R+10Qv10dYaLFy+WcePGmQ7IAoMFmd1t27aVAgXY7QS1/eF9WovCB5U0xf0f7xQu4RS/PjRPcRDqpwXUpEahfTxb0CliRgwhXFiCmu0v2PdPlA7DIjmNGjWSYsWKpWwfSTD7PxqoLtEmMPlTM42Nk/wJ9fM38JQiznThwoUx22vXrm2Wri5fvrzpJNn+gt/+ENqBxXhQpYf4g3yK+7+UG6ivvPJKtn/Hklx+xmchuyRBzdBBcnUTnVA/f4LYUsSYoirL0aNHo9vLlStnEqDgNQXUTzfUTzcRxf1fyg1ULD16ImDt+xUaqPqAZph2xHWlrYES6ufH9oSs/AkTJpgsfQtiD7t16yatWrWK8daw/emG+ukmorj/S7mBmrkOnjY0usnDDjSrWbOm17tBcgj18w/r1q0zcabbtm2L0addu3YmCapIkSLHfYb66Yb66Saf4v6PMaguoQdVp2aIjcIqNdpGkIT6+QEU2scKUFgJygnKRaFsFGpYx4PtTzdu9MMABddEVgMV4g0Rxf1fyt2BcDPv2rUr+n+sHIW6WFqggaoPaIbAfWqnE+rnHQcPHjQrQA0dOjTGOK1YsaJcd911csUVV2RrnALqpxs3+qGcGBKk8Ez8QURx/5fyQv1wN2N6CJmdAIVaEc906qmnip9xU1yWEEI0g6SKuXPnyqRJk0zpIEuJEiXM0qTNmzdnuBM5Dnjq4IAqW7as8dgRorpQvzarXtv+kj81s6ubaJviINQv1axatcp4TX/77bfoNhTX79Chg3Tq1Mm1d4ztTzdu9MNgZvbs2SYemSsu+oOI4v7PcwNVGzRQdWqGzrZKlSrqGiihfqkCbQSGKQxUJ02aNJGzzjorxwYH259uqJ9uIor7P08M1H//+99mqgigft6IESNM7Twnd9xxh/gRZvHrA5pVq1bN690gOYT6JRd4vSZOnGim9J0D8KpVq5p6pnjODdRPN9RPN/kU938pj0FFuYMTWfH4+5o1a8SPcRO///47py6UgUscyR7ILNU2giTUL1kcO3ZMZs6cKVOmTDFTgBbEhcFjCs9pXrQXtj/duNEPcYW4njjF7x8iPuv/fB2Dijp6muEUv07NUCanUqVKvmigxB3UL+/PJzLyUTZqz5490e1IauncubOJNc3LBBfqpxs3+sFbV7JkSc40+oiI4v4v5R5UrTCLnxCiHZSbQZxpZkfBaaedZrLzYVwQQkgoPagHDhyQ8ePHy/nnn2/+P2jQoJjppfz588tTTz3l20K/tOf1Ac0QZ1esWDF1I0hC/fKCvXv3mqVJUdIvc8hVz549jXclWbD96Yb66SaiuP9LuYH63nvvyXfffRc1UFGov3HjxmYdZ4Cpp8qVK8tdd90lfoQGqj6gGUZtuMa0NVBC/XJbl3L69OkydepU89qC4vpYAap+/fpJbxNsf7pxox+8Yunp6dKxY0fmaviEiOL+L+UG6kcffST3339/zLaPP/44Wqj/ww8/NKuW+NVAZRa/PqBZMj1EJLlQv5x1SosWLZJx48bFrNSHWohdunSRtm3bmtmqVED9dONWP1TmIf4hn+L+L+UGKmrsNW3aNPp/TOU7jT7cOPv37y9+hR5UfUCzffv2mdJm2kaQhPq5ZePGjTJ27FjZvHlzdBuu+9atW0vXrl3NVF8qYfvTDfXTTURx/5dyAxVlmpwxp87VSuwSe86/+w0aqHpjcIoXL66ugRLq5+beivh+eE6d1KlTx8SZnnLKKZ5cTmx/uqF+uoko7v9SbqCi6DNuoIh9yopff/0114Whkwmn+PUBzSpUqOD1bpAcQv2yBwN6xJjOmDEjZnoVBikMUxioXkL9dEP9dKNZv5QbqOeee6489thjct555x2XqY8M/yeffNL8za/Qg6o3SBwlLbSNIAn1iwdmm5CVj1WgMIVnwRQ+pvJbtWrliwE1259u3OiHaWQU6bcrRRLviSju/1JuoD700EPy2WefGQ/qgAEDpF69emb78uXLTUY/PAB4j1+hgaoPaAYvE561NVBC/bJi7dq1pp7ptm3bottgjLZr184YCH4q08f2pxs3+iHxDjUuiX+IKO7/PCnUj5trv379zEom9udx4lD25PXXX49m9PsJFuonhHjNrl27zH0TA3onDRs2NMuTonwUIV6BWVAkQiOsxJaOJCSntpQn8z+1atWSMWPGmAQpxE3hgdfYllvj9NlnnzXG7sCBA6PbsA4tKgOULVvWTD1cdtllsn379hx9Pz2o+oBmSCChdjqhfn92/MjMxwDeaZyifEyfPn3k8ssv961xSv1040a/w4cPm1XK8Ez8QURx/5fyKX4nuKGirFReMXv2bHnrrbekWbNmMdtRUxWLA3z++efGckdowaWXXirTpk1z/RsaRQ470AyhIxqnOEi49Tt27JjMnTtXJk2aZIxUCwba3bt3l+bNm/v+nIRZvyBA/XQTUdz+Umqg3nrrrfLII48klKU/cuRIc1KvvvrqhL4bSQJ47zvvvCNPP/10dDvcyO+++65ZDABrTYPhw4ebKTF4btu3b+/qGPyQdEDEtWblypXjaVNKGPVDZ4KpUsSZ7ty5M7q9QIECZpWeTp06SaFChUQDYdQvSFA/3eRT3P5Sam2h7AmWNUUm/xtvvGE8nigmjbgq3Iy//vprs8pU9erV5aWXXoop6H8iMIWP7H/EYTmB9wFL/Dm3N2jQwPwGlgCMB4KKESvhfFiPhu1ArDcV2bTJfm1/M9mvg3hMeL17926jXVCOKYg6xfv9ZOjn9TFl93rHjh1mRT0Mqp3GKe6Ht912m8nQh3Gq5Zhyo59fjymo115O9dN2TEHUKZKAfn45Jl8aqE899ZSsWLHCjP4RSwXvJQzF8uXLm6z+6667TtasWSNvv/228W5mnqqPx6effirz5s2TwYMHH/c3ZLniZl6qVKmY7agL5syAzQy+C+EA9lGtWjWzHbEcYM+ePeYBID48tQAdijVmEVdry78g5hXFcsHWrVtNXCyAgW4XJsAKMHa97A0bNpgLCqLiNZ7xf7wGeB/eD/B5u2oMvhffD/B7NtYW+2EXRcD+2Y4P+439D8Mx4TloxxREncJ6TIjd++qrr+TNN98090EL7o/XXnutCUvC57TqhPttEHQK4rWXyDFt2rTphMeEwRXySDCVrOGYgqjTRgXH5OssfgsOAicKsVVwQdeuXdt1jAROLpbwQ2arNWjhYTjttNNkyJAhxgtxww03HLc6FWJfu3XrJs8991yW34v3Oz+DEwsjFfsMY9eeNuwvRMdzMl/DTW9HJsl8zWOiTrz2Utue0GHMmjVLfv7555h7DgbGmPlBOBK+j/cI3vd4L2efm6bcjti7d2/CWfyeGqh5wejRo+WSSy4x9dcsuOHjROBkIfMVN3lrWFpq1KhhMv2RQOWmNELm7yH+x05xICmPMcT6CKp+uPUuXbpUxo0bF/U4AMz4dO7cWTp06GBiTrUTVP3Cghv9kDcCA6RkyZKBuHaDQIbP2p+bMlPqryBksi5cuDBmGzymiDN94IEHjNezYMGCZo1qlJcCKNMCzy06ALdoy4Ijf2qGmyW100kQ9duyZYtJgFq/fn3M9hYtWphkziCtxBNE/cKEG/3++OMPs+wuFotgwX5/kKa4/ak3UDFSa9KkScy24sWLm5qndvtNN90kd999txlBwGK//fbbjXHqNoMfaBQ57EAzer31EiT94F3CYHnBggXH1Ybu2bOnVKxYUYJGkPQLI9RPN2mK2596AzURUBEArm14UBHj1atXL5OklRNsphrRAzRDgDbinP0wxUHCpx+SEdLT003tZZvAADBohmGKJZ+DOvgNgn5hhvrpJkNx+wukgYqi1k6wLvXQoUPNI7cEtRMJMtCscOHC1E4pmvVDnClCkOA1dWaw4p7UpUsXadOmTUz8fBDRrB+hftpJU9z+PDVQEVANY3L16tVy1VVXmel6xGZhGt6vMVgaRQ470IzxUHrRqh8qjCBJ05ZusccCoxTGabFixSQMaNWPuNcP70WSH/tJ/5CmuP15ZqAiOeDss882yUqYdu/Ro4cxUFH2Cf9HLUA/wil+fUAz1G7DQhHapjiIPv1QKxmZ+YsXL47ZXrduXTOdr3VVl7DoR3KuH5xLCKEj/iFDcfvzzEC98847Tf1SJAsgocmCklE333yz+BWODPUBzeCtonY60aIfBtaoZYpFRuyqLbbQPgxT1HkOI1r0I1lD/XSTprj9eWag4kaOpIHM60nXrFkzZkrMb2gUOexAM3jniU78rh88FPPnz5eJEyeaMjsWdApYDKRly5bqPBdh0o/knX6oUoElzBHGQs39QZri9lJopYYAAERQSURBVOeZgWpXUMkMllPz88nkFL8+oBmWasPytmE2FLTiZ/2wJCnqmdqlAAGSntq1ayenn366SYYKO37Wj+StfngvBmnsJ/1DhuL255mBiikvLEX69ttvR618rPP6+OOPy7nnnit+hR5UfUAzxEZRO534Ub9du3YZw3TFihUx2xs1amRWritdurRn++Y3/KgfSRzqp5s0xe3PMwP1hRdeMMHUuKEfPHjQZPGvXLnSJBB88skn4lc0ihx2oBkWbyA68ZN+Bw4ckMmTJ5tpTKeXqFKlSuZ+hiWUiX/1I+6hfrpJU9z+PDNQq1atahKkRo4caZ7hPcWKT1dffbUULVpU/AqnLvQBzbZu3WqMCG1THMQf+iEcac6cOcY4hZFqQTgSlltu1qwZB68+1o/kHOqnmwzF7S8tgkrS5ISgyDZqiaGEjNaaYmEFlzi89IgHpAdcH17qh9/GzA6m8zGtb8Ha1p06dZKOHTsel+hJjj+HbH/h0A+1zXfv3m1WSEMbId4T8Vn7s7bUf//7XxN6kB2eXUGDBw82Qbs33nhjzPZhw4aZml0PPPCA+BE/CEzca+Znrzzxp35ILIBhikQoJ/CWwmt6opsr+RO2v/DoB6MUZdWIf0hT3P955u996623pEGDBsdtb9y4sW+L9ANO8esDmmFVH2qnk1Trhyzkb775xtyjnMZptWrV5G9/+5up1UzjNHHY/sKjHzx1y5cvN8/EH2Qo7v8886Bu27bNxERkBqsdIF7Cr9CDqg9ohuuK2ukkVfphehJF9lGj+fDhw9HtpUqVMpn5SOjkNeQetr/w6IfFKlDZomLFiiyx5hPSFPd/nhmo8EZMmzZNatWqFbMd2ypXrix+RaPIYQeasR6lXpKtH2K0lixZYpYnRYy5BbGlqGXavn17xtPlArY/3VA/3aQp7v88M1CxnOnAgQPlyJEjcuaZZ5pt48ePl/vvv1/uuece8Ssa3eRhx05xYFCkLYuRJFe/LVu2yNixY2XDhg0xN/QWLVqYVaBKlChBCXIJ259uqJ9uMhT3f54ZqPfdd5/Jir3tttui02mw8pEcNWjQIPEr9KDqA5ohnITa6SQZ+iGTFAPiX3/9NWb7qaeeahYRQQInyRvY/nRD/XSTprj/87zMFOqfLl261GSZ1a1bVwoXLix+xE1pBEKIP8FgOD093YQSIebUUrZsWWOY4h6k8UZOiB/Yv3+/SZKqX7++FCtWzOvdIcptKc8NVG0ndc+ePSZpguia4sAUbvXq1dVNcZC80Q+3OXhL4TXdu3dvdDtmbbp27SqtW7eW/Pnz83QnAbY/3VA/3WT4rP9TUQcVpVyeffZZ02Hs2LHjuNjOzLUH/QK9K/qAZli5jNqFUz/cnBFninhTC27Ubdq0kS5duqitEagFtr/w6IcV12xReA74/EGa4v7PMwMV9QSxbOC1116rKj5Cy36SWM1gkFC7cOmH2Q5k5iND30m9evWkR48eUq5cuTzeU5IVbH/h0Q8he1OmTJEzzjiDKy76hDTF/Z9nBuoPP/wg3333nVkuUBPM4teH36Y4SHL1Qy1GdJIzZ840Hh0LEp8QZ4pEKJI62P50Q/10k6G4//PMQC1durRZr1cb2gQmf2qmsXESd/rhRjxv3jyZOHGiSdawFC9e3JSMQukoXgOph+1PN9RPN/kU93+eGahPPfWUPPbYY/Lee++pyvZjTpk+oBmMF0xxaJzmCDuJ6Ld69Wr58ccfTTy7BTFwKLKPYvt+rQ4SBtj+dJMq/ZD9v3btWjn77LOP+xva9ccff2xqpycb5MWgslCBAgWMUYc67XXq1MnyvSiVOXr0aDMgRtztRRddJOXLlz/ufb/88ouMGTMmJsH6wgsvjC5KhMoiOMeIFf3oo49MVRGAbe3atZNWrVpJGNufZwbqCy+8YDoVTLvVrFlTChYsGPN3eEL8CA1UfUCzTZs2mVGktgZKstdv586dxjBduXJlzPbGjRub5UlZccN72P50kwr9YEChNBUeXoPjRAwtbBIsyT5ixAi5++67zcpymfn222+N8XjaaaeZWPevvvrKLEKUFbBzevfuneXfli1bZgxWxPDCOL311lujGe+vvPKKNGnSJMeDbM3tzzMD9eKLLxaNaHSThx1ohpsDCY5+8FggyXLOnDkxceHwSPTq1cvcjIk/YPsLj34oH3TBBRck9N4nn3zSGIKrVq2SGjVqGM8jDDVrxE2aNEkWLlxoDLPMHky0++nTpxujsUGDBua9jz/+uPnb5s2bTXIkYtFhnHXu3NkMWBMFtZAtcKDhO3C/yWygohIRKoMg0Rs0bNhQvv/+e9m9e7er8EUYpah8gKRNvHZy6NAhYyjnpiKC5vbnmYFqLyZt0IOqUzMsqYuGrm0ESWL1gzE6e/ZsY5zipm5BPb3u3btL06ZNqbHPYPvTTTL1g/FkPY6YBresWLHCeCT79u1rDMNRo0bFTPej/d9yyy1mKWLEnFtwT4BX86qrrpKSJUsaw/Ktt94yy3ziHjF8+HBj9GUFfiuzA2r+/PkmXwaGd2ZQxxO/YT+Dc2Pre2ZloK5bt07efPNN8xr7fc0115jXdmEDZ9gA3nfs2DFTieScc84x4QZhbH+eGahaoYGqU7OtW7eam5S2Bkr+1A+eigMHDhjPCDwUFtx0UQmkY8eOx4UJEX/A9hce/eABhKGJKW8YYScCiYtZgVjURo0aRae1MY2OTHT7N3hU7ffjb6jaAbDmPIw6xHE6gdEHA/WGG25I8Kj/rMVuS2HmRb8Rb4ofXmMsFmLJPMU/bNgwMzOEcpxha3+eGagYHbz00kvy2WefmQsPSxA6cXZCfoJT/PqAZphCIjqBxwQdEDomJ82bNzcJDFx62N+w/YVHP+v1c5Z3y46s4jqzIlHDCsbYKaecIjfddFOWf0/UgwpvJ+JJr7zyyrj1kuEtxap0mNXB5/Db8J5m5W2NB/YFxrNNlsrMSSedJFWqVDHGck4NVM3tzzMDFfEn//73v+Wee+6RRx55RB5++GFzUSAjDtn9foUeVH1AM9wIMBrXNoIMM/DGTJgwwUyzOUF8KeJM493Uib9g+9ONF/qhVvFPP/0kHTp0MEbs3LlzYzyRU6dONTGgKCHnvD/AS/j7778bg87WO0aiE4xWxHEm4kFdv369CSmAt7NixYpx34ffhtGIJZThMUbmPwxKN/GnSO6ENzjeeT148KDxfjZr1kzC2P48M1Dhgn/nnXfkvPPOkyeeeMKMVGrXrm2EmDFjhtxxxx3iR2ig6gOa/fbbb2Ykqq2BhpGjR4+aBAh0Qs6ZFcSCITMfyQjUUQ9sf7rxQj8kKiHZ6e233z4uSQqJS0iuwtQ3jFf8zYYCYNlixJ+isgce8OTCoxkvez4rvv76a/M5eFAtl1xyifldxIvigYx7cP7555v3/fzzz2YfUGbKDZjeb9myZcw2G4MKsB+Iq89NdQPN7S8t4pHFhdEHRhzwhmAUglWlIBRGPohLgavcTyAWxAZAc0qRkLwHt6LFixebOFNn+8eNH7VMUQ8wN8kChJDkgnabiqVOrUcQwKGFkpVXX321aALG56uvvmqccWEKHfyfC1vKs7OCgrRwXQN4TjHaAcjQdVPv64033jBeVxwoHpgSwDKqThd5//79TeAxgqovu+wy2b59e473mx5UfUAzJNhQO/8Cbwniw7744ouocYrRPhIgBgwYYAavuSm1QryD7S88+sGDCQcTnpMJBrHwMr7++utmmvzcc88VbeB+hoUHkm2cRhT3f565I+Ayx4oN8IrcfvvtpuTCu+++axKm7rrrLleG7rPPPmumBCAAVqaCmx1xKah9hu+Cd/bzzz83Vjs6u0svvVSmTZuWo/3WKHLYgWZIuoOnXtsUR9CBMYr7AOodOsGgtWfPnqY2IpIQMJilfjph+wuPfphyR5+cbBAaSILf/jyb4s8MYs7wgKGZaKHfeCBI+Z///Kf85S9/McHRWCINr23MB2LY8FtYBjG7KQRnth/c0gjARoYiVqexpw2CO5cRS9ZrmyWIRzJf85ioUyquPcSZIsYU7RCvLciYRZwp7gN4P9sT7xG87+m5l2PGEjOUSC6Cscr+yZ86RTy0I1D5wPdT/JnB1DyWE8uNcYqYjk8//dRk9+H7kPmHArXo8CxYdQJxr+gYs2Pw4MHmJNoHjFMAA9U+29cYndhpSSy9CGMWIDDZrgyBRouiwQDeIFtkHFOb1hBGDTfsL4AnGccDUfEaz/i/rQWH9+H9AJ/H9ziz/gB+z4YzYD+wPwD7h/0E2G9b0iuox4TXuCaCdExadcK+wjBF7BUSC6xxinWsEbeG+n8Ix7HHgWPCZ6Afyk358ZiCqFNeHhO0wyNIxxREneIdE15Dv0SOCbGgmA2BEeLnYwqiTofiHBPusdAD1Qn8ckwqPKgovo3OCh2Pc7lC4CaLHw0CBilOKuJM4TFFTAqeUVYic92ztm3bSrdu3eS5555z7UFFhh08tGEc+Wg9JvwWrjFbaiQIx6RRJ9wIx44dG73xAfwd7RFJUIhby+r38dm81o86pe7ay41+1Mn7e0Qi+tnfRIkn9Oloz/CO8b7n/b084tAPSaaaPKiexaCOGDHCLFWGaQB4TLDjFrx2Y6CiBANWr8AB/+c//5E+ffqYFSByAxK1skrWslnEzv11Bjkn87UVOpmvg3hMuKlmLnKs/ZhScRx5dUwYTSOpAVU7MrfbHj16mPbvJKvfT4Z+1Cl1115u9KNO3t8jEtEPvxnvdRjve346pkoO/fxwTInimYH66KOPmoL8gwYNytGOO7G10ACyflEJ4OWXX5YrrrjC1FHEqA5xoxYbI5MTPHQ4kxwCzTA1Ae+6s/GQ5IIZDZScmTVrVszKMqgniEL7tWrVSuh7qJ9uqJ9uqJ9uIor7P88MVMQ1oHhubo3TrIArGdPzMFaxPjeyhFFeCqDILuIvEBKQE2ig6gOa4XpD7V1tDVQjaH+I/540aVI0Xgrg/GNpUqy64qbdUz/dUL/w6IcZRjuVTPxBRHH/51kM6v33329iOR988MFcfQ88sOecc45JfEJsA+JOEVuKWDdMH/br10++//57E1KAeAeUtALp6emufoeF+gk5MatWrTI1jW0gPUCIBQaEnTt3dlXjmBBCSLBwY0t5NsxBljyWCRszZoxZygueTicvvvhiQt+D4N/rrrvOJF7goFG03xqn4KWXXjLeGnhQ4VXF1CKK++YUelD1Ac3QKNAYtI0gtQCDFIYpDFQnTZo0ke7du8eE2LiF+umG+oVHP7wX4Tw2mYp4T0Rx/+epgQpD0q4x6zxxbk4iivtnB8rXDB061DzyAhqo+oBmGJzgWVsD9TuYOsJU/pw5c2LaBtZ9xmDQlmfLDdRPN9QvPPrBEErFUqckHO3PMwP1hRdekGHDhsn1118vmkhGzCxJvmZYkYjkHfCSIPkJnZGtxQcwSkfdYXhO8+pmSP10Q/10Q/10k09x/+eZgYpYtE6dOok26EEVlZoh3gUjem0jSD+eSyQa/vTTT9HCzAAhOogxRaxp5nCdvPhN6qcX6qcb6qebiOL7p2cG6p133mlWk3nllVdEEzRQ9QHNsJqGxikOP7Ft2zYTlrNu3bqY7cjKR3Z+yZIlk/K71E831E831E83EcX9n2cGKqYHJ0yYIN9++600btz4OK/Ll19+KX6EU/z6gGZY453kDFTHQFvFYhhOatSoYeJMMxfxzmuon26on26on27yKe7/PDNQkdV76aWXijboQRWVmmE1o9KlS6sbQXoJ1mmePn26WbrQru0McB5RJaNBgwYpOZ/UTzfULzz6YRalZ8+eeR7mQ8LZ/jwxUOFu7tatm7mQc7qiEyEkeTe0RYsWmQUuELvkjBtHdm7btm1ZiJsQkqW3jrWOifpC/cWKFTNrc2OaUAMs1E/CwKZNm0ycKZ4tGHVjVbauXbua1UgIISQr/vjjD1m8eLEJ2+O9gqgt1A8vzPz589UYqM5lHImo0wwZ51i5jDHEWYObxbhx44zn1EmdOnXMTAeWL/QK6qcb6hce/TA7un379mh9c+I9GYr7P88M1Ntuu03uuece46mBdybzaAsrQvkRbTEc5E/NsDY0tTuew4cPmxhTxJqic7HAIIVhCgPVa6ifbqifbqifbtIU93+eTfFnZcnjBNpSCCgE7ic4xU+CNqpesGCByc7ft29fdHvRokVNfDgGjdpG24QQ72diuJIUUT/Fv3btWtEIp/h1arZz505TaoNGl5g6pogzRV1TC85Lu3btTBIUlgf2E9RPN9RPN9RPNxmK+z/PDFRtsacWjW7ysAPNkFkadu0Qh4QVoJYtWxazHeWiUDYKMUp+hPrphvqFRz8MbpEg5bdBbphJU9z/eTbFD1avXi1Dhgwx2fygUaNGZoWp2rVri9/gFD/RysGDB2Xy5MlmcQznDABKvKHQfs2aNT3dP0IIIeHgfxqm+DHFeOGFF5plEjt16mS2TZs2zYy+vvnmG+PR8SOc4tcHNPvtt99M4o+2KY7cHvecOXNk0qRJcuDAgej2EiVKmKVJmzdvruJ8hFW/oED9wqMfFvSw72Wxfn+Qofj+6ZmB+uCDD8pdd90lzz777HHbH3jgAd8aqBrd5GEHmqHubpi0W7lypfz4448m9siCTM4OHTpI586dpVChQqKFMOoXJKhfePTbv3+/zJ0718Syw0tGvCdN8f3TMwMV0/qfffbZcdtvvPFGM+3vVzSKHHagGZbgCwM7duwwhinCZ5w0bdpUunfvrrLTCJN+QYT66Yb66SZN8f3TMwMV7uZffvlF6tatG7Md28qXLy9+hVP8+oBmKB5doUIFdVMcblZwwVQ+vBfOsPKqVauaOFM8ayUM+gUZ6qcb6qebDMX3T88M1Jtvvln69u0ra9askY4dO0ZjUJ977jm5++67xa/Qg6oPaIZg7CBqh+L6SH5C7cFDhw5Ft8NTetZZZ5mYbu3HHWT9wgD10w31002a4vunZwbqo48+atzOL7zwggwaNMhsq1y5sjzxxBNyxx13iF/RKHLYgWZBWxcaXlKUi0LZqD179kS3I7YUMabt27cPTJJCEPULE9QvPPrBQ4fBsTZPXZBJU3z/TGmZqa+//lrOOeec4zrOvXv3mmc/x0nY0ggwBkqVKuX17hCXUxxbt26VSpUqBeLGiWNBFYz169fHbG/RooXJzkeWfpAImn5hg/rphvrpJsNn90/flpm65JJLzOo1iD/Nnz+/OWmIN/WzYZoZelD1Ac1QhF67dhjIYWlSxGk7QR1TxJkeKlhSBn6xRB49v5HUKKtzxBxk/cIK9dMN9dNNmuL7Z0oNVBimM2bMkAsuuMBMUWo8YRr3OexAM6wxrxXUFkxPTzcx2nhtwU0H5djq169vjnH9rj8kiGjXL+xQv/DoB6/Y1KlTTZiRxoohQSRN8f0zpQbqrbfeKhdddJE5YXhgJZt4HDt2TPwIs/j1Ac02b94sVapU8cUUR6JgELdw4UIZP368mRaxYBlB1Bls27atmYmwwGv67z5tJGho1Y/8CfULl37sI/1FhuL7Z0oNVCRA9e7dW1atWmVWkRo+fLi6eE56UPUBzeC916Tdxo0bTZwpbiwW7H/r1q2la9eupvByVgbtsYyI5M/35wAwKGjUj/wf1E831E83aYrvnynP4m/QoIGZkuzTp49cdtll6hI6NIocdqAZvI4a+P3332XcuHGyePHimO2oF4zpfNxo4rF4y//k/Fenyre3d5YmVYIzvaZJP3I81E831E83aYrvn574e+Hp+eijj0ySlDY4fSEqNUPGu5+1Qw1TTOW/9tprMcYpDNJrrrlGrrrqqmyNU1ClVFH551+amecgoUE/Eh/qpxvqp5sMxfdPT+qgIg4CHqFdu3Ydt5KU36EHVR/QDCU2/KgdbhrIykd2PlaDsmAKv1u3btKyZcuE44ZKFy8kf21dTYKGn/UjJ4b6hUc/zIjGC0Ei3pCm+P7pWaH+Z599Vu677z554403pEmTJqIFjSKHHWiGAvZ+Y+3atSbOFMvQWZD01K5dOzn99NNdT8v8d/8Rmbpqp3SuU05OLhaMIv1+1o8kBvULj364f2kqGxkG0hTfPz0zUK+77jrZv3+/NG/e3Jy8zGUQdu/eLX5Eo5s87ECzDRs2SPXq1X2RxYiZA6wAtXz58pjtDRs2NMuTonxUTti4Z7/0/3ieiUE9uVhwYlD9ph9xB/ULj37o01euXGlmRulF9QcZiu+fnhmoQ4YMyZPvGTx4sHz55Zdm2UcYuR07dpTnnnvOJGJZDh48KPfcc498+umnJtYPRc1ff/11qVChguvfowdVH9CsatWqnmt34MABmTx5ssyePTtmoIPpF1yTNWrUyNX3N6x0kix8oqcUK+RZsw60fiRnUL/w6Ic6zTCGsHgI8Qdpiu+fnvVkyOLPC9Dh9+/fX9q0aSNHjx6Vhx56SHr27ClLliyJrj971113yXfffSeff/65KR48YMAAufTSS03hc7doFDnsQDOMHL3SDjV958yZY65VGKkWTIVhaVLMIuTFvqG8VMkiwZna94t+JHdQP91QP92kKb5/eupqWb16tamFiueXX37ZLHv6ww8/GFd048aNE/qOMWPGxPx/xIgR5nvmzp1ripljZYt3331XPv74Y2MMAPwmplOxqlX79u1d7TOn+PXh1RQHqlVgugvT+Tt37oxuL1CggPH0d+rUKU9jgzbu3i/Pj10u9/eqL9XKBCdJQfMUFaF+2mH7002G4vunZ3sLb1LTpk1l5syZZop+3759ZvuCBQvk8ccfz/H3wiAFNo4PhiqmHRDb56zFCrGmT58e93sQCoDVe5yPzMYHHvYCSPZr+5vJfh3EY8LIEXrb/6fimLZt2yYffvihfPLJJzHGKa55ePCR6QpDNS91Onz0mOzed0iOZkRU6hTv95Ohn9fHpLk9ud2v3Ojn12MKok650U/bMQVRp0gC+vnlmHxvoD744IPy9NNPG++S04sELyc8mzkBJ2DgwIHGM2UrA8BQwPdnXrEK8af4W3axrQgHsI9q1f4s37Nnz57os32NhC5rGMMYscbsb7/9FjW8kamNAHKA+q+IiwVYKQjGsF09yK61jhEPpoZxTHiNZ/wfrwHeh/cDfN6uOITvtfVl8Xs2Qxz7gf0B2D9rNGG/bUJaUI8Jr/FbqTimvXv3yjfffCNvv/22rFmzJno94fq59tprTSgKrqdk6FRSDsjrlzeUWuWKB+raw2vsw44dOwJzTJrbk9tjQvk07FuQjimIOsU7JrzGPidyTPjOOnXqGE+dn48piDodinNMCH3Ew9ZC9cMxJUpaxK1Jm0egXhrWGa9Vq5aJxYPn9NRTT5V169YZD6c98W7o16+fCRGYOnWqCQoGmNq/4YYbouJZsI456kwioSor8H7nZ3BiYWQgAxveWXvaMDqxo5RkvkaDtyOTZL4O4jHZmyuuCZRBScYxodFjYIVrz3ndwBjt3r17dMBEndxfe/hbXuvH9pS6e0Ru9KNO3t/LE9GPOnmvU1oC+mHWzms7Ak4c9IswXE866SR/xqDCowkLHQaqk/nz50uVKlVcfx+mTb/99luZMmVK1DgFFStWlMOHD5slJJ1eVIwI8Ld4FC5c2DwyY6dlnQHHzriOZL62QifzdRCPCTfVzFmleXUc+P6lS5eamQBcYxZ47VHLFDHO9pqx78+LY8pqX5Zs3SuXvp4uX97WMWapUy06Zff7ydDP62NKxmu/HlNu9PPrMeXmtbZjSkQ/O1CH9wwGiLOv9OMxBVGnRPTzwzH5foq/d+/e8sADD5hpdmtdI6v+3nvvNTVSEwXWOozTUaNGmdV4Mhu8rVq1koIFC5plJC2oPwkXd4cOHVzvt0cOZ5ILoBkGKXmt3ZYtW0xSHqpDWOMU1zJWf7r99tulc+fOMcZpsql0chF55PyG5jlIJEs/khqoX3j0QzhHenp6zKp4xFsiiu+fnnlQ//GPf5jyUJg2x6irUaNG5hlrjj/yyCMJfw++A9P4X331lQkVsHGlGMGhLiqeb7rpJrn77rvN1DxcyjAeYJy6zeAHGkUOO9AM3npca87RXU5BuAcGQwhLcYLBEeqZ5qS+bl5QtkRhua5D8OoP5rV+JLVQP91QP91EFN8/PYtBtSA2ArGoCL5t0aKFWYHCDfFOOEpJXX/99TGF+pFR7SzUn90Uf1ZGSaJxEySYIKAcXn54CGwQOihbtqz06NFD6tWr5+kN4H8Hj8icdbuldc0yclIA66ESQvwN+keE2aHEI/pLQnJjS6Xcg4qp/H/+85/y9ddfG7czEkhQVirzUqeJkoh9jTXNhw4dah65hR5UfUAzDEwQU5wTAxKf//XXX02YCAK8nddVly5dTGY+4ly9ZsOu/XLjiDlmqVNnDGrY9SPeQv10Q/10E1F8/0y5gfrMM8/IE088YeqSwihFgX6Ujxk2bJhogAaqPqAZSmMg+c5tA0Ws8tixY028qTPYu3Xr1qaWaU4HVsmgfsWSMuuh7lK6eN4V/9euH/Ee6hce/fB3DNzZTv1DRPH9M+VT/JjCRyLULbfcYv4/btw4Oe+888wSkDnJ8koVnOIPF8hExbWJJXOdYBof0/nlypXzbN8IIYQQjfh6ih8eqXPPPTf6f3hSYdXDQ+UsD+VX6EHVBzRDHHIiI3tMhfz888+mpimS9ixYPhexy6jV61c27dkvr45fJbd3ryNVSxcLpX7Ef1A/3VA/3UQU3z9TbqBiRQOcKCcoA+VMOvEzNFD1Ac2wokWlSpXiNlDERqMG78SJE2NKpBQvXtws6IAEPj97+MGhoxmyYsde8xw2/Yh/oX7h0Q/eMSxf3q5dOyYT+4SI4vtnAS9OFrLrnUXwYd3feuutxhiwfPnll+JH/G6kkKw1y27xByxJijhTxEJbkPSEMmQotp/Vgg1+pPYpJWTUbZ0kbPoRf0P9wqOf9dbRkeMf8im+f6bcQO3Tp89x26655hrRAhuePqAZ1hMuVqxYzAgSawNjBagVK1bEvB81eRF6Urp0aQ/2liSqH9EB9dMN9dNNRPH9M+UGKuqTaoYGqk7NMPWEjHs0UCTkTZo0SebMmWOm9i2VK1c2cabVq1cXjSzZ8j+58p0Z8snN7aVR5ZMCqx/RBfXTDfXTTUTx/dOzlaS0wil+nZoh/gZJT0h+mjx5spmGsmAFMtTjbdasmboG7OSUkoXltq61zXMQ9SM6oX66oX66yaf4/un5SlLaSiNgzXWukKELeElRaH/q1Kmya9eumOS8jh07mkehQsGqHRokcIvCSnMlSpRQPYAIK9QvPPohCRrlg9BHFihA/5cfiPjs/unrMlPaoT2vi+3bt5sEqLVr18Zsb968uZx55pmByjTdd+ioLNz0X2la9WQpUbhA4GKokETphxsscQf1C49+MEqx9DPxDxHF98/g9GIpglP8OsCIESWjUDrKOahAfCniTBFvGjTW7fzDxKAGbalTtLkKFSp4vRskh1C/8OiH0Ck4A2rVqnVcOUniDfkU3z9poLqEHlR/gykmxJmi2P7hw4ej2+Ep7dmzp8nQ1zaKPBG79h2SkXM2ytSVO6VBxZLyj++Xyul1T5HLW1eVsiUKBybIHxoGTbswQP3Cox8WOlm1apVxANBA9QcRxfdPGqguoYHqX12wLCmWJ0WcsAWxpahlihWgKlasqK6BZsfBI8fk798skc/mbJRjkYg4o8mnr9klL/y4XK5oU00eu6CRFC6QXzRri44Pz0HSLyxQP91QP91EFN8/aaC6hFP8/mPz5s0mznTjxo3RbWiILVu2NKtAOReACAowTq8bNkvmrNstGVmkOcJYPRqJyCezNsiqHfvk/ZvaqjVS0eaw1CzRCfXTDfXTTT7F908aqC6hB9U/YNpi/PjxJkPfCbylmM63cTfQzGaWahtBxuOpb5fENU6d4O+z1u02ntZnLmkqGgmifmGC+umG+ukmovj+SQPVJTRQvQexpdOmTZP09HQTc2pB9igM07p168Y0RGiG92mc4ogbczp74wmNU6c3Fe+/p2d9KVNcXzmtoOkXNqhfePRD6T4kouKZ+IOI4vsnDVSXcIrfO9DAFixYIBMmTJC9e/dGt2OFjC5dukjr1q0lf/78WWpWrlw5CQqfzdlkYk7dkBGJGCO1X9faoo2g6Rc2qF949MNymijhR/xDPsX3TxqoLqEH1RvWr19v4ky3bt0a0/DatGljjFMYqdlptmfPHildurS6EWRWpK/eGZMQlQjwtuJzGg3UoOkXNqhfePTDan123fesnAUk9UQU3z9poBJfg4b1008/ydKlS2O2169fX3r06BHKotD/O3AkpZ8jhJBE609PmTJFzjjjDK64SHINDVSXaBuBaAUFn1HLdObMmWZUbkHiE+JMkQjlRrMyZcpIUDipaMGUfs5rgqZf2KB+uqF+uklTfP+kgZqDdd1Jcs/vvHnzzCpQmCqyoFQUliY97bTTXMcB4zt3795tGmkQYog71i4nU1e5m+bPl/bn5zQSNP3CBvXTDfXTTYbi+ycNVJfQg5o8Vq9eLT/++KPs2LEjug1xTB06dJDOnTtL4cKFc6wZ1ogOinZYIQpF+FHnNFHypaWZov0aCZp+YYP66Yb66SZN8f2TBqpLNIrsd3bu3GkM05UrV8Zsb9y4sZx11llSqlSpXGuW2+/wE1i+FMYmivAnUmoKlyzer7HEVBD1CxvUL1z6afPSBZ00xfdPGqgu4RR/3oEp/EmTJsmcOXNiqiNUqVJFevXqJdWqVcszzWAEo9RGUG6eWL505Y59JyzWD+O0bc0y5v1aCaJ+YYL6hUc/FIM/77zzUrZvJNjtjwaqS+hBzT1Iepo1a5bJ9kQylOWkk06S7t27S9OmTfP0POO7EB4QJO2wbOn7N7Y1K0r9WbQ/EmOoIubUTuvDONW6zGlQ9QsT1E831E83aYrvn2kRFvZMeFlNjA6xZBgMKeIeXGrLly83ZaMQtG3BqiOdOnWSjh07cgWSHK4sheL9qHOKUlLI1kdCFGJVEQ5ACCGpAAuozJ8/X1q0aCElS5bkSSe5sqXoQXUJp/hzxrZt20yc6dq1a2O2Iysf2fnJvJlBs99++01OOeUUdVMciQAjFAX4NRbhT4Sg6xd0qF949MN7YXiwn/QPGYrvnzRQXaLRTe514WYsTYpRtZMaNWqYONNKlSqlRDOsbELtdEL9dEP9dEP9dJOmuP+jgeoSjSJ7wZEjR2TGjBkydepUOXz4cHQ7llvDClANGjRI2bnE73C6SS/UTzfUTzfUTzdpivs/Gqgu4dTFieNMFy9eLOPGjTNTPRYEaWP5u7Zt25qabKnWbPv27WYVKm1THIT6aYftTzfUTzcZivs/XXsbB2SDX3DBBVK5cmUzWhg9evRxRtNjjz1mppOLFi1qamtmrrmZKPSgxmfTpk0ybNgw+eKLL6LGKc5X69at5fbbbzdJUKk2Tu0+IBib2umE+umG+oVHP0wlt2rVyjwTf5CmuP8LhAf1jz/+kObNm8uNN94ol1566XF/f/755+WVV16R9957T2rVqiWPPvqoiX9csmSJFClSxNVvaRQ52cAYHT9+vCxcuDBme+3ataVnz55Svnx58RJohqVSiU6on26oX3j0Q0UWOIqIf0hT3P8FwkA955xzzCMr4D0dMmSIPPLII3LRRReZbe+//75xd8PT2rt37yw/d+jQIfNwlkYAR48ejX6vFR8udDwn8zVc8/hNPJL52s0xoYZpenq6TJ8+PXpeAAoCI860Xr165v34Xi+PCb+FKgLQHEunhk0n7ceEv+W1fl4fUxB1ivc6N/r59ZiCqFNu9LO/iT5h69atxkgtVKiQb48piDqlJaAfZjC9PqbQTfFnB8oaQRxM61tQg6tdu3bGsIrH4MGDzfvsw65qZKeu9+zZYx4ANT3tdqzYYI1ZlHZAFjtADAhWTgJowLZA/ebNm6OG8MaNG01yEdiwYYMpaA9R8RrP+D9eA7wP7wf4PL4H2BsEwO/hdwH2A/sDsH/YT3s8tiZposdka929+uqr8vPPP0eNU4RPYKBw/vnnS/Xq1X1zTL///ruUKVPGPIdJp6AcE6436IfXQTmmIOoU75gOHDhg9MProBxTEHWKd0xIcoV+eH2iY1q9erXJQUCb9fMxBVGnQ3GOCceBpU6x3S/HFNpC/bDQR40aJRdffLH5Pzx8KAK/ZcuWmJJGl19+uXnvyJEjE/agwkjFiYfYYR3NweBHPVMY/RZ8FslPp59+uok90nZMQdSJx0SdeO2xPaX6HgEnACq3oC9A3CPve7yXp2W6ZjB4YaH+XIKsczzi4XRVOzPjkvnaCp3M1/F+HyMhrAC1bNmymPOAclHwTpctW9a3x4SGgQSuKlWqRLcHVacgHlOy9KNOqbn2cqsfdfL2HpGofvhbvNe873l3L89w6OeX9hSqGNTsqFixonmGi9rpQcX/sYqRW5wnPwzA1Y8qCTNnzjQXuvO8IgEKSWd+B5phFY2waRcUqJ9uqJ9uqJ9u0hT3f4E3UGFAwZhClrk1SDFdD4OrX79+rr9Po8g5Acbo3LlzZdKkSdGYF1CiRAmzNCmqJuRkROQF0MxttQbiH6ifbqhfePRDEo5NxiH+IE1x/xeIqwiBu6tWrYr+H3GSv/zyiwnsRrLOwIED5emnn5a6detGy0why9DGqbrB6UUMKjiXiDO1wdAAN5wOHTqYeN7sQh/8CDRDIDhiiLUY1eT/oH66oX7h0Q/ljJCPQPxDhuL+LxAG6pw5c6Rbt27R/999993muU+fPjJixAi5//77Ta3Uvn37miDuzp07y5gxY3I0qgiyBxUGKQxTp7EPmjRpYuJMEdisEWiG8I4gaxdkqJ9uqF949IMxhMxw1EPVZgwFlTTF/V/gsviTBcICEs080wam8CdOnGim9J2XQ9WqVc2CBngmhBBCsgP9I3IWsKy1VocG8Y8tFQgPaioJ0hQ/6qEhFhc3FGdJLVw08JjCc6px1JUZW9cO4R4c1euD+umG+umG+ukmQ3H/RwPVJUEw2OAlRbkolI2yBXUBpmUQ/oBYU7wOkmbwAgdBuzBC/XRD/XRD/XSTprj/o4HqEo0iO8HqEIgzXbduXcx2VDhAdn7JkiUlaNiafNq1CyvUTzfUTzfUTzdpivs/GqghmeLH6g0TJkww1Q2c1KxZ09QzddaIDRqapzgI9dMO259uqJ9uMhT3f0ySCniSFDIqp0+fbpafs+vzgtKlSxvDtH79+ipHVm6xy/ERnVA/3VC/cOiH8DHkNuTPnz8U/YoWMnzU/zFJKoloKXqA/Vy0aJGMGzfOXBAW1DDt0qWLqVWHm0gYwLlwrh1NdEH9dEP9wqMf/s4i/f4iorj/4xR/AA1UFOUdO3asbN68OboNF2br1q2la9euUqxYMQmbZliLGFMc2hoooX7aYfsLj36oN75w4UJp2rSpKdpPvCeiuP+jgeoSv7jJswKLEGBJV3hOndSpU8dM52M93rBqhlhbohPqpxvqFx79jh49ahZ8wTPxB/kU9380UAPgQUUNU8SYzpgxI+bGAIMUhikM1LBrZlc30TaCJNRPO2x/uqF+uoko7v9ooCo2UBFXgqx8rAK1b9++6HZM4WMqv1WrVr72+KZSM5TXwlrE2hoooX7aYfvTDfXTTURx/0cD1SV+MfjWrl1r6plu27YtZt/atWtnlpkrUqSIp/vnJ3BeatSo4fVukBxC/XRD/XRD/XSTT3H/RwNVmQd1165dZgWo5cuXx2xv2LChWZ60TJkynu2bnzVDGAQqGGgbQRLqpx22v/DoB8cIEqToIPEPEcX9Hw1UJQbqgQMHZMqUKTJr1qyYxQIqVqwovXr1UhsEnSrNELhfpUoVdQ2UUD/tsP2FRz8YQeyL/EVEcf/HQv0+L9SPosdz586VSZMmGSPVUqJECenevbs0b95c3UVHCCEkeBw+fFh27Ngh5cuXl0KFCnm9O8SHsFB/ADyo+J1Vq1aZONOdO3dGt6MIcseOHaVTp068Abg4lwcPHjTTTjTm9UH9dEP9wqMfnCjz5883eRA0UP1BRHH/xyl+HxqoGIHCMF29enXMdsT2wGsKTy5xp9nu3bulUqVK6hoooX7aYfvTDfXTTURx/0cD1UdZ/FiFAyWj5s2bF2MIV61a1cSZ4pnkTDPE3xCdUD/dUD/dUD/d5FPc/9FA9YEHFcX1Z86cKT///LPJtrPAU4rM/MaNG6sb+fhNs/3795v6sDyP+qB+uqF+uqF+uoko7v9ooHpooOK7li5dKuPGjZM9e/ZEtyN2p3PnztK+fXuz+gPJ/XlGYHbRokXVNVBC/bTD9hce/fLnzy+lS5c2z8QfRBT3f8zi9yiLf8uWLSbOdP369THbW7RoIWeeeabJ0ieEEEIICQrM4vexB3Xv3r0yfvx4WbBgQcz2WrVqSc+ePU1dU5L3mmEpWBj92kaQhPpph+1PN9RPNxHF/R+n+FNkoB45ckTS09Nl2rRp5rUFKz/BMK1Xr566i0dbDE7x4sV5jhVC/XRD/cKjH2YYsaAMykyx2ow/iCju/2igJjmLHxfHwoULjdcUrm0LapJ16dJF2rRpw3idFGhWoUKFZP8MSRLUTzfUTzfUTzf5FPd/NFCT6EHduHGjjB07VjZv3hzdhhEMjFIYp8iqI6kLEkfssLYRJKF+2mH70w31001Ecf9HAzUJBurvv/9uMvMXL14cs71u3bpmOr9cuXJuf5bkUjOU78KztgZKqJ922P50Q/10E1Hc/9FAzcMpflwEqGU6Y8YMOXbsWHQ71iWGYVq7du2cK0VypRk0IDqhfrqhfrqhfrrJp7j/o4GaBx7UjIwMs/4wVoHCalAWTOF369ZNWrZsmdQVqMiJNUPwPoL2tY0gCfXTDttfePRDpjjKJCLHgviDiOL+jwZqLg3UNWvWmHqm27dvj25DkeJ27drJ6aefzobqE82wWpfGKQ5C/bTD9hce/dD3IVuc+IeI4v6PBqpLrCd0165dxjBdsWJFzN8bNWpklifFahrEP5ox7lcv1E831C88+qGc0fLly6V+/fpMAvYJ+RT3f6Gadx46dKjUrFnTeDXh4Zw1a5br70ADHDNmjLz++usxxmmlSpXk+uuvl7/+9a80Tn0GRo67d+/O02VqSeqgfrqhfuHRDzW+N23aFFPrm3hLRHH/FxoP6siRI+Xuu++WN9980xinQ4YMkV69epnRnpsA4rfffjtG6JIlS0r37t2lWbNm6tznhBBCCCF+JDQe1BdffFFuvvlmueGGG8w0PAxVJDENGzbM1fccOHDAPBcoUMDUMh0wYIA0b96cxqmPwcABK3ZxAKET6qcb6qcb6qebNMX9Xyg8qIcPH5a5c+fKoEGDYuIyECs6ffr0uCWj8LAgC85ub9KkiVnKDYVvDx48aKb9IT4eyOhPxmvsLzy3eCTzNUjmcXhxTPgt1KZFFiOC+INwTEHUKd4x4W95rZ/XxxREneK9zo1+fj2mIOqUG/3sb+J96A/RX/r5mIKoU1oC+sGx5vUx7d271/zdvk/CbqDu3LnT1CXNvNwX/r9s2bIsPzN48GB58sknj9v+0ksvJW0/CSGEEEKCDgxVGM0SdgM1J8DbiphVC0YgNWrUkA0bNpzwpBJ/gWXeqlWrZpaehdeb6IL66Yb66Yb66eZ/Puv/4DmFcVq5cuUTvjcUBipKLGBqwlmrFOD/FStWzPIzhQsXNo/MwDj1g8jEPdCN2umF+umG+umG+unmJB/1f4k6+UKRJFWoUCFp1aqVjB8/ProN8RD4f4cOHTzdN0IIIYQQEkIPKsB0fZ8+faR169bStm1bU2YKy5Iiq58QQgghhPiH0BioV1xxhfz222/y2GOPybZt2+S0004zBfczJ07FA9P9jz/+eJbT/sTfUDvdUD/dUD/dUD/dFFZsu6RFEsn1J4QQQgghJEWEIgaVEEIIIYTogQYqIYQQQgjxFTRQCSGEEEKIr6CBSgghhBBCfAUN1P/P0KFDpWbNmlKkSBFp166dzJo1K9sT9/nnn0uDBg3M+5s2bSrff/99KvQieaDfiBEjousD2wc+R7xhypQpcsEFF5iVRaDF6NGjT/iZSZMmScuWLU1map06dYymxBvc6gftMrc/PFBdhaQWLOndpk0bKVmypJQvX14uvvhiWb58+Qk/x/5Pr34jFPV/NFBFZOTIkaZOKkoxzJs3T5o3by69evWSHTt2ZHnS0tPT5corr5SbbrpJ5s+fby4KPBYtWpRq/UgO9ANYUWPr1q3Rx/r163kuPQL1iKEZBhmJsHbtWjnvvPOkW7du8ssvv8jAgQPlb3/7m4wdOzbp+0pyr58FHamzDaKDJall8uTJ0r9/f5kxY4b89NNPcuTIEenZs6fRNB7s/3Trp6r/Q5mpsNO2bdtI//79o/8/duxYpHLlypHBgwdn+f7LL788ct5558Vsa9euXeSWW25J+r6S3Os3fPjwyMknn8xT6UNwSxo1alS277n//vsjjRs3jtl2xRVXRHr16pXkvSN5od/EiRPN+/bs2cMT6jN27NhhtJk8eXLc97D/063fcEX9X+g9qIcPH5a5c+fKWWedFTXa8+XLZ/4/ffr0LI16bHe+H8BjF+/9xF/6gX379kmNGjWkWrVqctFFF8nixYspkxLY/oIBFkupVKmS9OjRQ6ZNm+b17hAR+e9//2vOQ5kyZeKeD7Y/3fpp6v9Cb6Du3LlTjh07dtyKUvh/vJgobHfzfuIv/erXry/Dhg2Tr776Sj788EPJyMiQjh07yqZNmyiVAuK1v//9739y4MABz/aLJAaM0jfffFO++OIL80An2bVrVxOeQ7wD90GEy3Tq1EmaNGkS933s/3TrV19R/xeapU4JsXTo0ME8LGicDRs2lLfeekueeuopnihCkgg6SDyc7W/16tXy0ksvyQcffMBz7xGIZUQexdSpU6lBgPXroKj/C70HtVy5cpI/f37Zvn17zInB/ytWrJjlScN2N+8n/tIvMwULFpQWLVrIqlWrkrSXJC+J1/4Q+F+0aFGebIW0bduW7c9DBgwYIN9++61MnDhRqlatmu172f/p1k9T/xd6A7VQoULSqlUrGT9+fPSkwOWN/ztHGU6w3fl+gAy6eO8n/tIvMwgRWLhwoZl6JP6H7S94oBoD21/qQV4bjJtRo0bJhAkTpFatWif8DNufbv1U9X9eZ2n5gU8//TRSuHDhyIgRIyJLliyJ9O3bN1KqVKnItm3bzN+vvfbayIMPPhh9/7Rp0yIFChSI/Otf/4osXbo08vjjj0cKFiwYWbhwoYdHEV7c6vfkk09Gxo4dG1m9enVk7ty5kd69e0eKFCkSWbx4sYdHEV727t0bmT9/vnnglvTiiy+a1+vXrzd/h3bQ0LJmzZpIsWLFIvfdd59pf0OHDo3kz58/MmbMGA+PIry41e+ll16KjB49OrJy5Upzz7zzzjsj+fLli4wbN87Dowgn/fr1MxndkyZNimzdujX62L9/f/Q97P+Cpd+Tivo/Gqj/n1dffTVSvXr1SKFChUzZohkzZkRPUpcuXSJ9+vSJOXGfffZZpF69eub9KHnz3XffpVY5kmP9Bg4cGH1vhQoVIueee25k3rx5PKMeYcsOZX5YzfAMDTN/5rTTTjMannrqqaZ0CtGh33PPPRepXbu26RTLlCkT6dq1a2TChAmUzwOy0g0PZ3ti/xcs/QYq6v/S8I/XXlxCCCGEEEIsoY9BJYQQQggh/oIGKiGEEEII8RU0UAkhhBBCiK+ggUoIIYQQQnwFDVRCCCGEEOIraKASQgghhBBfQQOVEEIIIYT4ChqohBBCCCHEV9BAJYR4xhNPPCGnnXZatu9Zt26dpKWlmfXa/ULNmjVlyJAhOf48jmf06NESBH1ywxlnnCEff/yxBIUlS5ZI1apV5Y8//vB6VwhRDw1UQkieMH36dMmfP7+cd955CX/m3nvvlfHjx0f/f/3118vFF1/sG0VGjBghpUqVOm777NmzpW/fvjn+3q1bt8o555yT6/1INsnU5+uvv5bt27dL7969Ywx/GO/OBwy+RAcGGzdulBtvvFEqV64shQoVkho1asidd94pu3btinlf165do99fpEgRadSokbz++uvHfd97770nnTt3Pu4zeFSoUEH++te/yvr166Pvx/e0b99eXnzxxVyfH0LCDg1UQkie8O6778rtt98uU6ZMkS1btmT7XqywfPToUSlRooSULVtWnQKnnHKKFCtWLMefr1ixohQuXFj8TjL1eeWVV+SGG26QfPliu6G///3vxoC3j/nz5yf0fWvWrJHWrVvLypUr5ZNPPpFVq1bJm2++aQzsDh06yO7du2Pef/PNN5vvh9fz8ssvl/79+5vPOfnqq6/kwgsvPO4zuL7xNxjE11xzTcxncExvvPGGub4JIbkgQgghuWTv3r2REiVKRJYtWxa54oorIs8880zM3ydOnBjB7eb777+PtGzZMlKwYEGz7fHHH480b97cvAev8R7nA+9Zu3atef3FF19EunbtGilatGikWbNmkfT09Oj3Dx8+PHLyySdHvvnmm0i9evXMey677LLIH3/8ERkxYkSkRo0akVKlSkVuv/32yNGjR6OfO3jwYOSee+6JVK5cOVKsWLFI27ZtzW8699n5wD4CfN9LL70U/Z49e/ZE+vbtGylfvnykcOHCkcaNG5t9iQe+a9SoUeb1iY4vu/3Ibv+d52XMmDGRBg0aRIoXLx7p1atXZMuWLTHatGnTxnwe7+3YsWNk3bp1UU1OpE+3bt0i/fv3jzm+HTt2GI3HjRuX5fHj72lpaZFFixbFbM98XjOT3d/PPvvsSNWqVSP79++P2b5161ZzbLfeemt0W5cuXSJ33nlnzPvq1q0b6d27d/T/Bw4cMOdr6dKlcT/zwQcfmO92cujQIXMNxDt2Qkhi0INKCMk1n332mTRo0EDq169vPErDhg0zXtLMPPjgg/Lss8/K0qVLpVmzZsdNJ8OTdfbZZ0e9Zx07doz+/eGHHzbvQSxqvXr15Morr4zxUu3fv9945T799FMZM2aMTJo0SS655BL5/vvvzeODDz6Qt956S/7zn/9EPzNgwAATmoDP/Prrr2bKFr8PLxx+G9PJJ510UnR/8PuZycjIMNP106ZNkw8//NB45HCMCHdwQ7zjy24/stt/53n517/+ZY4f3u0NGzZEP4/vx5R9ly5dzOfxXQhdwBR2ZuLp87e//c3EkR46dCj6XpyHKlWqyJlnnpnlsU6dOtV4oBs2bCh5AbyjY8eOldtuu02KFi16nLf66quvlpEjR2Z5TVrwucOHD0f/D88rjgHXdbzfxHXfrl27mO0ILUDc7s8//5zr4yIk1CRoyBJCSFzgdRsyZIh5feTIkUi5cuViPHnWCzh69OiYzzk9dKBPnz6Riy66KOY91sP473//O7pt8eLFZpv1bsFTiP+vWrUq+p5bbrnFeLfg3bXAe4jtYP369ZH8+fNHNm/eHPN73bt3jwwaNCj6vfAqZufJGzt2bCRfvnyR5cuXJ3yFZOVBPdHxZd6PRPc/83kZOnRopEKFCub1rl27zN8nTZqU5X4mog88jaVLl46MHDkyug0e4CeeeCLu8ePcnXrqqVme10KFChnPpX28/PLLJ/SgzpgxI+acZubFF180f9++fftx3lB41OEJxd9fe+216GduvvnmyL333hv9Pz4DrzD2CdcV3g9vPfTLzCWXXBK5/vrr4x4/IeTE0INKCMkVy5cvl1mzZhmPHyhQoIBcccUVJiY1M4gRzClOj2ulSpXM844dO6Lb4JGrXbt29P9IYkFSDeIondvsZxYuXCjHjh0z3kq8xz4mT54sq1evTni/4PFEIg++Jzec6Pgyk+j+Zz4v+G77vWXKlDGJT7169ZILLrhAXn75ZeMZdQOSjK699lrjNQfz5s2TRYsWme+Nx4EDB8znsuK+++4z59Q+rrvuuoT3JTsPaWaQFIXzBc8pYkvvuusu6devX/R7vvnmm5j4UwBPLPZpwYIFxgtcp04d6dmzp+zduzfmffhOeK4JITmnQC4+SwghxhDFVDEypy3o4JEE9Nprr8nJJ58c3V68ePEcn7GCBQtGX9spaEyvZ/V3+56sttnP7Nu3z0zDz50797jpeKdReyIyTykn6/gyk+j+Z3UOnIbc8OHD5Y477jBhEZgGf+SRR+Snn34y2eiJgml+TGtv2rTJfB+m9pFBH49y5crJnj174v4Nhp8b8H4cF0JHENaRGWwvXbq0SW5zGpsIq4B+MNqdyVoYcNnwCie4lu2+4RnXPj6L84Zz4Jz+dw4KCCHuoQeVEJJj0Im///778sILL8R4veBhgsGaOSv6RCB+D17BVNCiRQvzW/AmwthwPhC3mOj+wPMJw2zFihVJ29es9iOR/U8UfNegQYMkPT1dmjRpErc2abzz0bRpU+Mdf+edd8xnUerpRL+3bdu2uEaqW1BpoEePHsYrCu+sE/zORx99ZLz6zthaa2wizjRzJQFk6KNc2oniiO3fM/8mPMg4RkJIzqGBSgjJMd9++60xMm666SZj2Dgfl112WZbT/NmBKXkk6yBsYOfOnXLkyJGkqYOpcXjRMIX85Zdfytq1a43nbPDgwfLdd99F9weeSiTMYH+ymrZFghEKzuN44XnE9/zwww/GI5lXZLUfiez/icBnYJgiOQr1PH/88UeTYBUveSk7feBBRHIYvLNZeTGdwHiDpxSJZW7ZvHlzzGAID1yD8NYjUQvhCkgGQwkoaADDFUboM88846pGa+bpfYDzDoMXDwzCEBKAUAVM8zsXlsA+nnXWWa6PjRDyf9BAJYTkGBig6Iid0/gWGGxz5swxBk2iIBYQlQDgjcN0bE4MGDdgOhoG3j333GN+FxntKMJfvXp183dM8d56663G+4b9ef7557P8ni+++ELatGlj4nBRrP3+++/PU09wvP040f6fCMSnLlu2zGgFgxcZ/KgHesstt7jWB8eO+GM8x4svdXoeUS8Unk23oCIBDFznAwZ53bp1zfV26qmnmmoDmGLH8XTr1s0Y4Ii3TQTE76KGKgzdzMBDjCl9PPC9MNJRIQLnxIJZAxis2YU4EEJOTBoypRJ4HyGEEBIXeA5hFMJAbtmy5QnPFLyQjRs3NklVfjLmsArUuHHjjOHpFpSpgqGMMIdOnTolZf8ICQs0UAkhhOQYTPNjKVHUSUXIgBuv9+jRo0386Omnn+4bBVDbFB7SnOwTPK8Iw4jngSaEJA4NVEIIITkGCyJguhshAlgEAQlThBCSW2igEkIIIYQQX8EkKUIIIYQQ4itooBJCCCGEEF9BA5UQQgghhPgKGqiEEEIIIcRX0EAlhBBCCCG+ggYqIYQQQgjxFTRQCSGEEEKIr6CBSgghhBBCxE/8P9brQ05cM705AAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 700x800 with 2 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plot_roofline(\n",
+    "    hw,\n",
+    "    [(\"matmul_small\", report), (\"sdpa\", sdpa_report),\n",
+    "     (\"softmax\", softmax_report), (\"paged_attn\", paged_attn_report)],\n",
+    "    title=\"Roofline — four kernels (default HW)\",\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Tuning HardwareConfig\n",
+    "\n",
+    "`HardwareConfig` lets you model different hardware targets by adjusting bandwidth, clock, and SIMD width.\n",
+    "All fields default to reasonable approximations — override with real Spyre specs when available."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Default HW  : 28 cycles  bottleneck=memory\n",
+      "High-BW HW  : 12 cycles  bottleneck=memory\n"
+     ]
+    }
+   ],
+   "source": [
+    "# High-bandwidth variant: 4× HBM bandwidth\n",
+    "hw_hbw = HardwareConfig(\n",
+    "    num_cores=32,\n",
+    "    clock_ghz=1.5,\n",
+    "    hbm_bandwidth_tb_s=4.0,   # 4 TB/s aggregate\n",
+    "    simd_elements_per_cycle=128,\n",
+    ")\n",
+    "\n",
+    "interp_hbw = KTIRInterpreter(latency_config=hw_hbw)\n",
+    "interp_hbw.load(str(_LATENCY / \"softmax_small.mlir\"))\n",
+    "interp_hbw.execute_function(\n",
+    "    \"softmax_kernel_small\",\n",
+    "    output_ptr=np.zeros((64, 64), dtype=np.float16),\n",
+    "    input_ptr=np.random.randn(64, 64).astype(np.float16),\n",
+    "    n_rows=64,\n",
+    ")\n",
+    "r_hbw = interp_hbw.get_latency_report()\n",
+    "\n",
+    "print(f\"Default HW  : {softmax_report.kernel_cycles:.0f} cycles  bottleneck={softmax_report.bottleneck}\")\n",
+    "print(f\"High-BW HW  : {r_hbw.kernel_cycles:.0f} cycles  bottleneck={r_hbw.bottleneck}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. MLIR frontend parser (optional)\n",
+    "\n",
+    "By default `KTIRInterpreter` uses the built-in regex parser.\n",
+    "The MLIR frontend uses the real MLIR C++ bindings for full-fidelity parsing.\n",
+    "\n",
+    "See the [README](../README.md#mlir-frontend-bindings-optional) for build and install instructions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    from ktir_cpu.mlir_frontend.parser import MLIRFrontendParser\n",
+    "    _mlir_available = True\n",
+    "except ImportError:\n",
+    "    _mlir_available = False\n",
+    "    print(\"mlir_ktdp not installed — skipping MLIR frontend cells.\")\n",
+    "    print(\"See the install instructions above.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "============================================================\n",
+      "KTIR Latency Estimation Report\n",
+      "============================================================\n",
+      "  Kernel cycles : 352\n",
+      "  Kernel time   : 0.352 us\n",
+      "  Bottleneck    : memory\n",
+      "  Cores         : 4\n",
+      "------------------------------------------------------------\n",
+      "  Core       Compute        Memory          Comm         Total\n",
+      "------------------------------------------------------------\n",
+      "     0             8           344             0           352\n",
+      "     1             8           344             0           352\n",
+      "     2             8           344             0           352\n",
+      "     3             8           344             0           352\n",
+      "============================================================\n",
+      "\n",
+      "Roofline Analysis (critical-path core)\n",
+      "------------------------------------------------------------\n",
+      "  Arithmetic intensity : 3.10 FLOP/B\n",
+      "  Peak bandwidth       : 31.25 GB/s\n",
+      "  Dominant unit        : systolic\n",
+      "  Efficiency           : 96.2%  (dominant unit)\n",
+      "\n",
+      "        Unit      Achieved       Ceiling       Ridge      Eff\n",
+      "  ----------  ------------  ------------  ----------  -------\n",
+      " *   systolic       93.06 G       96.73 G   16777.2 F/B   96.2%\n",
+      "         simd        1.45 G       64.00 G       2.0 F/B    2.3%\n",
+      "============================================================\n"
+     ]
+    }
+   ],
+   "source": [
+    "if _mlir_available:\n",
+    "    # Pass MLIRFrontendParser directly to the interpreter\n",
+    "    mlir_interp = KTIRInterpreter(\n",
+    "        latency_config=hw,\n",
+    "        parser=MLIRFrontendParser(),\n",
+    "    )\n",
+    "    mlir_interp.load(str(_LATENCY / \"matmul_small.mlir\"))\n",
+    "\n",
+    "    M, K, N = 16, 64, 64\n",
+    "    mlir_interp.execute_function(\n",
+    "        \"matmul_kernel_small\",\n",
+    "        a_ptr=np.random.rand(M, K).astype(np.float16),\n",
+    "        b_ptr=np.random.rand(K, N).astype(np.float16),\n",
+    "        c_ptr=np.zeros((M, N), dtype=np.float16),\n",
+    "        K=K, BLOCK_SIZE_M=8, BLOCK_SIZE_N=32, BLOCK_SIZE_K=32,\n",
+    "    )\n",
+    "\n",
+    "    mlir_report = mlir_interp.get_latency_report()\n",
+    "    print(mlir_report)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "regex  cycles=352  AI=3.10\n",
+      "mlir   cycles=352  AI=3.10\n",
+      "Results are identical — the two parsers produce the same IR.\n"
+     ]
+    }
+   ],
+   "source": [
+    "if _mlir_available:\n",
+    "    rf_regex = report.roofline()\n",
+    "    rf_mlir  = mlir_report.roofline()\n",
+    "    print(f\"regex  cycles={report.kernel_cycles:.0f}  AI={rf_regex['arithmetic_intensity']:.2f}\")\n",
+    "    print(f\"mlir   cycles={mlir_report.kernel_cycles:.0f}  AI={rf_mlir['arithmetic_intensity']:.2f}\")\n",
+    "    print(\"Results are identical — the two parsers produce the same IR.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "```python\n",
+    "from ktir_cpu.interpreter import KTIRInterpreter\n",
+    "from ktir_cpu.latency import HardwareConfig\n",
+    "\n",
+    "hw = HardwareConfig()                        # or HardwareConfig(clock_ghz=1.5, ...)\n",
+    "interp = KTIRInterpreter(latency_config=hw)  # add parser=MLIRFrontendParser() for MLIR\n",
+    "interp.load(\"path/to/kernel.mlir\")           # or inline MLIR text\n",
+    "\n",
+    "interp.execute_function(\"kernel_name\", arg=tensor, ...)\n",
+    "\n",
+    "report = interp.get_latency_report()\n",
+    "print(report)                        # human-readable table + roofline\n",
+    "report.kernel_cycles                 # float\n",
+    "report.kernel_time_us                # float\n",
+    "report.bottleneck                    # 'compute' | 'memory' | 'comm'\n",
+    "report.per_core_summary()            # list[dict] — per-core breakdown\n",
+    "report.roofline()                    # dict — arithmetic intensity, efficiency, ...\n",
+    "```"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "ktir-cpu",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,3 +49,9 @@ markers = [
     "spec_gap: RFC conformance gap — feature not yet implemented in the interpreter",
     "regex_only: test validates regex-parser-specific behaviour; skipped under the MLIR frontend adapter",
 ]
+
+[dependency-groups]
+dev = [
+    "jupyter>=1.1.1",
+    "matplotlib>=3.10.9",
+]

--- a/tests/test_latency.py
+++ b/tests/test_latency.py
@@ -164,7 +164,7 @@ class TestVectorAddLatency:
 
         # Extract addf cycles from trace
         addf_cycles = sum(e.cycles for e in core0.trace
-                          if e.op_type == "arith.addf" and e.category == "compute")
+                          if e.op_type == "arith.addf" and e.category.startswith("compute_"))
         # Per-core tile is 128 elements (BLOCK_SIZE=128), addf costs tile_size / simd
         assert addf_cycles == pytest.approx(128.0 / simd)
 
@@ -236,25 +236,24 @@ class TestRoofline:
         rf = report.roofline()
 
         assert "arithmetic_intensity" in rf
-        assert "achieved_gflops" in rf
-        assert "peak_gflops" in rf
         assert "peak_bw_gb_s" in rf
-        assert "ridge_point" in rf
-        assert "ceiling_gflops" in rf
+        assert "dominant_unit" in rf
         assert "efficiency" in rf
+        assert "units" in rf
 
         assert 0 < rf["efficiency"] <= 1.0
-        assert rf["achieved_gflops"] <= rf["ceiling_gflops"]
-        assert rf["ceiling_gflops"] <= rf["peak_gflops"]
+        for unit in rf["units"].values():
+            assert unit["achieved_gflops"] <= unit["ceiling_gflops"]
 
     @pytest.mark.parametrize("path,func_name,entry", get_test_params("add_kernel"))
     def test_vector_add_is_memory_bound(self, path, func_name, entry):
         """vector_add has low arithmetic intensity → memory-bound on roofline."""
         report, _ = _run_vector_add(path, func_name, entry, HardwareConfig())
         rf = report.roofline()
+        dominant = rf["dominant_unit"]
 
-        # AI should be well below the ridge point (memory-bound)
-        assert rf["arithmetic_intensity"] < rf["ridge_point"]
+        # AI should be well below the dominant unit's ridge point (memory-bound)
+        assert rf["arithmetic_intensity"] < rf["units"][dominant]["ridge_point"]
 
     @pytest.mark.parametrize("path,func_name,entry", get_test_params("reduce_explicit_region"))
     def test_vector_reduce_is_memory_bound(self, path, func_name, entry):
@@ -297,21 +296,23 @@ class TestRoofline:
 
     @pytest.mark.parametrize("path,func_name,entry", get_test_params("add_kernel"))
     def test_memory_bound_roofline_matches_bottleneck(self, path, func_name, entry):
-        """When bottleneck is memory, roofline AI should be below ridge point."""
+        """When bottleneck is memory, roofline AI should be below the dominant unit's ridge point."""
         report, _ = _run_vector_add(path, func_name, entry, HardwareConfig())
         assert report.bottleneck == "memory"
         rf = report.roofline()
-        assert rf["arithmetic_intensity"] < rf["ridge_point"]
+        dominant = rf["dominant_unit"]
+        assert rf["arithmetic_intensity"] < rf["units"][dominant]["ridge_point"]
 
     @pytest.mark.parametrize("path,func_name,entry", get_test_params("softmax_kernel_small"))
     def test_compute_bound_roofline_matches_bottleneck(self, path, func_name, entry):
-        """When bottleneck is compute, roofline AI should be above ridge point."""
+        """When bottleneck is compute, roofline AI should be above the dominant unit's ridge point."""
         # Single core + high HBM BW → compute-dominated
         cfg = HardwareConfig(num_cores=1, hbm_bandwidth_tb_s=100.0)
         report = _run_softmax(path, func_name, entry, cfg)
         assert report.bottleneck == "compute"
         rf = report.roofline()
-        assert rf["arithmetic_intensity"] > rf["ridge_point"]
+        dominant = rf["dominant_unit"]
+        assert rf["arithmetic_intensity"] > rf["units"][dominant]["ridge_point"]
 
 
 # ---------------------------------------------------------------------------
@@ -340,7 +341,7 @@ class TestSoftmaxLatency:
         core0 = report.counters[0]
         compute_by_op = Counter()
         for e in core0.trace:
-            if e.category == "compute":
+            if e.category.startswith("compute_"):
                 compute_by_op[e.op_type] += e.cycles
         top_op = compute_by_op.most_common(1)[0]
         assert top_op[0] == "math.exp"
@@ -685,7 +686,7 @@ class TestLatencyEdgeCases:
 
         # addf on 128 elements with SIMD=1024 → 128/1024 = 0.125 cycles
         addf_cycles = sum(e.cycles for e in core0.trace
-                          if e.op_type == "arith.addf" and e.category == "compute")
+                          if e.op_type == "arith.addf" and e.category.startswith("compute_"))
         assert addf_cycles == pytest.approx(128.0 / 1024)
         assert addf_cycles > 0
         assert not math.isnan(addf_cycles)

--- a/tests/test_latency.py
+++ b/tests/test_latency.py
@@ -261,7 +261,8 @@ class TestRoofline:
         report = _run_vector_reduce(path, func_name, entry, HardwareConfig())
         rf = report.roofline()
         assert "arithmetic_intensity" in rf
-        assert rf["arithmetic_intensity"] < rf["ridge_point"]
+        dominant = rf["dominant_unit"]
+        assert rf["arithmetic_intensity"] < rf["units"][dominant]["ridge_point"]
 
     @pytest.mark.parametrize("path,func_name,entry", get_test_params("add_kernel"))
     def test_roofline_in_report_str(self, path, func_name, entry):

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,293 @@
 version = 1
 revision = 3
 requires-python = ">=3.12"
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version < '3.14'",
+]
+
+[[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
+name = "appnope"
+version = "0.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/5d/752690df9ef5b76e169e68d6a129fa6d08a7100ca7f754c89495db3c6019/appnope-0.1.4.tar.gz", hash = "sha256:1de3860566df9caf38f01f86f65e0e13e379af54f9e4bee1e66b48f2efffd1ee", size = 4170, upload-time = "2024-02-06T09:43:11.258Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/29/5ecc3a15d5a33e31b26c11426c45c501e439cb865d0bff96315d86443b78/appnope-0.1.4-py2.py3-none-any.whl", hash = "sha256:502575ee11cd7a28c0205f379b525beefebab9d161b7c964670864014ed7213c", size = 4321, upload-time = "2024-02-06T09:43:09.663Z" },
+]
+
+[[package]]
+name = "argon2-cffi"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "argon2-cffi-bindings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/89/ce5af8a7d472a67cc819d5d998aa8c82c5d860608c4db9f46f1162d7dab9/argon2_cffi-25.1.0.tar.gz", hash = "sha256:694ae5cc8a42f4c4e2bf2ca0e64e51e23a040c6a517a85074683d3959e1346c1", size = 45706, upload-time = "2025-06-03T06:55:32.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/d3/a8b22fa575b297cd6e3e3b0155c7e25db170edf1c74783d6a31a2490b8d9/argon2_cffi-25.1.0-py3-none-any.whl", hash = "sha256:fdc8b074db390fccb6eb4a3604ae7231f219aa669a2652e0f20e16ba513d5741", size = 14657, upload-time = "2025-06-03T06:55:30.804Z" },
+]
+
+[[package]]
+name = "argon2-cffi-bindings"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/2d/db8af0df73c1cf454f71b2bbe5e356b8c1f8041c979f505b3d3186e520a9/argon2_cffi_bindings-25.1.0.tar.gz", hash = "sha256:b957f3e6ea4d55d820e40ff76f450952807013d361a65d7f28acc0acbf29229d", size = 1783441, upload-time = "2025-07-30T10:02:05.147Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/97/3c0a35f46e52108d4707c44b95cfe2afcafc50800b5450c197454569b776/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:3d3f05610594151994ca9ccb3c771115bdb4daef161976a266f0dd8aa9996b8f", size = 54393, upload-time = "2025-07-30T10:01:40.97Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/f4/98bbd6ee89febd4f212696f13c03ca302b8552e7dbf9c8efa11ea4a388c3/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:8b8efee945193e667a396cbc7b4fb7d357297d6234d30a489905d96caabde56b", size = 29328, upload-time = "2025-07-30T10:01:41.916Z" },
+    { url = "https://files.pythonhosted.org/packages/43/24/90a01c0ef12ac91a6be05969f29944643bc1e5e461155ae6559befa8f00b/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:3c6702abc36bf3ccba3f802b799505def420a1b7039862014a65db3205967f5a", size = 31269, upload-time = "2025-07-30T10:01:42.716Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/d3/942aa10782b2697eee7af5e12eeff5ebb325ccfb86dd8abda54174e377e4/argon2_cffi_bindings-25.1.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a1c70058c6ab1e352304ac7e3b52554daadacd8d453c1752e547c76e9c99ac44", size = 86558, upload-time = "2025-07-30T10:01:43.943Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/82/b484f702fec5536e71836fc2dbc8c5267b3f6e78d2d539b4eaa6f0db8bf8/argon2_cffi_bindings-25.1.0-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e2fd3bfbff3c5d74fef31a722f729bf93500910db650c925c2d6ef879a7e51cb", size = 92364, upload-time = "2025-07-30T10:01:44.887Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/c1/a606ff83b3f1735f3759ad0f2cd9e038a0ad11a3de3b6c673aa41c24bb7b/argon2_cffi_bindings-25.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c4f9665de60b1b0e99bcd6be4f17d90339698ce954cfd8d9cf4f91c995165a92", size = 85637, upload-time = "2025-07-30T10:01:46.225Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b4/678503f12aceb0262f84fa201f6027ed77d71c5019ae03b399b97caa2f19/argon2_cffi_bindings-25.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ba92837e4a9aa6a508c8d2d7883ed5a8f6c308c89a4790e1e447a220deb79a85", size = 91934, upload-time = "2025-07-30T10:01:47.203Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/c7/f36bd08ef9bd9f0a9cff9428406651f5937ce27b6c5b07b92d41f91ae541/argon2_cffi_bindings-25.1.0-cp314-cp314t-win32.whl", hash = "sha256:84a461d4d84ae1295871329b346a97f68eade8c53b6ed9a7ca2d7467f3c8ff6f", size = 28158, upload-time = "2025-07-30T10:01:48.341Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/80/0106a7448abb24a2c467bf7d527fe5413b7fdfa4ad6d6a96a43a62ef3988/argon2_cffi_bindings-25.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b55aec3565b65f56455eebc9b9f34130440404f27fe21c3b375bf1ea4d8fbae6", size = 32597, upload-time = "2025-07-30T10:01:49.112Z" },
+    { url = "https://files.pythonhosted.org/packages/05/b8/d663c9caea07e9180b2cb662772865230715cbd573ba3b5e81793d580316/argon2_cffi_bindings-25.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:87c33a52407e4c41f3b70a9c2d3f6056d88b10dad7695be708c5021673f55623", size = 28231, upload-time = "2025-07-30T10:01:49.92Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/57/96b8b9f93166147826da5f90376e784a10582dd39a393c99bb62cfcf52f0/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:aecba1723ae35330a008418a91ea6cfcedf6d31e5fbaa056a166462ff066d500", size = 54121, upload-time = "2025-07-30T10:01:50.815Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/08/a9bebdb2e0e602dde230bdde8021b29f71f7841bd54801bcfd514acb5dcf/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:2630b6240b495dfab90aebe159ff784d08ea999aa4b0d17efa734055a07d2f44", size = 29177, upload-time = "2025-07-30T10:01:51.681Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/02/d297943bcacf05e4f2a94ab6f462831dc20158614e5d067c35d4e63b9acb/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:7aef0c91e2c0fbca6fc68e7555aa60ef7008a739cbe045541e438373bc54d2b0", size = 31090, upload-time = "2025-07-30T10:01:53.184Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/93/44365f3d75053e53893ec6d733e4a5e3147502663554b4d864587c7828a7/argon2_cffi_bindings-25.1.0-cp39-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1e021e87faa76ae0d413b619fe2b65ab9a037f24c60a1e6cc43457ae20de6dc6", size = 81246, upload-time = "2025-07-30T10:01:54.145Z" },
+    { url = "https://files.pythonhosted.org/packages/09/52/94108adfdd6e2ddf58be64f959a0b9c7d4ef2fa71086c38356d22dc501ea/argon2_cffi_bindings-25.1.0-cp39-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d3e924cfc503018a714f94a49a149fdc0b644eaead5d1f089330399134fa028a", size = 87126, upload-time = "2025-07-30T10:01:55.074Z" },
+    { url = "https://files.pythonhosted.org/packages/72/70/7a2993a12b0ffa2a9271259b79cc616e2389ed1a4d93842fac5a1f923ffd/argon2_cffi_bindings-25.1.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c87b72589133f0346a1cb8d5ecca4b933e3c9b64656c9d175270a000e73b288d", size = 80343, upload-time = "2025-07-30T10:01:56.007Z" },
+    { url = "https://files.pythonhosted.org/packages/78/9a/4e5157d893ffc712b74dbd868c7f62365618266982b64accab26bab01edc/argon2_cffi_bindings-25.1.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1db89609c06afa1a214a69a462ea741cf735b29a57530478c06eb81dd403de99", size = 86777, upload-time = "2025-07-30T10:01:56.943Z" },
+    { url = "https://files.pythonhosted.org/packages/74/cd/15777dfde1c29d96de7f18edf4cc94c385646852e7c7b0320aa91ccca583/argon2_cffi_bindings-25.1.0-cp39-abi3-win32.whl", hash = "sha256:473bcb5f82924b1becbb637b63303ec8d10e84c8d241119419897a26116515d2", size = 27180, upload-time = "2025-07-30T10:01:57.759Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/c6/a759ece8f1829d1f162261226fbfd2c6832b3ff7657384045286d2afa384/argon2_cffi_bindings-25.1.0-cp39-abi3-win_amd64.whl", hash = "sha256:a98cd7d17e9f7ce244c0803cad3c23a7d379c301ba618a5fa76a67d116618b98", size = 31715, upload-time = "2025-07-30T10:01:58.56Z" },
+    { url = "https://files.pythonhosted.org/packages/42/b9/f8d6fa329ab25128b7e98fd83a3cb34d9db5b059a9847eddb840a0af45dd/argon2_cffi_bindings-25.1.0-cp39-abi3-win_arm64.whl", hash = "sha256:b0fdbcf513833809c882823f98dc2f931cf659d9a1429616ac3adebb49f5db94", size = 27149, upload-time = "2025-07-30T10:01:59.329Z" },
+]
+
+[[package]]
+name = "arrow"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+    { name = "tzdata" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/33/032cdc44182491aa708d06a68b62434140d8c50820a087fac7af37703357/arrow-1.4.0.tar.gz", hash = "sha256:ed0cc050e98001b8779e84d461b0098c4ac597e88704a655582b21d116e526d7", size = 152931, upload-time = "2025-10-18T17:46:46.761Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ed/c9/d7977eaacb9df673210491da99e6a247e93df98c715fc43fd136ce1d3d33/arrow-1.4.0-py3-none-any.whl", hash = "sha256:749f0769958ebdc79c173ff0b0670d59051a535fa26e8eba02953dc19eb43205", size = 68797, upload-time = "2025-10-18T17:46:45.663Z" },
+]
+
+[[package]]
+name = "asttokens"
+version = "3.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/a5/8e3f9b6771b0b408517c82d97aed8f2036509bc247d46114925e32fe33f0/asttokens-3.0.1.tar.gz", hash = "sha256:71a4ee5de0bde6a31d64f6b13f2293ac190344478f081c3d1bccfcf5eacb0cb7", size = 62308, upload-time = "2025-11-15T16:43:48.578Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/39/e7eaf1799466a4aef85b6a4fe7bd175ad2b1c6345066aa33f1f58d4b18d0/asttokens-3.0.1-py3-none-any.whl", hash = "sha256:15a3ebc0f43c2d0a50eeafea25e19046c68398e487b9f1f5b517f7c0f40f976a", size = 27047, upload-time = "2025-11-15T16:43:16.109Z" },
+]
+
+[[package]]
+name = "async-lru"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/1f/989ecfef8e64109a489fff357450cb73fa73a865a92bd8c272170a6922c2/async_lru-2.3.0.tar.gz", hash = "sha256:89bdb258a0140d7313cf8f4031d816a042202faa61d0ab310a0a538baa1c24b6", size = 16332, upload-time = "2026-03-19T01:04:32.413Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/e2/c2e3abf398f80732e58b03be77bde9022550d221dd8781bf586bd4d97cc1/async_lru-2.3.0-py3-none-any.whl", hash = "sha256:eea27b01841909316f2cc739807acea1c623df2be8c5cfad7583286397bb8315", size = 8403, upload-time = "2026-03-19T01:04:30.883Z" },
+]
+
+[[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
+name = "babel"
+version = "2.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/b2/51899539b6ceeeb420d40ed3cd4b7a40519404f9baf3d4ac99dc413a834b/babel-2.18.0.tar.gz", hash = "sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d", size = 9959554, upload-time = "2026-02-01T12:30:56.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl", hash = "sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35", size = 10196845, upload-time = "2026-02-01T12:30:53.445Z" },
+]
+
+[[package]]
+name = "beautifulsoup4"
+version = "4.14.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b0/1c6a16426d389813b48d95e26898aff79abbde42ad353958ad95cc8c9b21/beautifulsoup4-4.14.3.tar.gz", hash = "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86", size = 627737, upload-time = "2025-11-30T15:08:26.084Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl", hash = "sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb", size = 107721, upload-time = "2025-11-30T15:08:24.087Z" },
+]
+
+[[package]]
+name = "bleach"
+version = "6.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "webencodings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/07/18/3c8523962314be6bf4c8989c79ad9531c825210dd13a8669f6b84336e8bd/bleach-6.3.0.tar.gz", hash = "sha256:6f3b91b1c0a02bb9a78b5a454c92506aa0fdf197e1d5e114d2e00c6f64306d22", size = 203533, upload-time = "2025-10-27T17:57:39.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/3a/577b549de0cc09d95f11087ee63c739bba856cd3952697eec4c4bb91350a/bleach-6.3.0-py3-none-any.whl", hash = "sha256:fe10ec77c93ddf3d13a73b035abaac7a9f5e436513864ccdad516693213c65d6", size = 164437, upload-time = "2025-10-27T17:57:37.538Z" },
+]
+
+[package.optional-dependencies]
+css = [
+    { name = "tinycss2" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.4.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/ee/6caf7a40c36a1220410afe15a1cc64993a1f864871f698c0f93acb72842a/certifi-2026.4.22.tar.gz", hash = "sha256:8d455352a37b71bf76a79caa83a3d6c25afee4a385d632127b6afb3963f1c580", size = 137077, upload-time = "2026-04-22T11:26:11.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl", hash = "sha256:3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a", size = 135707, upload-time = "2026-04-22T11:26:09.372Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d", size = 185271, upload-time = "2025-09-08T23:22:44.795Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c", size = 181048, upload-time = "2025-09-08T23:22:45.938Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529, upload-time = "2025-09-08T23:22:47.349Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097, upload-time = "2025-09-08T23:22:48.677Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983, upload-time = "2025-09-08T23:22:50.06Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519, upload-time = "2025-09-08T23:22:51.364Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572, upload-time = "2025-09-08T23:22:52.902Z" },
+    { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963, upload-time = "2025-09-08T23:22:54.518Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361, upload-time = "2025-09-08T23:22:55.867Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/2b/2b6435f76bfeb6bbf055596976da087377ede68df465419d192acf00c437/cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18", size = 172932, upload-time = "2025-09-08T23:22:57.188Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5", size = 183557, upload-time = "2025-09-08T23:22:58.351Z" },
+    { url = "https://files.pythonhosted.org/packages/95/31/9f7f93ad2f8eff1dbc1c3656d7ca5bfd8fb52c9d786b4dcf19b2d02217fa/cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6", size = 177762, upload-time = "2025-09-08T23:22:59.668Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46", size = 311328, upload-time = "2026-04-02T09:26:24.331Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e3/0fadc706008ac9d7b9b5be6dc767c05f9d3e5df51744ce4cc9605de7b9f4/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6178f72c5508bfc5fd446a5905e698c6212932f25bcdd4b47a757a50605a90e2", size = 208061, upload-time = "2026-04-02T09:26:25.568Z" },
+    { url = "https://files.pythonhosted.org/packages/42/f0/3dd1045c47f4a4604df85ec18ad093912ae1344ac706993aff91d38773a2/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1421b502d83040e6d7fb2fb18dff63957f720da3d77b2fbd3187ceb63755d7b", size = 229031, upload-time = "2026-04-02T09:26:26.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/67/675a46eb016118a2fbde5a277a5d15f4f69d5f3f5f338e5ee2f8948fcf43/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:edac0f1ab77644605be2cbba52e6b7f630731fc42b34cb0f634be1a6eface56a", size = 225239, upload-time = "2026-04-02T09:26:28.044Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f8/d0118a2f5f23b02cd166fa385c60f9b0d4f9194f574e2b31cef350ad7223/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116", size = 216589, upload-time = "2026-04-02T09:26:29.239Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f1/6d2b0b261b6c4ceef0fcb0d17a01cc5bc53586c2d4796fa04b5c540bc13d/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:203104ed3e428044fd943bc4bf45fa73c0730391f9621e37fe39ecf477b128cb", size = 202733, upload-time = "2026-04-02T09:26:30.5Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/c0/7b1f943f7e87cc3db9626ba17807d042c38645f0a1d4415c7a14afb5591f/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:298930cec56029e05497a76988377cbd7457ba864beeea92ad7e844fe74cd1f1", size = 212652, upload-time = "2026-04-02T09:26:31.709Z" },
+    { url = "https://files.pythonhosted.org/packages/38/dd/5a9ab159fe45c6e72079398f277b7d2b523e7f716acc489726115a910097/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:708838739abf24b2ceb208d0e22403dd018faeef86ddac04319a62ae884c4f15", size = 211229, upload-time = "2026-04-02T09:26:33.282Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ff/531a1cad5ca855d1c1a8b69cb71abfd6d85c0291580146fda7c82857caa1/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:0f7eb884681e3938906ed0434f20c63046eacd0111c4ba96f27b76084cd679f5", size = 203552, upload-time = "2026-04-02T09:26:34.845Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/4c/a5fb52d528a8ca41f7598cb619409ece30a169fbdf9cdce592e53b46c3a6/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4dc1e73c36828f982bfe79fadf5919923f8a6f4df2860804db9a98c48824ce8d", size = 230806, upload-time = "2026-04-02T09:26:36.152Z" },
+    { url = "https://files.pythonhosted.org/packages/59/7a/071feed8124111a32b316b33ae4de83d36923039ef8cf48120266844285b/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:aed52fea0513bac0ccde438c188c8a471c4e0f457c2dd20cdbf6ea7a450046c7", size = 212316, upload-time = "2026-04-02T09:26:37.672Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/35/f7dba3994312d7ba508e041eaac39a36b120f32d4c8662b8814dab876431/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464", size = 227274, upload-time = "2026-04-02T09:26:38.93Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/2d/a572df5c9204ab7688ec1edc895a73ebded3b023bb07364710b05dd1c9be/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bb6d88045545b26da47aa879dd4a89a71d1dce0f0e549b1abcb31dfe4a8eac49", size = 218468, upload-time = "2026-04-02T09:26:40.17Z" },
+    { url = "https://files.pythonhosted.org/packages/86/eb/890922a8b03a568ca2f336c36585a4713c55d4d67bf0f0c78924be6315ca/charset_normalizer-3.4.7-cp312-cp312-win32.whl", hash = "sha256:2257141f39fe65a3fdf38aeccae4b953e5f3b3324f4ff0daf9f15b8518666a2c", size = 148460, upload-time = "2026-04-02T09:26:41.416Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d9/0e7dffa06c5ab081f75b1b786f0aefc88365825dfcd0ac544bdb7b2b6853/charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl", hash = "sha256:5ed6ab538499c8644b8a3e18debabcd7ce684f3fa91cf867521a7a0279cab2d6", size = 159330, upload-time = "2026-04-02T09:26:42.554Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/5d/481bcc2a7c88ea6b0878c299547843b2521ccbc40980cb406267088bc701/charset_normalizer-3.4.7-cp312-cp312-win_arm64.whl", hash = "sha256:56be790f86bfb2c98fb742ce566dfb4816e5a83384616ab59c49e0604d49c51d", size = 147828, upload-time = "2026-04-02T09:26:44.075Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063", size = 309627, upload-time = "2026-04-02T09:26:45.198Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c", size = 207008, upload-time = "2026-04-02T09:26:46.824Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/bb/ec73c0257c9e11b268f018f068f5d00aa0ef8c8b09f7753ebd5f2880e248/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66", size = 228303, upload-time = "2026-04-02T09:26:48.397Z" },
+    { url = "https://files.pythonhosted.org/packages/85/fb/32d1f5033484494619f701e719429c69b766bfc4dbc61aa9e9c8c166528b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18", size = 224282, upload-time = "2026-04-02T09:26:49.684Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd", size = 215595, upload-time = "2026-04-02T09:26:50.915Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7c/fc890655786e423f02556e0216d4b8c6bcb6bdfa890160dc66bf52dee468/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215", size = 201986, upload-time = "2026-04-02T09:26:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/97/bfb18b3db2aed3b90cf54dc292ad79fdd5ad65c4eae454099475cbeadd0d/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859", size = 211711, upload-time = "2026-04-02T09:26:53.49Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/a5/a581c13798546a7fd557c82614a5c65a13df2157e9ad6373166d2a3e645d/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8", size = 210036, upload-time = "2026-04-02T09:26:54.975Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/bf/b3ab5bcb478e4193d517644b0fb2bf5497fbceeaa7a1bc0f4d5b50953861/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5", size = 202998, upload-time = "2026-04-02T09:26:56.303Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/4e/23efd79b65d314fa320ec6017b4b5834d5c12a58ba4610aa353af2e2f577/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832", size = 230056, upload-time = "2026-04-02T09:26:57.554Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9f/1e1941bc3f0e01df116e68dc37a55c4d249df5e6fa77f008841aef68264f/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6", size = 211537, upload-time = "2026-04-02T09:26:58.843Z" },
+    { url = "https://files.pythonhosted.org/packages/80/0f/088cbb3020d44428964a6c97fe1edfb1b9550396bf6d278330281e8b709c/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48", size = 226176, upload-time = "2026-04-02T09:27:00.437Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/9f/130394f9bbe06f4f63e22641d32fc9b202b7e251c9aef4db044324dac493/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a", size = 217723, upload-time = "2026-04-02T09:27:02.021Z" },
+    { url = "https://files.pythonhosted.org/packages/73/55/c469897448a06e49f8fa03f6caae97074fde823f432a98f979cc42b90e69/charset_normalizer-3.4.7-cp313-cp313-win32.whl", hash = "sha256:4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e", size = 148085, upload-time = "2026-04-02T09:27:03.192Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110", size = 158819, upload-time = "2026-04-02T09:27:04.454Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/46bd42279d323deb8687c4a5a811fd548cb7d1de10cf6535d099877a9a9f/charset_normalizer-3.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b", size = 147915, upload-time = "2026-04-02T09:27:05.971Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0", size = 309234, upload-time = "2026-04-02T09:27:07.194Z" },
+    { url = "https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a", size = 208042, upload-time = "2026-04-02T09:27:08.749Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1c/ab2ce611b984d2fd5d86a5a8a19c1ae26acac6bad967da4967562c75114d/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b", size = 228706, upload-time = "2026-04-02T09:27:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/29/2b1d2cb00bf085f59d29eb773ce58ec2d325430f8c216804a0a5cd83cbca/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41", size = 224727, upload-time = "2026-04-02T09:27:11.175Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e", size = 215882, upload-time = "2026-04-02T09:27:12.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c2/356065d5a8b78ed04499cae5f339f091946a6a74f91e03476c33f0ab7100/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae", size = 200860, upload-time = "2026-04-02T09:27:13.721Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/cd/a32a84217ced5039f53b29f460962abb2d4420def55afabe45b1c3c7483d/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18", size = 211564, upload-time = "2026-04-02T09:27:15.272Z" },
+    { url = "https://files.pythonhosted.org/packages/44/86/58e6f13ce26cc3b8f4a36b94a0f22ae2f00a72534520f4ae6857c4b81f89/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b", size = 211276, upload-time = "2026-04-02T09:27:16.834Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/fe/d17c32dc72e17e155e06883efa84514ca375f8a528ba2546bee73fc4df81/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356", size = 201238, upload-time = "2026-04-02T09:27:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/29/f33daa50b06525a237451cdb6c69da366c381a3dadcd833fa5676bc468b3/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab", size = 230189, upload-time = "2026-04-02T09:27:19.445Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6e/52c84015394a6a0bdcd435210a7e944c5f94ea1055f5cc5d56c5fe368e7b/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46", size = 211352, upload-time = "2026-04-02T09:27:20.79Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d7/4353be581b373033fb9198bf1da3cf8f09c1082561e8e922aa7b39bf9fe8/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44", size = 227024, upload-time = "2026-04-02T09:27:22.063Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/99d18aa925bd1740098ccd3060e238e21115fffbfdcb8f3ece837d0ace6c/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72", size = 217869, upload-time = "2026-04-02T09:27:23.486Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/5ee478aa53f4bb7996482153d4bfe1b89e0f087f0ab6b294fcf92d595873/charset_normalizer-3.4.7-cp314-cp314-win32.whl", hash = "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10", size = 148541, upload-time = "2026-04-02T09:27:25.146Z" },
+    { url = "https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f", size = 159634, upload-time = "2026-04-02T09:27:26.642Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/a3/c2369911cd72f02386e4e340770f6e158c7980267da16af8f668217abaa0/charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246", size = 148384, upload-time = "2026-04-02T09:27:28.271Z" },
+    { url = "https://files.pythonhosted.org/packages/94/09/7e8a7f73d24dba1f0035fbbf014d2c36828fc1bf9c88f84093e57d315935/charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24", size = 330133, upload-time = "2026-04-02T09:27:29.474Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/96975ddb11f8e977f706f45cddd8540fd8242f71ecdb5d18a80723dcf62c/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79", size = 216257, upload-time = "2026-04-02T09:27:30.793Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/e8/1d63bf8ef2d388e95c64b2098f45f84758f6d102a087552da1485912637b/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960", size = 234851, upload-time = "2026-04-02T09:27:32.44Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/40/e5ff04233e70da2681fa43969ad6f66ca5611d7e669be0246c4c7aaf6dc8/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4", size = 233393, upload-time = "2026-04-02T09:27:34.03Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/06c6c49d5a5450f76899992f1ee40b41d076aee9279b49cf9974d2f313d5/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e", size = 223251, upload-time = "2026-04-02T09:27:35.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9f/f2ff16fb050946169e3e1f82134d107e5d4ae72647ec8a1b1446c148480f/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1", size = 206609, upload-time = "2026-04-02T09:27:36.661Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d5/a527c0cd8d64d2eab7459784fb4169a0ac76e5a6fc5237337982fd61347e/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44", size = 220014, upload-time = "2026-04-02T09:27:38.019Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/80/8a7b8104a3e203074dc9aa2c613d4b726c0e136bad1cc734594b02867972/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e", size = 218979, upload-time = "2026-04-02T09:27:39.37Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9a/b759b503d507f375b2b5c153e4d2ee0a75aa215b7f2489cf314f4541f2c0/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3", size = 209238, upload-time = "2026-04-02T09:27:40.722Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/4e/0f3f5d47b86bdb79256e7290b26ac847a2832d9a4033f7eb2cd4bcf4bb5b/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0", size = 236110, upload-time = "2026-04-02T09:27:42.33Z" },
+    { url = "https://files.pythonhosted.org/packages/96/23/bce28734eb3ed2c91dcf93abeb8a5cf393a7b2749725030bb630e554fdd8/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e", size = 219824, upload-time = "2026-04-02T09:27:43.924Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6f/6e897c6984cc4d41af319b077f2f600fc8214eb2fe2d6bcb79141b882400/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb", size = 233103, upload-time = "2026-04-02T09:27:45.348Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/ef7bd0fe480a0ae9b656189ec00744b60933f68b4f42a7bb06589f6f576a/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe", size = 225194, upload-time = "2026-04-02T09:27:46.706Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a7/0e0ab3e0b5bc1219bd80a6a0d4d72ca74d9250cb2382b7c699c147e06017/charset_normalizer-3.4.7-cp314-cp314t-win32.whl", hash = "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0", size = 159827, upload-time = "2026-04-02T09:27:48.053Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1d/29d32e0fb40864b1f878c7f5a0b343ae676c6e2b271a2d55cc3a152391da/charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c", size = 174168, upload-time = "2026-04-02T09:27:49.795Z" },
+    { url = "https://files.pythonhosted.org/packages/de/32/d92444ad05c7a6e41fb2036749777c163baf7a0301a040cb672d6b2b1ae9/charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d", size = 153018, upload-time = "2026-04-02T09:27:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
+]
 
 [[package]]
 name = "colorama"
@@ -9,6 +296,81 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "comm"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/13/7d740c5849255756bc17888787313b61fd38a0a8304fc4f073dfc46122aa/comm-0.2.3.tar.gz", hash = "sha256:2dc8048c10962d55d7ad693be1e7045d891b7ce8d999c97963a5e3e99c055971", size = 6319, upload-time = "2025-07-25T14:02:04.452Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl", hash = "sha256:c615d91d75f7f04f095b30d1c1711babd43bdc6419c1be9886a85f2f4e489417", size = 7294, upload-time = "2025-07-25T14:02:02.896Z" },
+]
+
+[[package]]
+name = "contourpy"
+version = "1.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/45/adfee365d9ea3d853550b2e735f9d66366701c65db7855cd07621732ccfc/contourpy-1.3.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b08a32ea2f8e42cf1d4be3169a98dd4be32bafe4f22b6c4cb4ba810fa9e5d2cb", size = 293419, upload-time = "2025-07-26T12:01:21.16Z" },
+    { url = "https://files.pythonhosted.org/packages/53/3e/405b59cfa13021a56bba395a6b3aca8cec012b45bf177b0eaf7a202cde2c/contourpy-1.3.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:556dba8fb6f5d8742f2923fe9457dbdd51e1049c4a43fd3986a0b14a1d815fc6", size = 273979, upload-time = "2025-07-26T12:01:22.448Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/1c/a12359b9b2ca3a845e8f7f9ac08bdf776114eb931392fcad91743e2ea17b/contourpy-1.3.3-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:92d9abc807cf7d0e047b95ca5d957cf4792fcd04e920ca70d48add15c1a90ea7", size = 332653, upload-time = "2025-07-26T12:01:24.155Z" },
+    { url = "https://files.pythonhosted.org/packages/63/12/897aeebfb475b7748ea67b61e045accdfcf0d971f8a588b67108ed7f5512/contourpy-1.3.3-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b2e8faa0ed68cb29af51edd8e24798bb661eac3bd9f65420c1887b6ca89987c8", size = 379536, upload-time = "2025-07-26T12:01:25.91Z" },
+    { url = "https://files.pythonhosted.org/packages/43/8a/a8c584b82deb248930ce069e71576fc09bd7174bbd35183b7943fb1064fd/contourpy-1.3.3-cp312-cp312-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:626d60935cf668e70a5ce6ff184fd713e9683fb458898e4249b63be9e28286ea", size = 384397, upload-time = "2025-07-26T12:01:27.152Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/8f/ec6289987824b29529d0dfda0d74a07cec60e54b9c92f3c9da4c0ac732de/contourpy-1.3.3-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4d00e655fcef08aba35ec9610536bfe90267d7ab5ba944f7032549c55a146da1", size = 362601, upload-time = "2025-07-26T12:01:28.808Z" },
+    { url = "https://files.pythonhosted.org/packages/05/0a/a3fe3be3ee2dceb3e615ebb4df97ae6f3828aa915d3e10549ce016302bd1/contourpy-1.3.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:451e71b5a7d597379ef572de31eeb909a87246974d960049a9848c3bc6c41bf7", size = 1331288, upload-time = "2025-07-26T12:01:31.198Z" },
+    { url = "https://files.pythonhosted.org/packages/33/1d/acad9bd4e97f13f3e2b18a3977fe1b4a37ecf3d38d815333980c6c72e963/contourpy-1.3.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:459c1f020cd59fcfe6650180678a9993932d80d44ccde1fa1868977438f0b411", size = 1403386, upload-time = "2025-07-26T12:01:33.947Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/8f/5847f44a7fddf859704217a99a23a4f6417b10e5ab1256a179264561540e/contourpy-1.3.3-cp312-cp312-win32.whl", hash = "sha256:023b44101dfe49d7d53932be418477dba359649246075c996866106da069af69", size = 185018, upload-time = "2025-07-26T12:01:35.64Z" },
+    { url = "https://files.pythonhosted.org/packages/19/e8/6026ed58a64563186a9ee3f29f41261fd1828f527dd93d33b60feca63352/contourpy-1.3.3-cp312-cp312-win_amd64.whl", hash = "sha256:8153b8bfc11e1e4d75bcb0bff1db232f9e10b274e0929de9d608027e0d34ff8b", size = 226567, upload-time = "2025-07-26T12:01:36.804Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/e2/f05240d2c39a1ed228d8328a78b6f44cd695f7ef47beb3e684cf93604f86/contourpy-1.3.3-cp312-cp312-win_arm64.whl", hash = "sha256:07ce5ed73ecdc4a03ffe3e1b3e3c1166db35ae7584be76f65dbbe28a7791b0cc", size = 193655, upload-time = "2025-07-26T12:01:37.999Z" },
+    { url = "https://files.pythonhosted.org/packages/68/35/0167aad910bbdb9599272bd96d01a9ec6852f36b9455cf2ca67bd4cc2d23/contourpy-1.3.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:177fb367556747a686509d6fef71d221a4b198a3905fe824430e5ea0fda54eb5", size = 293257, upload-time = "2025-07-26T12:01:39.367Z" },
+    { url = "https://files.pythonhosted.org/packages/96/e4/7adcd9c8362745b2210728f209bfbcf7d91ba868a2c5f40d8b58f54c509b/contourpy-1.3.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d002b6f00d73d69333dac9d0b8d5e84d9724ff9ef044fd63c5986e62b7c9e1b1", size = 274034, upload-time = "2025-07-26T12:01:40.645Z" },
+    { url = "https://files.pythonhosted.org/packages/73/23/90e31ceeed1de63058a02cb04b12f2de4b40e3bef5e082a7c18d9c8ae281/contourpy-1.3.3-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:348ac1f5d4f1d66d3322420f01d42e43122f43616e0f194fc1c9f5d830c5b286", size = 334672, upload-time = "2025-07-26T12:01:41.942Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/93/b43d8acbe67392e659e1d984700e79eb67e2acb2bd7f62012b583a7f1b55/contourpy-1.3.3-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:655456777ff65c2c548b7c454af9c6f33f16c8884f11083244b5819cc214f1b5", size = 381234, upload-time = "2025-07-26T12:01:43.499Z" },
+    { url = "https://files.pythonhosted.org/packages/46/3b/bec82a3ea06f66711520f75a40c8fc0b113b2a75edb36aa633eb11c4f50f/contourpy-1.3.3-cp313-cp313-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:644a6853d15b2512d67881586bd03f462c7ab755db95f16f14d7e238f2852c67", size = 385169, upload-time = "2025-07-26T12:01:45.219Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/32/e0f13a1c5b0f8572d0ec6ae2f6c677b7991fafd95da523159c19eff0696a/contourpy-1.3.3-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4debd64f124ca62069f313a9cb86656ff087786016d76927ae2cf37846b006c9", size = 362859, upload-time = "2025-07-26T12:01:46.519Z" },
+    { url = "https://files.pythonhosted.org/packages/33/71/e2a7945b7de4e58af42d708a219f3b2f4cff7386e6b6ab0a0fa0033c49a9/contourpy-1.3.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a15459b0f4615b00bbd1e91f1b9e19b7e63aea7483d03d804186f278c0af2659", size = 1332062, upload-time = "2025-07-26T12:01:48.964Z" },
+    { url = "https://files.pythonhosted.org/packages/12/fc/4e87ac754220ccc0e807284f88e943d6d43b43843614f0a8afa469801db0/contourpy-1.3.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ca0fdcd73925568ca027e0b17ab07aad764be4706d0a925b89227e447d9737b7", size = 1403932, upload-time = "2025-07-26T12:01:51.979Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/2e/adc197a37443f934594112222ac1aa7dc9a98faf9c3842884df9a9d8751d/contourpy-1.3.3-cp313-cp313-win32.whl", hash = "sha256:b20c7c9a3bf701366556e1b1984ed2d0cedf999903c51311417cf5f591d8c78d", size = 185024, upload-time = "2025-07-26T12:01:53.245Z" },
+    { url = "https://files.pythonhosted.org/packages/18/0b/0098c214843213759692cc638fce7de5c289200a830e5035d1791d7a2338/contourpy-1.3.3-cp313-cp313-win_amd64.whl", hash = "sha256:1cadd8b8969f060ba45ed7c1b714fe69185812ab43bd6b86a9123fe8f99c3263", size = 226578, upload-time = "2025-07-26T12:01:54.422Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/9a/2f6024a0c5995243cd63afdeb3651c984f0d2bc727fd98066d40e141ad73/contourpy-1.3.3-cp313-cp313-win_arm64.whl", hash = "sha256:fd914713266421b7536de2bfa8181aa8c699432b6763a0ea64195ebe28bff6a9", size = 193524, upload-time = "2025-07-26T12:01:55.73Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/b3/f8a1a86bd3298513f500e5b1f5fd92b69896449f6cab6a146a5d52715479/contourpy-1.3.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:88df9880d507169449d434c293467418b9f6cbe82edd19284aa0409e7fdb933d", size = 306730, upload-time = "2025-07-26T12:01:57.051Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/11/4780db94ae62fc0c2053909b65dc3246bd7cecfc4f8a20d957ad43aa4ad8/contourpy-1.3.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:d06bb1f751ba5d417047db62bca3c8fde202b8c11fb50742ab3ab962c81e8216", size = 287897, upload-time = "2025-07-26T12:01:58.663Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/15/e59f5f3ffdd6f3d4daa3e47114c53daabcb18574a26c21f03dc9e4e42ff0/contourpy-1.3.3-cp313-cp313t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e4e6b05a45525357e382909a4c1600444e2a45b4795163d3b22669285591c1ae", size = 326751, upload-time = "2025-07-26T12:02:00.343Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/81/03b45cfad088e4770b1dcf72ea78d3802d04200009fb364d18a493857210/contourpy-1.3.3-cp313-cp313t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ab3074b48c4e2cf1a960e6bbeb7f04566bf36b1861d5c9d4d8ac04b82e38ba20", size = 375486, upload-time = "2025-07-26T12:02:02.128Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/ba/49923366492ffbdd4486e970d421b289a670ae8cf539c1ea9a09822b371a/contourpy-1.3.3-cp313-cp313t-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6c3d53c796f8647d6deb1abe867daeb66dcc8a97e8455efa729516b997b8ed99", size = 388106, upload-time = "2025-07-26T12:02:03.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/52/5b00ea89525f8f143651f9f03a0df371d3cbd2fccd21ca9b768c7a6500c2/contourpy-1.3.3-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:50ed930df7289ff2a8d7afeb9603f8289e5704755c7e5c3bbd929c90c817164b", size = 352548, upload-time = "2025-07-26T12:02:05.165Z" },
+    { url = "https://files.pythonhosted.org/packages/32/1d/a209ec1a3a3452d490f6b14dd92e72280c99ae3d1e73da74f8277d4ee08f/contourpy-1.3.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:4feffb6537d64b84877da813a5c30f1422ea5739566abf0bd18065ac040e120a", size = 1322297, upload-time = "2025-07-26T12:02:07.379Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/9e/46f0e8ebdd884ca0e8877e46a3f4e633f6c9c8c4f3f6e72be3fe075994aa/contourpy-1.3.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:2b7e9480ffe2b0cd2e787e4df64270e3a0440d9db8dc823312e2c940c167df7e", size = 1391023, upload-time = "2025-07-26T12:02:10.171Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/70/f308384a3ae9cd2209e0849f33c913f658d3326900d0ff5d378d6a1422d2/contourpy-1.3.3-cp313-cp313t-win32.whl", hash = "sha256:283edd842a01e3dcd435b1c5116798d661378d83d36d337b8dde1d16a5fc9ba3", size = 196157, upload-time = "2025-07-26T12:02:11.488Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/dd/880f890a6663b84d9e34a6f88cded89d78f0091e0045a284427cb6b18521/contourpy-1.3.3-cp313-cp313t-win_amd64.whl", hash = "sha256:87acf5963fc2b34825e5b6b048f40e3635dd547f590b04d2ab317c2619ef7ae8", size = 240570, upload-time = "2025-07-26T12:02:12.754Z" },
+    { url = "https://files.pythonhosted.org/packages/80/99/2adc7d8ffead633234817ef8e9a87115c8a11927a94478f6bb3d3f4d4f7d/contourpy-1.3.3-cp313-cp313t-win_arm64.whl", hash = "sha256:3c30273eb2a55024ff31ba7d052dde990d7d8e5450f4bbb6e913558b3d6c2301", size = 199713, upload-time = "2025-07-26T12:02:14.4Z" },
+    { url = "https://files.pythonhosted.org/packages/72/8b/4546f3ab60f78c514ffb7d01a0bd743f90de36f0019d1be84d0a708a580a/contourpy-1.3.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fde6c716d51c04b1c25d0b90364d0be954624a0ee9d60e23e850e8d48353d07a", size = 292189, upload-time = "2025-07-26T12:02:16.095Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/e1/3542a9cb596cadd76fcef413f19c79216e002623158befe6daa03dbfa88c/contourpy-1.3.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:cbedb772ed74ff5be440fa8eee9bd49f64f6e3fc09436d9c7d8f1c287b121d77", size = 273251, upload-time = "2025-07-26T12:02:17.524Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/71/f93e1e9471d189f79d0ce2497007731c1e6bf9ef6d1d61b911430c3db4e5/contourpy-1.3.3-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:22e9b1bd7a9b1d652cd77388465dc358dafcd2e217d35552424aa4f996f524f5", size = 335810, upload-time = "2025-07-26T12:02:18.9Z" },
+    { url = "https://files.pythonhosted.org/packages/91/f9/e35f4c1c93f9275d4e38681a80506b5510e9327350c51f8d4a5a724d178c/contourpy-1.3.3-cp314-cp314-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a22738912262aa3e254e4f3cb079a95a67132fc5a063890e224393596902f5a4", size = 382871, upload-time = "2025-07-26T12:02:20.418Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/71/47b512f936f66a0a900d81c396a7e60d73419868fba959c61efed7a8ab46/contourpy-1.3.3-cp314-cp314-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:afe5a512f31ee6bd7d0dda52ec9864c984ca3d66664444f2d72e0dc4eb832e36", size = 386264, upload-time = "2025-07-26T12:02:21.916Z" },
+    { url = "https://files.pythonhosted.org/packages/04/5f/9ff93450ba96b09c7c2b3f81c94de31c89f92292f1380261bd7195bea4ea/contourpy-1.3.3-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f64836de09927cba6f79dcd00fdd7d5329f3fccc633468507079c829ca4db4e3", size = 363819, upload-time = "2025-07-26T12:02:23.759Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/a6/0b185d4cc480ee494945cde102cb0149ae830b5fa17bf855b95f2e70ad13/contourpy-1.3.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:1fd43c3be4c8e5fd6e4f2baeae35ae18176cf2e5cced681cca908addf1cdd53b", size = 1333650, upload-time = "2025-07-26T12:02:26.181Z" },
+    { url = "https://files.pythonhosted.org/packages/43/d7/afdc95580ca56f30fbcd3060250f66cedbde69b4547028863abd8aa3b47e/contourpy-1.3.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:6afc576f7b33cf00996e5c1102dc2a8f7cc89e39c0b55df93a0b78c1bd992b36", size = 1404833, upload-time = "2025-07-26T12:02:28.782Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/e2/366af18a6d386f41132a48f033cbd2102e9b0cf6345d35ff0826cd984566/contourpy-1.3.3-cp314-cp314-win32.whl", hash = "sha256:66c8a43a4f7b8df8b71ee1840e4211a3c8d93b214b213f590e18a1beca458f7d", size = 189692, upload-time = "2025-07-26T12:02:30.128Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/c2/57f54b03d0f22d4044b8afb9ca0e184f8b1afd57b4f735c2fa70883dc601/contourpy-1.3.3-cp314-cp314-win_amd64.whl", hash = "sha256:cf9022ef053f2694e31d630feaacb21ea24224be1c3ad0520b13d844274614fd", size = 232424, upload-time = "2025-07-26T12:02:31.395Z" },
+    { url = "https://files.pythonhosted.org/packages/18/79/a9416650df9b525737ab521aa181ccc42d56016d2123ddcb7b58e926a42c/contourpy-1.3.3-cp314-cp314-win_arm64.whl", hash = "sha256:95b181891b4c71de4bb404c6621e7e2390745f887f2a026b2d99e92c17892339", size = 198300, upload-time = "2025-07-26T12:02:32.956Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/42/38c159a7d0f2b7b9c04c64ab317042bb6952b713ba875c1681529a2932fe/contourpy-1.3.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:33c82d0138c0a062380332c861387650c82e4cf1747aaa6938b9b6516762e772", size = 306769, upload-time = "2025-07-26T12:02:34.2Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/6c/26a8205f24bca10974e77460de68d3d7c63e282e23782f1239f226fcae6f/contourpy-1.3.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ea37e7b45949df430fe649e5de8351c423430046a2af20b1c1961cae3afcda77", size = 287892, upload-time = "2025-07-26T12:02:35.807Z" },
+    { url = "https://files.pythonhosted.org/packages/66/06/8a475c8ab718ebfd7925661747dbb3c3ee9c82ac834ccb3570be49d129f4/contourpy-1.3.3-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d304906ecc71672e9c89e87c4675dc5c2645e1f4269a5063b99b0bb29f232d13", size = 326748, upload-time = "2025-07-26T12:02:37.193Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/a3/c5ca9f010a44c223f098fccd8b158bb1cb287378a31ac141f04730dc49be/contourpy-1.3.3-cp314-cp314t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ca658cd1a680a5c9ea96dc61cdbae1e85c8f25849843aa799dfd3cb370ad4fbe", size = 375554, upload-time = "2025-07-26T12:02:38.894Z" },
+    { url = "https://files.pythonhosted.org/packages/80/5b/68bd33ae63fac658a4145088c1e894405e07584a316738710b636c6d0333/contourpy-1.3.3-cp314-cp314t-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ab2fd90904c503739a75b7c8c5c01160130ba67944a7b77bbf36ef8054576e7f", size = 388118, upload-time = "2025-07-26T12:02:40.642Z" },
+    { url = "https://files.pythonhosted.org/packages/40/52/4c285a6435940ae25d7410a6c36bda5145839bc3f0beb20c707cda18b9d2/contourpy-1.3.3-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b7301b89040075c30e5768810bc96a8e8d78085b47d8be6e4c3f5a0b4ed478a0", size = 352555, upload-time = "2025-07-26T12:02:42.25Z" },
+    { url = "https://files.pythonhosted.org/packages/24/ee/3e81e1dd174f5c7fefe50e85d0892de05ca4e26ef1c9a59c2a57e43b865a/contourpy-1.3.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:2a2a8b627d5cc6b7c41a4beff6c5ad5eb848c88255fda4a8745f7e901b32d8e4", size = 1322295, upload-time = "2025-07-26T12:02:44.668Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/b2/6d913d4d04e14379de429057cd169e5e00f6c2af3bb13e1710bcbdb5da12/contourpy-1.3.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:fd6ec6be509c787f1caf6b247f0b1ca598bef13f4ddeaa126b7658215529ba0f", size = 1391027, upload-time = "2025-07-26T12:02:47.09Z" },
+    { url = "https://files.pythonhosted.org/packages/93/8a/68a4ec5c55a2971213d29a9374913f7e9f18581945a7a31d1a39b5d2dfe5/contourpy-1.3.3-cp314-cp314t-win32.whl", hash = "sha256:e74a9a0f5e3fff48fb5a7f2fd2b9b70a3fe014a67522f79b7cca4c0c7e43c9ae", size = 202428, upload-time = "2025-07-26T12:02:48.691Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/96/fd9f641ffedc4fa3ace923af73b9d07e869496c9cc7a459103e6e978992f/contourpy-1.3.3-cp314-cp314t-win_amd64.whl", hash = "sha256:13b68d6a62db8eafaebb8039218921399baf6e47bf85006fd8529f2a08ef33fc", size = 250331, upload-time = "2025-07-26T12:02:50.137Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/8c/469afb6465b853afff216f9528ffda78a915ff880ed58813ba4faf4ba0b6/contourpy-1.3.3-cp314-cp314t-win_arm64.whl", hash = "sha256:b7448cb5a725bb1e35ce88771b86fba35ef418952474492cf7c764059933ff8b", size = 203831, upload-time = "2025-07-26T12:02:51.449Z" },
 ]
 
 [[package]]
@@ -96,12 +458,626 @@ wheels = [
 ]
 
 [[package]]
+name = "cycler"
+version = "0.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/95/a3dbbb5028f35eafb79008e7522a75244477d2838f38cbb722248dabc2a8/cycler-0.12.1.tar.gz", hash = "sha256:88bb128f02ba341da8ef447245a9e138fae777f6a23943da4540077d3601eb1c", size = 7615, upload-time = "2023-10-07T05:32:18.335Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl", hash = "sha256:85cef7cff222d8644161529808465972e51340599459b8ac3ccbac5a854e0d30", size = 8321, upload-time = "2023-10-07T05:32:16.783Z" },
+]
+
+[[package]]
+name = "debugpy"
+version = "1.8.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/b7/cd8080344452e4874aae67c40d8940e2b4d47b01601a8fd9f44786c757c7/debugpy-1.8.20.tar.gz", hash = "sha256:55bc8701714969f1ab89a6d5f2f3d40c36f91b2cbe2f65d98bf8196f6a6a2c33", size = 1645207, upload-time = "2026-01-29T23:03:28.199Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/57/7f34f4736bfb6e00f2e4c96351b07805d83c9a7b33d28580ae01374430f7/debugpy-1.8.20-cp312-cp312-macosx_15_0_universal2.whl", hash = "sha256:4ae3135e2089905a916909ef31922b2d733d756f66d87345b3e5e52b7a55f13d", size = 2550686, upload-time = "2026-01-29T23:03:42.023Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/78/b193a3975ca34458f6f0e24aaf5c3e3da72f5401f6054c0dfd004b41726f/debugpy-1.8.20-cp312-cp312-manylinux_2_34_x86_64.whl", hash = "sha256:88f47850a4284b88bd2bfee1f26132147d5d504e4e86c22485dfa44b97e19b4b", size = 4310588, upload-time = "2026-01-29T23:03:43.314Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/55/f14deb95eaf4f30f07ef4b90a8590fc05d9e04df85ee379712f6fb6736d7/debugpy-1.8.20-cp312-cp312-win32.whl", hash = "sha256:4057ac68f892064e5f98209ab582abfee3b543fb55d2e87610ddc133a954d390", size = 5331372, upload-time = "2026-01-29T23:03:45.526Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/39/2bef246368bd42f9bd7cba99844542b74b84dacbdbea0833e610f384fee8/debugpy-1.8.20-cp312-cp312-win_amd64.whl", hash = "sha256:a1a8f851e7cf171330679ef6997e9c579ef6dd33c9098458bd9986a0f4ca52e3", size = 5372835, upload-time = "2026-01-29T23:03:47.245Z" },
+    { url = "https://files.pythonhosted.org/packages/15/e2/fc500524cc6f104a9d049abc85a0a8b3f0d14c0a39b9c140511c61e5b40b/debugpy-1.8.20-cp313-cp313-macosx_15_0_universal2.whl", hash = "sha256:5dff4bb27027821fdfcc9e8f87309a28988231165147c31730128b1c983e282a", size = 2539560, upload-time = "2026-01-29T23:03:48.738Z" },
+    { url = "https://files.pythonhosted.org/packages/90/83/fb33dcea789ed6018f8da20c5a9bc9d82adc65c0c990faed43f7c955da46/debugpy-1.8.20-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "sha256:84562982dd7cf5ebebfdea667ca20a064e096099997b175fe204e86817f64eaf", size = 4293272, upload-time = "2026-01-29T23:03:50.169Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/25/b1e4a01bfb824d79a6af24b99ef291e24189080c93576dfd9b1a2815cd0f/debugpy-1.8.20-cp313-cp313-win32.whl", hash = "sha256:da11dea6447b2cadbf8ce2bec59ecea87cc18d2c574980f643f2d2dfe4862393", size = 5331208, upload-time = "2026-01-29T23:03:51.547Z" },
+    { url = "https://files.pythonhosted.org/packages/13/f7/a0b368ce54ffff9e9028c098bd2d28cfc5b54f9f6c186929083d4c60ba58/debugpy-1.8.20-cp313-cp313-win_amd64.whl", hash = "sha256:eb506e45943cab2efb7c6eafdd65b842f3ae779f020c82221f55aca9de135ed7", size = 5372930, upload-time = "2026-01-29T23:03:53.585Z" },
+    { url = "https://files.pythonhosted.org/packages/33/2e/f6cb9a8a13f5058f0a20fe09711a7b726232cd5a78c6a7c05b2ec726cff9/debugpy-1.8.20-cp314-cp314-macosx_15_0_universal2.whl", hash = "sha256:9c74df62fc064cd5e5eaca1353a3ef5a5d50da5eb8058fcef63106f7bebe6173", size = 2538066, upload-time = "2026-01-29T23:03:54.999Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/56/6ddca50b53624e1ca3ce1d1e49ff22db46c47ea5fb4c0cc5c9b90a616364/debugpy-1.8.20-cp314-cp314-manylinux_2_34_x86_64.whl", hash = "sha256:077a7447589ee9bc1ff0cdf443566d0ecf540ac8aa7333b775ebcb8ce9f4ecad", size = 4269425, upload-time = "2026-01-29T23:03:56.518Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/d9/d64199c14a0d4c476df46c82470a3ce45c8d183a6796cfb5e66533b3663c/debugpy-1.8.20-cp314-cp314-win32.whl", hash = "sha256:352036a99dd35053b37b7803f748efc456076f929c6a895556932eaf2d23b07f", size = 5331407, upload-time = "2026-01-29T23:03:58.481Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/d9/1f07395b54413432624d61524dfd98c1a7c7827d2abfdb8829ac92638205/debugpy-1.8.20-cp314-cp314-win_amd64.whl", hash = "sha256:a98eec61135465b062846112e5ecf2eebb855305acc1dfbae43b72903b8ab5be", size = 5372521, upload-time = "2026-01-29T23:03:59.864Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/c3/7f67dea8ccf8fdcb9c99033bbe3e90b9e7395415843accb81428c441be2d/debugpy-1.8.20-py2.py3-none-any.whl", hash = "sha256:5be9bed9ae3be00665a06acaa48f8329d2b9632f15fd09f6a9a8c8d9907e54d7", size = 5337658, upload-time = "2026-01-29T23:04:17.404Z" },
+]
+
+[[package]]
+name = "decorator"
+version = "5.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/fa/6d96a0978d19e17b68d634497769987b16c8f4cd0a7a05048bec693caa6b/decorator-5.2.1.tar.gz", hash = "sha256:65f266143752f734b0a7cc83c46f4618af75b8c5911b00ccb61d0ac9b6da0360", size = 56711, upload-time = "2025-02-24T04:41:34.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/8c/f3147f5c4b73e7550fe5f9352eaa956ae838d5c51eb58e7a25b9f3e2643b/decorator-5.2.1-py3-none-any.whl", hash = "sha256:d316bb415a2d9e2d2b3abcc4084c6502fc09240e292cd76a76afc106a1c8e04a", size = 9190, upload-time = "2025-02-24T04:41:32.565Z" },
+]
+
+[[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
+]
+
+[[package]]
+name = "executing"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/28/c14e053b6762b1044f34a13aab6859bbf40456d37d23aa286ac24cfd9a5d/executing-2.2.1.tar.gz", hash = "sha256:3632cc370565f6648cc328b32435bd120a1e4ebb20c77e3fdde9a13cd1e533c4", size = 1129488, upload-time = "2025-09-01T09:48:10.866Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl", hash = "sha256:760643d3452b4d777d295bb167ccc74c64a81df23fb5e08eff250c425a4b2017", size = 28317, upload-time = "2025-09-01T09:48:08.5Z" },
+]
+
+[[package]]
+name = "fastjsonschema"
+version = "2.21.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/b5/23b216d9d985a956623b6bd12d4086b60f0059b27799f23016af04a74ea1/fastjsonschema-2.21.2.tar.gz", hash = "sha256:b1eb43748041c880796cd077f1a07c3d94e93ae84bba5ed36800a33554ae05de", size = 374130, upload-time = "2025-08-14T18:49:36.666Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/a8/20d0723294217e47de6d9e2e40fd4a9d2f7c4b6ef974babd482a59743694/fastjsonschema-2.21.2-py3-none-any.whl", hash = "sha256:1c797122d0a86c5cace2e54bf4e819c36223b552017172f32c5c024a6b77e463", size = 24024, upload-time = "2025-08-14T18:49:34.776Z" },
+]
+
+[[package]]
+name = "fonttools"
+version = "4.62.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/08/7012b00a9a5874311b639c3920270c36ee0c445b69d9989a85e5c92ebcb0/fonttools-4.62.1.tar.gz", hash = "sha256:e54c75fd6041f1122476776880f7c3c3295ffa31962dc6ebe2543c00dca58b5d", size = 3580737, upload-time = "2026-03-13T13:54:25.52Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/d4/dbacced3953544b9a93088cc10ef2b596d348c983d5c67a404fa41ec51ba/fonttools-4.62.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:90365821debbd7db678809c7491ca4acd1e0779b9624cdc6ddaf1f31992bf974", size = 2870219, upload-time = "2026-03-13T13:52:53.664Z" },
+    { url = "https://files.pythonhosted.org/packages/66/9e/a769c8e99b81e5a87ab7e5e7236684de4e96246aae17274e5347d11ebd78/fonttools-4.62.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:12859ff0b47dd20f110804c3e0d0970f7b832f561630cd879969011541a464a9", size = 2414891, upload-time = "2026-03-13T13:52:56.493Z" },
+    { url = "https://files.pythonhosted.org/packages/69/64/f19a9e3911968c37e1e620e14dfc5778299e1474f72f4e57c5ec771d9489/fonttools-4.62.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9c125ffa00c3d9003cdaaf7f2c79e6e535628093e14b5de1dccb08859b680936", size = 5033197, upload-time = "2026-03-13T13:52:59.179Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/8a/99c8b3c3888c5c474c08dbfd7c8899786de9604b727fcefb055b42c84bba/fonttools-4.62.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:149f7d84afca659d1a97e39a4778794a2f83bf344c5ee5134e09995086cc2392", size = 4988768, upload-time = "2026-03-13T13:53:02.761Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/c6/0f904540d3e6ab463c1243a0d803504826a11604c72dd58c2949796a1762/fonttools-4.62.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0aa72c43a601cfa9273bb1ae0518f1acadc01ee181a6fc60cd758d7fdadffc04", size = 4971512, upload-time = "2026-03-13T13:53:05.678Z" },
+    { url = "https://files.pythonhosted.org/packages/29/0b/5cbef6588dc9bd6b5c9ad6a4d5a8ca384d0cea089da31711bbeb4f9654a6/fonttools-4.62.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:19177c8d96c7c36359266e571c5173bcee9157b59cfc8cb0153c5673dc5a3a7d", size = 5122723, upload-time = "2026-03-13T13:53:08.662Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/47/b3a5342d381595ef439adec67848bed561ab7fdb1019fa522e82101b7d9c/fonttools-4.62.1-cp312-cp312-win32.whl", hash = "sha256:a24decd24d60744ee8b4679d38e88b8303d86772053afc29b19d23bb8207803c", size = 2281278, upload-time = "2026-03-13T13:53:10.998Z" },
+    { url = "https://files.pythonhosted.org/packages/28/b1/0c2ab56a16f409c6c8a68816e6af707827ad5d629634691ff60a52879792/fonttools-4.62.1-cp312-cp312-win_amd64.whl", hash = "sha256:9e7863e10b3de72376280b515d35b14f5eeed639d1aa7824f4cf06779ec65e42", size = 2331414, upload-time = "2026-03-13T13:53:13.992Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/56/6f389de21c49555553d6a5aeed5ac9767631497ac836c4f076273d15bd72/fonttools-4.62.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:c22b1014017111c401469e3acc5433e6acf6ebcc6aa9efb538a533c800971c79", size = 2865155, upload-time = "2026-03-13T13:53:16.132Z" },
+    { url = "https://files.pythonhosted.org/packages/03/c5/0e3966edd5ec668d41dfe418787726752bc07e2f5fd8c8f208615e61fa89/fonttools-4.62.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:68959f5fc58ed4599b44aad161c2837477d7f35f5f79402d97439974faebfebe", size = 2412802, upload-time = "2026-03-13T13:53:18.878Z" },
+    { url = "https://files.pythonhosted.org/packages/52/94/e6ac4b44026de7786fe46e3bfa0c87e51d5d70a841054065d49cd62bb909/fonttools-4.62.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef46db46c9447103b8f3ff91e8ba009d5fe181b1920a83757a5762551e32bb68", size = 5013926, upload-time = "2026-03-13T13:53:21.379Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/98/8b1e801939839d405f1f122e7d175cebe9aeb4e114f95bfc45e3152af9a7/fonttools-4.62.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6706d1cb1d5e6251a97ad3c1b9347505c5615c112e66047abbef0f8545fa30d1", size = 4964575, upload-time = "2026-03-13T13:53:23.857Z" },
+    { url = "https://files.pythonhosted.org/packages/46/76/7d051671e938b1881670528fec69cc4044315edd71a229c7fd712eaa5119/fonttools-4.62.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2e7abd2b1e11736f58c1de27819e1955a53267c21732e78243fa2fa2e5c1e069", size = 4953693, upload-time = "2026-03-13T13:53:26.569Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/ae/b41f8628ec0be3c1b934fc12b84f4576a5c646119db4d3bdd76a217c90b5/fonttools-4.62.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:403d28ce06ebfc547fbcb0cb8b7f7cc2f7a2d3e1a67ba9a34b14632df9e080f9", size = 5094920, upload-time = "2026-03-13T13:53:29.329Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/f6/53a1e9469331a23dcc400970a27a4caa3d9f6edbf5baab0260285238b884/fonttools-4.62.1-cp313-cp313-win32.whl", hash = "sha256:93c316e0f5301b2adbe6a5f658634307c096fd5aae60a5b3412e4f3e1728ab24", size = 2279928, upload-time = "2026-03-13T13:53:32.352Z" },
+    { url = "https://files.pythonhosted.org/packages/38/60/35186529de1db3c01f5ad625bde07c1f576305eab6d86bbda4c58445f721/fonttools-4.62.1-cp313-cp313-win_amd64.whl", hash = "sha256:7aa21ff53e28a9c2157acbc44e5b401149d3c9178107130e82d74ceb500e5056", size = 2330514, upload-time = "2026-03-13T13:53:34.991Z" },
+    { url = "https://files.pythonhosted.org/packages/36/f0/2888cdac391807d68d90dcb16ef858ddc1b5309bfc6966195a459dd326e2/fonttools-4.62.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:fa1d16210b6b10a826d71bed68dd9ec24a9e218d5a5e2797f37c573e7ec215ca", size = 2864442, upload-time = "2026-03-13T13:53:37.509Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/b2/e521803081f8dc35990816b82da6360fa668a21b44da4b53fc9e77efcd62/fonttools-4.62.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:aa69d10ed420d8121118e628ad47d86e4caa79ba37f968597b958f6cceab7eca", size = 2410901, upload-time = "2026-03-13T13:53:40.55Z" },
+    { url = "https://files.pythonhosted.org/packages/00/a4/8c3511ff06e53110039358dbbdc1a65d72157a054638387aa2ada300a8b8/fonttools-4.62.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bd13b7999d59c5eb1c2b442eb2d0c427cb517a0b7a1f5798fc5c9e003f5ff782", size = 4999608, upload-time = "2026-03-13T13:53:42.798Z" },
+    { url = "https://files.pythonhosted.org/packages/28/63/cd0c3b26afe60995a5295f37c246a93d454023726c3261cfbb3559969bb9/fonttools-4.62.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8d337fdd49a79b0d51c4da87bc38169d21c3abbf0c1aa9367eff5c6656fb6dae", size = 4912726, upload-time = "2026-03-13T13:53:45.405Z" },
+    { url = "https://files.pythonhosted.org/packages/70/b9/ac677cb07c24c685cf34f64e140617d58789d67a3dd524164b63648c6114/fonttools-4.62.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d241cdc4a67b5431c6d7f115fdf63335222414995e3a1df1a41e1182acd4bcc7", size = 4951422, upload-time = "2026-03-13T13:53:48.326Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/10/11c08419a14b85b7ca9a9faca321accccc8842dd9e0b1c8a72908de05945/fonttools-4.62.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c05557a78f8fa514da0f869556eeda40887a8abc77c76ee3f74cf241778afd5a", size = 5060979, upload-time = "2026-03-13T13:53:51.366Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/3c/12eea4a4cf054e7ab058ed5ceada43b46809fce2bf319017c4d63ae55bb4/fonttools-4.62.1-cp314-cp314-win32.whl", hash = "sha256:49a445d2f544ce4a69338694cad575ba97b9a75fff02720da0882d1a73f12800", size = 2283733, upload-time = "2026-03-13T13:53:53.606Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/67/74b070029043186b5dd13462c958cb7c7f811be0d2e634309d9a1ffb1505/fonttools-4.62.1-cp314-cp314-win_amd64.whl", hash = "sha256:1eecc128c86c552fb963fe846ca4e011b1be053728f798185a1687502f6d398e", size = 2335663, upload-time = "2026-03-13T13:53:56.23Z" },
+    { url = "https://files.pythonhosted.org/packages/42/c5/4d2ed3ca6e33617fc5624467da353337f06e7f637707478903c785bd8e20/fonttools-4.62.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:1596aeaddf7f78e21e68293c011316a25267b3effdaccaf4d59bc9159d681b82", size = 2947288, upload-time = "2026-03-13T13:53:59.397Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/e9/7ab11ddfda48ed0f89b13380e5595ba572619c27077be0b2c447a63ff351/fonttools-4.62.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:8f8fca95d3bb3208f59626a4b0ea6e526ee51f5a8ad5d91821c165903e8d9260", size = 2449023, upload-time = "2026-03-13T13:54:01.642Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/10/a800fa090b5e8819942e54e19b55fc7c21fe14a08757c3aa3ca8db358939/fonttools-4.62.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee91628c08e76f77b533d65feb3fbe6d9dad699f95be51cf0d022db94089cdc4", size = 5137599, upload-time = "2026-03-13T13:54:04.495Z" },
+    { url = "https://files.pythonhosted.org/packages/37/dc/8ccd45033fffd74deb6912fa1ca524643f584b94c87a16036855b498a1ed/fonttools-4.62.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5f37df1cac61d906e7b836abe356bc2f34c99d4477467755c216b72aa3dc748b", size = 4920933, upload-time = "2026-03-13T13:54:07.557Z" },
+    { url = "https://files.pythonhosted.org/packages/99/eb/e618adefb839598d25ac8136cd577925d6c513dc0d931d93b8af956210f0/fonttools-4.62.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:92bb00a947e666169c99b43753c4305fc95a890a60ef3aeb2a6963e07902cc87", size = 5016232, upload-time = "2026-03-13T13:54:10.611Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/5f/9b5c9bfaa8ec82def8d8168c4f13615990d6ce5996fe52bd49bfb5e05134/fonttools-4.62.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:bdfe592802ef939a0e33106ea4a318eeb17822c7ee168c290273cbd5fabd746c", size = 5042987, upload-time = "2026-03-13T13:54:13.569Z" },
+    { url = "https://files.pythonhosted.org/packages/90/aa/dfbbe24c6a6afc5c203d90cc0343e24bcbb09e76d67c4d6eef8c2558d7ba/fonttools-4.62.1-cp314-cp314t-win32.whl", hash = "sha256:b820fcb92d4655513d8402d5b219f94481c4443d825b4372c75a2072aa4b357a", size = 2348021, upload-time = "2026-03-13T13:54:16.98Z" },
+    { url = "https://files.pythonhosted.org/packages/13/6f/ae9c4e4dd417948407b680855c2c7790efb52add6009aaecff1e3bc50e8e/fonttools-4.62.1-cp314-cp314t-win_amd64.whl", hash = "sha256:59b372b4f0e113d3746b88985f1c796e7bf830dd54b28374cd85c2b8acd7583e", size = 2414147, upload-time = "2026-03-13T13:54:19.416Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/ba/56147c165442cc5ba7e82ecf301c9a68353cede498185869e6e02b4c264f/fonttools-4.62.1-py3-none-any.whl", hash = "sha256:7487782e2113861f4ddcc07c3436450659e3caa5e470b27dc2177cade2d8e7fd", size = 1152647, upload-time = "2026-03-13T13:54:22.735Z" },
+]
+
+[[package]]
+name = "fqdn"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/3e/a80a8c077fd798951169626cde3e239adeba7dab75deb3555716415bd9b0/fqdn-1.5.1.tar.gz", hash = "sha256:105ed3677e767fb5ca086a0c1f4bb66ebc3c100be518f0e0d755d9eae164d89f", size = 6015, upload-time = "2021-03-11T07:16:29.08Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cf/58/8acf1b3e91c58313ce5cb67df61001fc9dcd21be4fadb76c1a2d540e09ed/fqdn-1.5.1-py3-none-any.whl", hash = "sha256:3a179af3761e4df6eb2e026ff9e1a3033d3587bf980a0b1b2e1e5d08d7358014", size = 9121, upload-time = "2021-03-11T07:16:28.351Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "ipykernel"
+version = "7.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "appnope", marker = "sys_platform == 'darwin'" },
+    { name = "comm" },
+    { name = "debugpy" },
+    { name = "ipython" },
+    { name = "jupyter-client" },
+    { name = "jupyter-core" },
+    { name = "matplotlib-inline" },
+    { name = "nest-asyncio" },
+    { name = "packaging" },
+    { name = "psutil" },
+    { name = "pyzmq" },
+    { name = "tornado" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ca/8d/b68b728e2d06b9e0051019640a40a9eb7a88fcd82c2e1b5ce70bef5ff044/ipykernel-7.2.0.tar.gz", hash = "sha256:18ed160b6dee2cbb16e5f3575858bc19d8f1fe6046a9a680c708494ce31d909e", size = 176046, upload-time = "2026-02-06T16:43:27.403Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/b9/e73d5d9f405cba7706c539aa8b311b49d4c2f3d698d9c12f815231169c71/ipykernel-7.2.0-py3-none-any.whl", hash = "sha256:3bbd4420d2b3cc105cbdf3756bfc04500b1e52f090a90716851f3916c62e1661", size = 118788, upload-time = "2026-02-06T16:43:25.149Z" },
+]
+
+[[package]]
+name = "ipython"
+version = "9.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "psutil" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/87cda5842cf5c31837c06ddb588e11c3c35d8ece89b7a0108c06b8c9b00a/ipython-9.13.0.tar.gz", hash = "sha256:7e834b6afc99f020e3f05966ced34792f40267d64cb1ea9043886dab0dde5967", size = 4430549, upload-time = "2026-04-24T12:24:55.221Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/86/3060e8029b7cc505cce9a0137431dda81d0a3fde93a8f0f50ee0bf37a795/ipython-9.13.0-py3-none-any.whl", hash = "sha256:57f9d4639e20818d328d287c7b549af3d05f12486ea8f2e7f73e52a36ec4d201", size = 627274, upload-time = "2026-04-24T12:24:53.038Z" },
+]
+
+[[package]]
+name = "ipython-pygments-lexers"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/33/1f075bf72b0b747cb3288d011319aaf64083cf2efef8354174e3ed4540e2/ipython_pygments_lexers-1.1.1-py3-none-any.whl", hash = "sha256:a9462224a505ade19a605f71f8fa63c2048833ce50abc86768a0d81d876dc81c", size = 8074, upload-time = "2025-01-17T11:24:33.271Z" },
+]
+
+[[package]]
+name = "ipywidgets"
+version = "8.1.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "comm" },
+    { name = "ipython" },
+    { name = "jupyterlab-widgets" },
+    { name = "traitlets" },
+    { name = "widgetsnbextension" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4c/ae/c5ce1edc1afe042eadb445e95b0671b03cee61895264357956e61c0d2ac0/ipywidgets-8.1.8.tar.gz", hash = "sha256:61f969306b95f85fba6b6986b7fe45d73124d1d9e3023a8068710d47a22ea668", size = 116739, upload-time = "2025-11-01T21:18:12.393Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/6d/0d9848617b9f753b87f214f1c682592f7ca42de085f564352f10f0843026/ipywidgets-8.1.8-py3-none-any.whl", hash = "sha256:ecaca67aed704a338f88f67b1181b58f821ab5dc89c1f0f5ef99db43c1c2921e", size = 139808, upload-time = "2025-11-01T21:18:10.956Z" },
+]
+
+[[package]]
+name = "isoduration"
+version = "20.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "arrow" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7c/1a/3c8edc664e06e6bd06cce40c6b22da5f1429aa4224d0c590f3be21c91ead/isoduration-20.11.0.tar.gz", hash = "sha256:ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9", size = 11649, upload-time = "2020-11-01T11:00:00.312Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/55/e5326141505c5d5e34c5e0935d2908a74e4561eca44108fbfb9c13d2911a/isoduration-20.11.0-py3-none-any.whl", hash = "sha256:b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042", size = 11321, upload-time = "2020-11-01T10:59:58.02Z" },
+]
+
+[[package]]
+name = "jedi"
+version = "0.20.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "parso" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/46/b7/a3635f6a2d7cf5b5dd98064fc1d5fbbafcb25477bcea204a3a92145d158b/jedi-0.20.0.tar.gz", hash = "sha256:c3f4ccbd276696f4b19c54618d4fb18f9fc24b0aef02acf704b23f487daa1011", size = 3119416, upload-time = "2026-05-01T23:38:47.814Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/93/242e2eab5fe682ffcb8b0084bde703a41d51e17ee0f3a31ff0d9d813620a/jedi-0.20.0-py2.py3-none-any.whl", hash = "sha256:7bdd9c2634f56713299976f4cbd59cb3fa92165cc5e05ea811fb253480728b67", size = 4884812, upload-time = "2026-05-01T23:38:43.919Z" },
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "json5"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/4b/6f8906aaf67d501e259b0adab4d312945bb7211e8b8d4dcc77c92320edaa/json5-0.14.0.tar.gz", hash = "sha256:b3f492fad9f6cdbced8b7d40b28b9b1c9701c5f561bef0d33b81c2ff433fefcb", size = 52656, upload-time = "2026-03-27T22:50:48.108Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/42/cf027b4ac873b076189d935b135397675dac80cb29acb13e1ab86ad6c631/json5-0.14.0-py3-none-any.whl", hash = "sha256:56cf861bab076b1178eb8c92e1311d273a9b9acea2ccc82c276abf839ebaef3a", size = 36271, upload-time = "2026-03-27T22:50:47.073Z" },
+]
+
+[[package]]
+name = "jsonpointer"
+version = "3.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/c7/af399a2e7a67fd18d63c40c5e62d3af4e67b836a2107468b6a5ea24c4304/jsonpointer-3.1.1.tar.gz", hash = "sha256:0b801c7db33a904024f6004d526dcc53bbb8a4a0f4e32bfd10beadf60adf1900", size = 9068, upload-time = "2026-03-23T22:32:32.458Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/6a/a83720e953b1682d2d109d3c2dbb0bc9bf28cc1cbc205be4ef4be5da709d/jsonpointer-3.1.1-py3-none-any.whl", hash = "sha256:8ff8b95779d071ba472cf5bc913028df06031797532f08a7d5b602d8b2a488ca", size = 7659, upload-time = "2026-03-23T22:32:31.568Z" },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[package.optional-dependencies]
+format-nongpl = [
+    { name = "fqdn" },
+    { name = "idna" },
+    { name = "isoduration" },
+    { name = "jsonpointer" },
+    { name = "rfc3339-validator" },
+    { name = "rfc3986-validator" },
+    { name = "rfc3987-syntax" },
+    { name = "uri-template" },
+    { name = "webcolors" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
+name = "jupyter"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ipykernel" },
+    { name = "ipywidgets" },
+    { name = "jupyter-console" },
+    { name = "jupyterlab" },
+    { name = "nbconvert" },
+    { name = "notebook" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/58/f3/af28ea964ab8bc1e472dba2e82627d36d470c51f5cd38c37502eeffaa25e/jupyter-1.1.1.tar.gz", hash = "sha256:d55467bceabdea49d7e3624af7e33d59c37fff53ed3a350e1ac957bed731de7a", size = 5714959, upload-time = "2024-08-30T07:15:48.299Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/64/285f20a31679bf547b75602702f7800e74dbabae36ef324f716c02804753/jupyter-1.1.1-py2.py3-none-any.whl", hash = "sha256:7a59533c22af65439b24bbe60373a4e95af8f16ac65a6c00820ad378e3f7cc83", size = 2657, upload-time = "2024-08-30T07:15:47.045Z" },
+]
+
+[[package]]
+name = "jupyter-client"
+version = "8.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jupyter-core" },
+    { name = "python-dateutil" },
+    { name = "pyzmq" },
+    { name = "tornado" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/05/e4/ba649102a3bc3fbca54e7239fb924fd434c766f855693d86de0b1f2bec81/jupyter_client-8.8.0.tar.gz", hash = "sha256:d556811419a4f2d96c869af34e854e3f059b7cc2d6d01a9cd9c85c267691be3e", size = 348020, upload-time = "2026-01-08T13:55:47.938Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2d/0b/ceb7694d864abc0a047649aec263878acb9f792e1fec3e676f22dc9015e3/jupyter_client-8.8.0-py3-none-any.whl", hash = "sha256:f93a5b99c5e23a507b773d3a1136bd6e16c67883ccdbd9a829b0bbdb98cd7d7a", size = 107371, upload-time = "2026-01-08T13:55:45.562Z" },
+]
+
+[[package]]
+name = "jupyter-console"
+version = "6.6.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ipykernel" },
+    { name = "ipython" },
+    { name = "jupyter-client" },
+    { name = "jupyter-core" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "pyzmq" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bd/2d/e2fd31e2fc41c14e2bcb6c976ab732597e907523f6b2420305f9fc7fdbdb/jupyter_console-6.6.3.tar.gz", hash = "sha256:566a4bf31c87adbfadf22cdf846e3069b59a71ed5da71d6ba4d8aaad14a53539", size = 34363, upload-time = "2023-03-06T14:13:31.02Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/77/71d78d58f15c22db16328a476426f7ac4a60d3a5a7ba3b9627ee2f7903d4/jupyter_console-6.6.3-py3-none-any.whl", hash = "sha256:309d33409fcc92ffdad25f0bcdf9a4a9daa61b6f341177570fdac03de5352485", size = 24510, upload-time = "2023-03-06T14:13:28.229Z" },
+]
+
+[[package]]
+name = "jupyter-core"
+version = "5.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "platformdirs" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/49/9d1284d0dc65e2c757b74c6687b6d319b02f822ad039e5c512df9194d9dd/jupyter_core-5.9.1.tar.gz", hash = "sha256:4d09aaff303b9566c3ce657f580bd089ff5c91f5f89cf7d8846c3cdf465b5508", size = 89814, upload-time = "2025-10-16T19:19:18.444Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/e7/80988e32bf6f73919a113473a604f5a8f09094de312b9d52b79c2df7612b/jupyter_core-5.9.1-py3-none-any.whl", hash = "sha256:ebf87fdc6073d142e114c72c9e29a9d7ca03fad818c5d300ce2adc1fb0743407", size = 29032, upload-time = "2025-10-16T19:19:16.783Z" },
+]
+
+[[package]]
+name = "jupyter-events"
+version = "0.12.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jsonschema", extra = ["format-nongpl"] },
+    { name = "packaging" },
+    { name = "python-json-logger" },
+    { name = "pyyaml" },
+    { name = "referencing" },
+    { name = "rfc3339-validator" },
+    { name = "rfc3986-validator" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/f8/475c4241b2b75af0deaae453ed003c6c851766dbc44d332d8baf245dc931/jupyter_events-0.12.1.tar.gz", hash = "sha256:faff25f77218335752f35f23c5fe6e4a392a7bd99a5939ccb9b8fbf594636cf3", size = 62854, upload-time = "2026-04-20T23:17:50.66Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/6c/6fcde0c8f616ed360ffd3587f7db9e225a7e62b583a04494d2f069cf64ea/jupyter_events-0.12.1-py3-none-any.whl", hash = "sha256:c366585253f537a627da52fa7ca7410c5b5301fe893f511e7b077c2d93ec8bcf", size = 19512, upload-time = "2026-04-20T23:17:48.927Z" },
+]
+
+[[package]]
+name = "jupyter-lsp"
+version = "2.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jupyter-server" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/36/ff/1e4a61f5170a9a1d978f3ac3872449de6c01fc71eaf89657824c878b1549/jupyter_lsp-2.3.1.tar.gz", hash = "sha256:fdf8a4aa7d85813976d6e29e95e6a2c8f752701f926f2715305249a3829805a6", size = 55677, upload-time = "2026-04-02T08:10:06.749Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/e8/9d61dcbd1dce8ef418f06befd4ac084b4720429c26b0b1222bc218685eff/jupyter_lsp-2.3.1-py3-none-any.whl", hash = "sha256:71b954d834e85ff3096400554f2eefaf7fe37053036f9a782b0f7c5e42dadb81", size = 77513, upload-time = "2026-04-02T08:10:01.753Z" },
+]
+
+[[package]]
+name = "jupyter-server"
+version = "2.18.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "argon2-cffi" },
+    { name = "jinja2" },
+    { name = "jupyter-client" },
+    { name = "jupyter-core" },
+    { name = "jupyter-events" },
+    { name = "jupyter-server-terminals" },
+    { name = "nbconvert" },
+    { name = "nbformat" },
+    { name = "packaging" },
+    { name = "prometheus-client" },
+    { name = "pywinpty", marker = "os_name == 'nt'" },
+    { name = "pyzmq" },
+    { name = "send2trash" },
+    { name = "terminado" },
+    { name = "tornado" },
+    { name = "traitlets" },
+    { name = "websocket-client" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ca/15/1eacb0fcb79ef86e8a0a79a708e6ad7435f6f223097dd29a4ce861fabc44/jupyter_server-2.18.2.tar.gz", hash = "sha256:06b4f40d8a7a00bb39d5216859c81374a0e7cfefe6d8a5a7facc5a5c37c679a7", size = 753177, upload-time = "2026-05-06T07:04:36.274Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e2/50/ecf4f70d65bdb7519b28a33d1b2fee8a4b4ba1ae1a92f15d97e877c5de21/jupyter_server-2.18.2-py3-none-any.whl", hash = "sha256:fa5e46539ded65791838035a2b6001f13e54d5f64b8b3752eb1e91fdd641a5b8", size = 391907, upload-time = "2026-05-06T07:04:34.014Z" },
+]
+
+[[package]]
+name = "jupyter-server-terminals"
+version = "0.5.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywinpty", marker = "os_name == 'nt'" },
+    { name = "terminado" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f4/a7/bcd0a9b0cbba88986fe944aaaf91bfda603e5a50bda8ed15123f381a3b2f/jupyter_server_terminals-0.5.4.tar.gz", hash = "sha256:bbda128ed41d0be9020349f9f1f2a4ab9952a73ed5f5ac9f1419794761fb87f5", size = 31770, upload-time = "2026-01-14T16:53:20.213Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/2d/6674563f71c6320841fc300911a55143925112a72a883e2ca71fba4c618d/jupyter_server_terminals-0.5.4-py3-none-any.whl", hash = "sha256:55be353fc74a80bc7f3b20e6be50a55a61cd525626f578dcb66a5708e2007d14", size = 13704, upload-time = "2026-01-14T16:53:18.738Z" },
+]
+
+[[package]]
+name = "jupyterlab"
+version = "4.5.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "async-lru" },
+    { name = "httpx" },
+    { name = "ipykernel" },
+    { name = "jinja2" },
+    { name = "jupyter-core" },
+    { name = "jupyter-lsp" },
+    { name = "jupyter-server" },
+    { name = "jupyterlab-server" },
+    { name = "notebook-shim" },
+    { name = "packaging" },
+    { name = "setuptools" },
+    { name = "tornado" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2b/22/8440ec827762146e7cdecf04335bd348795899d29dc6ae82238707353a2c/jupyterlab-4.5.7.tar.gz", hash = "sha256:55a9822c4754da305f41e113452c68383e214dcf96de760146af89ce5d5117b0", size = 23992763, upload-time = "2026-04-29T16:43:51.328Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/aa/537b8f7d80e799af19af35fb3ddfc970b951088a13c57dd9387dcfbb7f61/jupyterlab-4.5.7-py3-none-any.whl", hash = "sha256:fba4cb0e2c44a52859669d8c98b45de029d5e515f8407bf8534d2a8fc5f0964d", size = 12450123, upload-time = "2026-04-29T16:43:46.639Z" },
+]
+
+[[package]]
+name = "jupyterlab-pygments"
+version = "0.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/90/51/9187be60d989df97f5f0aba133fa54e7300f17616e065d1ada7d7646b6d6/jupyterlab_pygments-0.3.0.tar.gz", hash = "sha256:721aca4d9029252b11cfa9d185e5b5af4d54772bb8072f9b7036f4170054d35d", size = 512900, upload-time = "2023-11-23T09:26:37.44Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b1/dd/ead9d8ea85bf202d90cc513b533f9c363121c7792674f78e0d8a854b63b4/jupyterlab_pygments-0.3.0-py3-none-any.whl", hash = "sha256:841a89020971da1d8693f1a99997aefc5dc424bb1b251fd6322462a1b8842780", size = 15884, upload-time = "2023-11-23T09:26:34.325Z" },
+]
+
+[[package]]
+name = "jupyterlab-server"
+version = "2.28.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "babel" },
+    { name = "jinja2" },
+    { name = "json5" },
+    { name = "jsonschema" },
+    { name = "jupyter-server" },
+    { name = "packaging" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d6/2c/90153f189e421e93c4bb4f9e3f59802a1f01abd2ac5cf40b152d7f735232/jupyterlab_server-2.28.0.tar.gz", hash = "sha256:35baa81898b15f93573e2deca50d11ac0ae407ebb688299d3a5213265033712c", size = 76996, upload-time = "2025-10-22T13:59:18.37Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/07/a000fe835f76b7e1143242ab1122e6362ef1c03f23f83a045c38859c2ae0/jupyterlab_server-2.28.0-py3-none-any.whl", hash = "sha256:e4355b148fdcf34d312bbbc80f22467d6d20460e8b8736bf235577dd18506968", size = 59830, upload-time = "2025-10-22T13:59:16.767Z" },
+]
+
+[[package]]
+name = "jupyterlab-widgets"
+version = "3.0.16"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/2d/ef58fed122b268c69c0aa099da20bc67657cdfb2e222688d5731bd5b971d/jupyterlab_widgets-3.0.16.tar.gz", hash = "sha256:423da05071d55cf27a9e602216d35a3a65a3e41cdf9c5d3b643b814ce38c19e0", size = 897423, upload-time = "2025-11-01T21:11:29.724Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/b5/36c712098e6191d1b4e349304ef73a8d06aed77e56ceaac8c0a306c7bda1/jupyterlab_widgets-3.0.16-py3-none-any.whl", hash = "sha256:45fa36d9c6422cf2559198e4db481aa243c7a32d9926b500781c830c80f7ecf8", size = 914926, upload-time = "2025-11-01T21:11:28.008Z" },
+]
+
+[[package]]
+name = "kiwisolver"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/67/9c61eccb13f0bdca9307614e782fec49ffdde0f7a2314935d489fa93cd9c/kiwisolver-1.5.0.tar.gz", hash = "sha256:d4193f3d9dc3f6f79aaed0e5637f45d98850ebf01f7ca20e69457f3e8946b66a", size = 103482, upload-time = "2026-03-09T13:15:53.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/b2/818b74ebea34dabe6d0c51cb1c572e046730e64844da6ed646d5298c40ce/kiwisolver-1.5.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:4e9750bc21b886308024f8a54ccb9a2cc38ac9fa813bf4348434e3d54f337ff9", size = 123158, upload-time = "2026-03-09T13:13:23.127Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/d9/405320f8077e8e1c5c4bd6adc45e1e6edf6d727b6da7f2e2533cf58bff71/kiwisolver-1.5.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:72ec46b7eba5b395e0a7b63025490d3214c11013f4aacb4f5e8d6c3041829588", size = 66388, upload-time = "2026-03-09T13:13:24.765Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9f/795fedf35634f746151ca8839d05681ceb6287fbed6cc1c9bf235f7887c2/kiwisolver-1.5.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ed3a984b31da7481b103f68776f7128a89ef26ed40f4dc41a2223cda7fb24819", size = 64068, upload-time = "2026-03-09T13:13:25.878Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/13/680c54afe3e65767bed7ec1a15571e1a2f1257128733851ade24abcefbcc/kiwisolver-1.5.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bb5136fb5352d3f422df33f0c879a1b0c204004324150cc3b5e3c4f310c9049f", size = 1477934, upload-time = "2026-03-09T13:13:27.166Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/2f/cebfcdb60fd6a9b0f6b47a9337198bcbad6fbe15e68189b7011fd914911f/kiwisolver-1.5.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b2af221f268f5af85e776a73d62b0845fc8baf8ef0abfae79d29c77d0e776aaf", size = 1278537, upload-time = "2026-03-09T13:13:28.707Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/0d/9b782923aada3fafb1d6b84e13121954515c669b18af0c26e7d21f579855/kiwisolver-1.5.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b0f172dc8ffaccb8522d7c5d899de00133f2f1ca7b0a49b7da98e901de87bf2d", size = 1296685, upload-time = "2026-03-09T13:13:30.528Z" },
+    { url = "https://files.pythonhosted.org/packages/27/70/83241b6634b04fe44e892688d5208332bde130f38e610c0418f9ede47ded/kiwisolver-1.5.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6ab8ba9152203feec73758dad83af9a0bbe05001eb4639e547207c40cfb52083", size = 1346024, upload-time = "2026-03-09T13:13:32.818Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/db/30ed226fb271ae1a6431fc0fe0edffb2efe23cadb01e798caeb9f2ceae8f/kiwisolver-1.5.0-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:cdee07c4d7f6d72008d3f73b9bf027f4e11550224c7c50d8df1ae4a37c1402a6", size = 987241, upload-time = "2026-03-09T13:13:34.435Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/bd/c314595208e4c9587652d50959ead9e461995389664e490f4dce7ff0f782/kiwisolver-1.5.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7c60d3c9b06fb23bd9c6139281ccbdc384297579ae037f08ae90c69f6845c0b1", size = 2227742, upload-time = "2026-03-09T13:13:36.4Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/43/0499cec932d935229b5543d073c2b87c9c22846aab48881e9d8d6e742a2d/kiwisolver-1.5.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:e315e5ec90d88e140f57696ff85b484ff68bb311e36f2c414aa4286293e6dee0", size = 2323966, upload-time = "2026-03-09T13:13:38.204Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/6f/79b0d760907965acfd9d61826a3d41f8f093c538f55cd2633d3f0db269f6/kiwisolver-1.5.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:1465387ac63576c3e125e5337a6892b9e99e0627d52317f3ca79e6930d889d15", size = 1977417, upload-time = "2026-03-09T13:13:39.966Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/31/01d0537c41cb75a551a438c3c7a80d0c60d60b81f694dac83dd436aec0d0/kiwisolver-1.5.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:530a3fd64c87cffa844d4b6b9768774763d9caa299e9b75d8eca6a4423b31314", size = 2491238, upload-time = "2026-03-09T13:13:41.698Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/34/8aefdd0be9cfd00a44509251ba864f5caf2991e36772e61c408007e7f417/kiwisolver-1.5.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:1d9daea4ea6b9be74fe2f01f7fbade8d6ffab263e781274cffca0dba9be9eec9", size = 2294947, upload-time = "2026-03-09T13:13:43.343Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/cf/0348374369ca588f8fe9c338fae49fa4e16eeb10ffb3d012f23a54578a9e/kiwisolver-1.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:f18c2d9782259a6dc132fdc7a63c168cbc74b35284b6d75c673958982a378384", size = 73569, upload-time = "2026-03-09T13:13:45.792Z" },
+    { url = "https://files.pythonhosted.org/packages/28/26/192b26196e2316e2bd29deef67e37cdf9870d9af8e085e521afff0fed526/kiwisolver-1.5.0-cp312-cp312-win_arm64.whl", hash = "sha256:f7c7553b13f69c1b29a5bde08ddc6d9d0c8bfb84f9ed01c30db25944aeb852a7", size = 64997, upload-time = "2026-03-09T13:13:46.878Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/69/024d6711d5ba575aa65d5538042e99964104e97fa153a9f10bc369182bc2/kiwisolver-1.5.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:fd40bb9cd0891c4c3cb1ddf83f8bbfa15731a248fdc8162669405451e2724b09", size = 123166, upload-time = "2026-03-09T13:13:48.032Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/adbb40df306f587054a348831220812b9b1d787aff714cfbc8556e38fccd/kiwisolver-1.5.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c0e1403fd7c26d77c1f03e096dc58a5c726503fa0db0456678b8668f76f521e3", size = 66395, upload-time = "2026-03-09T13:13:49.365Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/3a/d0a972b34e1c63e2409413104216cd1caa02c5a37cb668d1687d466c1c45/kiwisolver-1.5.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:dda366d548e89a90d88a86c692377d18d8bd64b39c1fb2b92cb31370e2896bbd", size = 64065, upload-time = "2026-03-09T13:13:50.562Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0a/7b98e1e119878a27ba8618ca1e18b14f992ff1eda40f47bccccf4de44121/kiwisolver-1.5.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:332b4f0145c30b5f5ad9374881133e5aa64320428a57c2c2b61e9d891a51c2f3", size = 1477903, upload-time = "2026-03-09T13:13:52.084Z" },
+    { url = "https://files.pythonhosted.org/packages/18/d8/55638d89ffd27799d5cc3d8aa28e12f4ce7a64d67b285114dbedc8ea4136/kiwisolver-1.5.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0c50b89ffd3e1a911c69a1dd3de7173c0cd10b130f56222e57898683841e4f96", size = 1278751, upload-time = "2026-03-09T13:13:54.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/97/b4c8d0d18421ecceba20ad8701358453b88e32414e6f6950b5a4bad54e65/kiwisolver-1.5.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4db576bb8c3ef9365f8b40fe0f671644de6736ae2c27a2c62d7d8a1b4329f099", size = 1296793, upload-time = "2026-03-09T13:13:56.287Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/10/f862f94b6389d8957448ec9df59450b81bec4abb318805375c401a1e6892/kiwisolver-1.5.0-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:0b85aad90cea8ac6797a53b5d5f2e967334fa4d1149f031c4537569972596cb8", size = 1346041, upload-time = "2026-03-09T13:13:58.269Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/6a/f1650af35821eaf09de398ec0bc2aefc8f211f0cda50204c9f1673741ba9/kiwisolver-1.5.0-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:d36ca54cb4c6c4686f7cbb7b817f66f5911c12ddb519450bbe86707155028f87", size = 987292, upload-time = "2026-03-09T13:13:59.871Z" },
+    { url = "https://files.pythonhosted.org/packages/de/19/d7fb82984b9238115fe629c915007be608ebd23dc8629703d917dbfaffd4/kiwisolver-1.5.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:38f4a703656f493b0ad185211ccfca7f0386120f022066b018eb5296d8613e23", size = 2227865, upload-time = "2026-03-09T13:14:01.401Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/b9/46b7f386589fd222dac9e9de9c956ce5bcefe2ee73b4e79891381dda8654/kiwisolver-1.5.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:3ac2360e93cb41be81121755c6462cff3beaa9967188c866e5fce5cf13170859", size = 2324369, upload-time = "2026-03-09T13:14:02.972Z" },
+    { url = "https://files.pythonhosted.org/packages/92/8b/95e237cf3d9c642960153c769ddcbe278f182c8affb20cecc1cc983e7cc5/kiwisolver-1.5.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:c95cab08d1965db3d84a121f1c7ce7479bdd4072c9b3dafd8fecce48a2e6b902", size = 1977989, upload-time = "2026-03-09T13:14:04.503Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/95/980c9df53501892784997820136c01f62bc1865e31b82b9560f980c0e649/kiwisolver-1.5.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:fc20894c3d21194d8041a28b65622d5b86db786da6e3cfe73f0c762951a61167", size = 2491645, upload-time = "2026-03-09T13:14:06.106Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/32/900647fd0840abebe1561792c6b31e6a7c0e278fc3973d30572a965ca14c/kiwisolver-1.5.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7a32f72973f0f950c1920475d5c5ea3d971b81b6f0ec53b8d0a956cc965f22e0", size = 2295237, upload-time = "2026-03-09T13:14:08.891Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8a/be60e3bbcf513cc5a50f4a3e88e1dcecebb79c1ad607a7222877becaa101/kiwisolver-1.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:0bf3acf1419fa93064a4c2189ac0b58e3be7872bf6ee6177b0d4c63dc4cea276", size = 73573, upload-time = "2026-03-09T13:14:12.327Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/d2/64be2e429eb4fca7f7e1c52a91b12663aeaf25de3895e5cca0f47ef2a8d0/kiwisolver-1.5.0-cp313-cp313-win_arm64.whl", hash = "sha256:fa8eb9ecdb7efb0b226acec134e0d709e87a909fa4971a54c0c4f6e88635484c", size = 64998, upload-time = "2026-03-09T13:14:13.469Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/69/ce68dd0c85755ae2de490bf015b62f2cea5f6b14ff00a463f9d0774449ff/kiwisolver-1.5.0-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:db485b3847d182b908b483b2ed133c66d88d49cacf98fd278fadafe11b4478d1", size = 125700, upload-time = "2026-03-09T13:14:14.636Z" },
+    { url = "https://files.pythonhosted.org/packages/74/aa/937aac021cf9d4349990d47eb319309a51355ed1dbdc9c077cdc9224cb11/kiwisolver-1.5.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:be12f931839a3bdfe28b584db0e640a65a8bcbc24560ae3fdb025a449b3d754e", size = 67537, upload-time = "2026-03-09T13:14:15.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/20/3a87fbece2c40ad0f6f0aefa93542559159c5f99831d596050e8afae7a9f/kiwisolver-1.5.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:16b85d37c2cbb3253226d26e64663f755d88a03439a9c47df6246b35defbdfb7", size = 65514, upload-time = "2026-03-09T13:14:18.035Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7f/f943879cda9007c45e1f7dba216d705c3a18d6b35830e488b6c6a4e7cdf0/kiwisolver-1.5.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4432b835675f0ea7414aab3d37d119f7226d24869b7a829caeab49ebda407b0c", size = 1584848, upload-time = "2026-03-09T13:14:19.745Z" },
+    { url = "https://files.pythonhosted.org/packages/37/f8/4d4f85cc1870c127c88d950913370dd76138482161cd07eabbc450deff01/kiwisolver-1.5.0-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b0feb50971481a2cc44d94e88bdb02cdd497618252ae226b8eb1201b957e368", size = 1391542, upload-time = "2026-03-09T13:14:21.54Z" },
+    { url = "https://files.pythonhosted.org/packages/04/0b/65dd2916c84d252b244bd405303220f729e7c17c9d7d33dca6feeff9ffc4/kiwisolver-1.5.0-cp313-cp313t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:56fa888f10d0f367155e76ce849fa1166fc9730d13bd2d65a2aa13b6f5424489", size = 1404447, upload-time = "2026-03-09T13:14:23.205Z" },
+    { url = "https://files.pythonhosted.org/packages/39/5c/2606a373247babce9b1d056c03a04b65f3cf5290a8eac5d7bdead0a17e21/kiwisolver-1.5.0-cp313-cp313t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:940dda65d5e764406b9fb92761cbf462e4e63f712ab60ed98f70552e496f3bf1", size = 1455918, upload-time = "2026-03-09T13:14:24.74Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/d1/c6078b5756670658e9192a2ef11e939c92918833d2745f85cd14a6004bdf/kiwisolver-1.5.0-cp313-cp313t-manylinux_2_39_riscv64.whl", hash = "sha256:89fc958c702ee9a745e4700378f5d23fddbc46ff89e8fdbf5395c24d5c1452a3", size = 1072856, upload-time = "2026-03-09T13:14:26.597Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/c8/7def6ddf16eb2b3741d8b172bdaa9af882b03c78e9b0772975408801fa63/kiwisolver-1.5.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9027d773c4ff81487181a925945743413f6069634d0b122d0b37684ccf4f1e18", size = 2333580, upload-time = "2026-03-09T13:14:28.237Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/87/2ac1fce0eb1e616fcd3c35caa23e665e9b1948bb984f4764790924594128/kiwisolver-1.5.0-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:5b233ea3e165e43e35dba1d2b8ecc21cf070b45b65ae17dd2747d2713d942021", size = 2423018, upload-time = "2026-03-09T13:14:30.018Z" },
+    { url = "https://files.pythonhosted.org/packages/67/13/c6700ccc6cc218716bfcda4935e4b2997039869b4ad8a94f364c5a3b8e63/kiwisolver-1.5.0-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:ce9bf03dad3b46408c08649c6fbd6ca28a9fce0eb32fdfffa6775a13103b5310", size = 2062804, upload-time = "2026-03-09T13:14:32.888Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/bd/877056304626943ff0f1f44c08f584300c199b887cb3176cd7e34f1515f1/kiwisolver-1.5.0-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:fc4d3f1fb9ca0ae9f97b095963bc6326f1dbfd3779d6679a1e016b9baaa153d3", size = 2597482, upload-time = "2026-03-09T13:14:34.971Z" },
+    { url = "https://files.pythonhosted.org/packages/75/19/c60626c47bf0f8ac5dcf72c6c98e266d714f2fbbfd50cf6dab5ede3aaa50/kiwisolver-1.5.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:f443b4825c50a51ee68585522ab4a1d1257fac65896f282b4c6763337ac9f5d2", size = 2394328, upload-time = "2026-03-09T13:14:36.816Z" },
+    { url = "https://files.pythonhosted.org/packages/47/84/6a6d5e5bb8273756c27b7d810d47f7ef2f1f9b9fd23c9ee9a3f8c75c9cef/kiwisolver-1.5.0-cp313-cp313t-win_arm64.whl", hash = "sha256:893ff3a711d1b515ba9da14ee090519bad4610ed1962fbe298a434e8c5f8db53", size = 68410, upload-time = "2026-03-09T13:14:38.695Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/060f45052f2a01ad5762c8fdecd6d7a752b43400dc29ff75cd47225a40fd/kiwisolver-1.5.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8df31fe574b8b3993cc61764f40941111b25c2d9fea13d3ce24a49907cd2d615", size = 123231, upload-time = "2026-03-09T13:14:41.323Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/a7/78da680eadd06ff35edef6ef68a1ad273bad3e2a0936c9a885103230aece/kiwisolver-1.5.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1d49a49ac4cbfb7c1375301cd1ec90169dfeae55ff84710d782260ce77a75a02", size = 66489, upload-time = "2026-03-09T13:14:42.534Z" },
+    { url = "https://files.pythonhosted.org/packages/49/b2/97980f3ad4fae37dd7fe31626e2bf75fbf8bdf5d303950ec1fab39a12da8/kiwisolver-1.5.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0cbe94b69b819209a62cb27bdfa5dc2a8977d8de2f89dfd97ba4f53ed3af754e", size = 64063, upload-time = "2026-03-09T13:14:44.759Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/f9/b06c934a6aa8bc91f566bd2a214fd04c30506c2d9e2b6b171953216a65b6/kiwisolver-1.5.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:80aa065ffd378ff784822a6d7c3212f2d5f5e9c3589614b5c228b311fd3063ac", size = 1475913, upload-time = "2026-03-09T13:14:46.247Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/f0/f768ae564a710135630672981231320bc403cf9152b5596ec5289de0f106/kiwisolver-1.5.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e7f886f47ab881692f278ae901039a234e4025a68e6dfab514263a0b1c4ae05", size = 1282782, upload-time = "2026-03-09T13:14:48.458Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/9f/1de7aad00697325f05238a5f2eafbd487fb637cc27a558b5367a5f37fb7f/kiwisolver-1.5.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5060731cc3ed12ca3a8b57acd4aeca5bbc2f49216dd0bec1650a1acd89486bcd", size = 1300815, upload-time = "2026-03-09T13:14:50.721Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/c2/297f25141d2e468e0ce7f7a7b92e0cf8918143a0cbd3422c1ad627e85a06/kiwisolver-1.5.0-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7a4aa69609f40fce3cbc3f87b2061f042eee32f94b8f11db707b66a26461591a", size = 1347925, upload-time = "2026-03-09T13:14:52.304Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/d3/f4c73a02eb41520c47610207b21afa8cdd18fdbf64ffd94674ae21c4812d/kiwisolver-1.5.0-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:d168fda2dbff7b9b5f38e693182d792a938c31db4dac3a80a4888de603c99554", size = 991322, upload-time = "2026-03-09T13:14:54.637Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/46/d3f2efef7732fcda98d22bf4ad5d3d71d545167a852ca710a494f4c15343/kiwisolver-1.5.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:413b820229730d358efd838ecbab79902fe97094565fdc80ddb6b0a18c18a581", size = 2232857, upload-time = "2026-03-09T13:14:56.471Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/ec/2d9756bf2b6d26ae4349b8d3662fb3993f16d80c1f971c179ce862b9dbae/kiwisolver-1.5.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:5124d1ea754509b09e53738ec185584cc609aae4a3b510aaf4ed6aa047ef9303", size = 2329376, upload-time = "2026-03-09T13:14:58.072Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/9f/876a0a0f2260f1bde92e002b3019a5fabc35e0939c7d945e0fa66185eb20/kiwisolver-1.5.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e4415a8db000bf49a6dd1c478bf70062eaacff0f462b92b0ba68791a905861f9", size = 1982549, upload-time = "2026-03-09T13:14:59.668Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/4f/ba3624dfac23a64d54ac4179832860cb537c1b0af06024936e82ca4154a0/kiwisolver-1.5.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d618fd27420381a4f6044faa71f46d8bfd911bd077c555f7138ed88729bfbe79", size = 2494680, upload-time = "2026-03-09T13:15:01.364Z" },
+    { url = "https://files.pythonhosted.org/packages/39/b7/97716b190ab98911b20d10bf92eca469121ec483b8ce0edd314f51bc85af/kiwisolver-1.5.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5092eb5b1172947f57d6ea7d89b2f29650414e4293c47707eb499ec07a0ac796", size = 2297905, upload-time = "2026-03-09T13:15:03.925Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/36/4e551e8aa55c9188bca9abb5096805edbf7431072b76e2298e34fd3a3008/kiwisolver-1.5.0-cp314-cp314-win_amd64.whl", hash = "sha256:d76e2d8c75051d58177e762164d2e9ab92886534e3a12e795f103524f221dd8e", size = 75086, upload-time = "2026-03-09T13:15:07.775Z" },
+    { url = "https://files.pythonhosted.org/packages/70/15/9b90f7df0e31a003c71649cf66ef61c3c1b862f48c81007fa2383c8bd8d7/kiwisolver-1.5.0-cp314-cp314-win_arm64.whl", hash = "sha256:fa6248cd194edff41d7ea9425ced8ca3a6f838bfb295f6f1d6e6bb694a8518df", size = 66577, upload-time = "2026-03-09T13:15:09.139Z" },
+    { url = "https://files.pythonhosted.org/packages/17/01/7dc8c5443ff42b38e72731643ed7cf1ed9bf01691ae5cdca98501999ed83/kiwisolver-1.5.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:d1ffeb80b5676463d7a7d56acbe8e37a20ce725570e09549fe738e02ca6b7e1e", size = 125794, upload-time = "2026-03-09T13:15:10.525Z" },
+    { url = "https://files.pythonhosted.org/packages/46/8a/b4ebe46ebaac6a303417fab10c2e165c557ddaff558f9699d302b256bc53/kiwisolver-1.5.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:bc4d8e252f532ab46a1de9349e2d27b91fce46736a9eedaa37beaca66f574ed4", size = 67646, upload-time = "2026-03-09T13:15:12.016Z" },
+    { url = "https://files.pythonhosted.org/packages/60/35/10a844afc5f19d6f567359bf4789e26661755a2f36200d5d1ed8ad0126e5/kiwisolver-1.5.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6783e069732715ad0c3ce96dbf21dbc2235ab0593f2baf6338101f70371f4028", size = 65511, upload-time = "2026-03-09T13:15:13.311Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/8a/685b297052dd041dcebce8e8787b58923b6e78acc6115a0dc9189011c44b/kiwisolver-1.5.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e7c4c09a490dc4d4a7f8cbee56c606a320f9dc28cf92a7157a39d1ce7676a657", size = 1584858, upload-time = "2026-03-09T13:15:15.103Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/80/04865e3d4638ac5bddec28908916df4a3075b8c6cc101786a96803188b96/kiwisolver-1.5.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2a075bd7bd19c70cf67c8badfa36cf7c5d8de3c9ddb8420c51e10d9c50e94920", size = 1392539, upload-time = "2026-03-09T13:15:16.661Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/01/77a19cacc0893fa13fafa46d1bba06fb4dc2360b3292baf4b56d8e067b24/kiwisolver-1.5.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:bdd3e53429ff02aa319ba59dfe4ceeec345bf46cf180ec2cf6fd5b942e7975e9", size = 1405310, upload-time = "2026-03-09T13:15:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/53/39/bcaf5d0cca50e604cfa9b4e3ae1d64b50ca1ae5b754122396084599ef903/kiwisolver-1.5.0-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3cdcb35dc9d807259c981a85531048ede628eabcffb3239adf3d17463518992d", size = 1456244, upload-time = "2026-03-09T13:15:20.444Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/7a/72c187abc6975f6978c3e39b7cf67aeb8b3c0a8f9790aa7fd412855e9e1f/kiwisolver-1.5.0-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:70d593af6a6ca332d1df73d519fddb5148edb15cd90d5f0155e3746a6d4fcc65", size = 1073154, upload-time = "2026-03-09T13:15:22.039Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/ca/cf5b25783ebbd59143b4371ed0c8428a278abe68d6d0104b01865b1bbd0f/kiwisolver-1.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:377815a8616074cabbf3f53354e1d040c35815a134e01d7614b7692e4bf8acfa", size = 2334377, upload-time = "2026-03-09T13:15:23.741Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/e5/b1f492adc516796e88751282276745340e2a72dcd0d36cf7173e0daf3210/kiwisolver-1.5.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0255a027391d52944eae1dbb5d4cc5903f57092f3674e8e544cdd2622826b3f0", size = 2425288, upload-time = "2026-03-09T13:15:25.789Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/e5/9b21fbe91a61b8f409d74a26498706e97a48008bfcd1864373d32a6ba31c/kiwisolver-1.5.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:012b1eb16e28718fa782b5e61dc6f2da1f0792ca73bd05d54de6cb9561665fc9", size = 2063158, upload-time = "2026-03-09T13:15:27.63Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/02/83f47986138310f95ea95531f851b2a62227c11cbc3e690ae1374fe49f0f/kiwisolver-1.5.0-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:0e3aafb33aed7479377e5e9a82e9d4bf87063741fc99fc7ae48b0f16e32bdd6f", size = 2597260, upload-time = "2026-03-09T13:15:29.421Z" },
+    { url = "https://files.pythonhosted.org/packages/07/18/43a5f24608d8c313dd189cf838c8e68d75b115567c6279de7796197cfb6a/kiwisolver-1.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:e7a116ae737f0000343218c4edf5bd45893bfeaff0993c0b215d7124c9f77646", size = 2394403, upload-time = "2026-03-09T13:15:31.517Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/b5/98222136d839b8afabcaa943b09bd05888c2d36355b7e448550211d1fca4/kiwisolver-1.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:1dd9b0b119a350976a6d781e7278ec7aca0b201e1a9e2d23d9804afecb6ca681", size = 79687, upload-time = "2026-03-09T13:15:33.204Z" },
+    { url = "https://files.pythonhosted.org/packages/99/a2/ca7dc962848040befed12732dff6acae7fb3c4f6fc4272b3f6c9a30b8713/kiwisolver-1.5.0-cp314-cp314t-win_arm64.whl", hash = "sha256:58f812017cd2985c21fbffb4864d59174d4903dd66fa23815e74bbc7a0e2dd57", size = 70032, upload-time = "2026-03-09T13:15:34.411Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/fa/2910df836372d8761bb6eff7d8bdcb1613b5c2e03f260efe7abe34d388a7/kiwisolver-1.5.0-graalpy312-graalpy250_312_native-macosx_10_13_x86_64.whl", hash = "sha256:5ae8e62c147495b01a0f4765c878e9bfdf843412446a247e28df59936e99e797", size = 130262, upload-time = "2026-03-09T13:15:35.629Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/41/c5f71f9f00aabcc71fee8b7475e3f64747282580c2fe748961ba29b18385/kiwisolver-1.5.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:f6764a4ccab3078db14a632420930f6186058750df066b8ea2a7106df91d3203", size = 138036, upload-time = "2026-03-09T13:15:36.894Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/06/7399a607f434119c6e1fdc8ec89a8d51ccccadf3341dee4ead6bd14caaf5/kiwisolver-1.5.0-graalpy312-graalpy250_312_native-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c31c13da98624f957b0fb1b5bae5383b2333c2c3f6793d9825dd5ce79b525cb7", size = 194295, upload-time = "2026-03-09T13:15:38.22Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/91/53255615acd2a1eaca307ede3c90eb550bae9c94581f8c00081b6b1c8f44/kiwisolver-1.5.0-graalpy312-graalpy250_312_native-win_amd64.whl", hash = "sha256:1f1489f769582498610e015a8ef2d36f28f505ab3096d0e16b4858a9ec214f57", size = 75987, upload-time = "2026-03-09T13:15:39.65Z" },
 ]
 
 [[package]]
@@ -120,6 +1096,12 @@ mlir-frontend = [
     { name = "ktir-mlir-frontend" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "jupyter" },
+    { name = "matplotlib" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "ktir-mlir-frontend", marker = "extra == 'mlir-frontend'", git = "https://github.com/torch-spyre/ktir-mlir-frontend?rev=c2412cddc2a247ff1700fd594d0dd9011d675404" },
@@ -128,6 +1110,12 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0" },
 ]
 provides-extras = ["dev", "mlir-frontend"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "jupyter", specifier = ">=1.1.1" },
+    { name = "matplotlib", specifier = ">=3.10.9" },
+]
 
 [[package]]
 name = "ktir-mlir-frontend"
@@ -138,12 +1126,251 @@ dependencies = [
 ]
 
 [[package]]
+name = "lark"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/34/28fff3ab31ccff1fd4f6c7c7b0ceb2b6968d8ea4950663eadcb5720591a0/lark-1.3.1.tar.gz", hash = "sha256:b426a7a6d6d53189d318f2b6236ab5d6429eaf09259f1ca33eb716eed10d2905", size = 382732, upload-time = "2025-10-27T18:25:56.653Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3d/14ce75ef66813643812f3093ab17e46d3a206942ce7376d31ec2d36229e7/lark-1.3.1-py3-none-any.whl", hash = "sha256:c629b661023a014c37da873b4ff58a817398d12635d3bbb2c5a03be7fe5d1e12", size = 113151, upload-time = "2025-10-27T18:25:54.882Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
+    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "matplotlib"
+version = "3.10.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "contourpy" },
+    { name = "cycler" },
+    { name = "fonttools" },
+    { name = "kiwisolver" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pillow" },
+    { name = "pyparsing" },
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/63/1b/4be5be87d43d327a0cf4de1a56e86f7f84c89312452406cf122efe2839e6/matplotlib-3.10.9.tar.gz", hash = "sha256:fd66508e8c6877d98e586654b608a0456db8d7e8a546eb1e2600efd957302358", size = 34811233, upload-time = "2026-04-24T00:14:13.539Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/35/c6/5581e26c72233ebb2a2a6fed2d24fb7c66b4700120b813f51b0555acf0b6/matplotlib-3.10.9-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:f0c3c28d9fbcc1fe7a03be236d73430cf6409c41fb2383a7ac52fe932b072cb1", size = 8319908, upload-time = "2026-04-24T00:12:21.323Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/18/4880dd762e40cd360c1bf06e890c5a97b997e91cb324602b1a19950ad5ce/matplotlib-3.10.9-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:41cb28c2bd769aa3e98322c6ab09854cbcc52ab69d2759d681bba3e327b2b320", size = 8216016, upload-time = "2026-04-24T00:12:23.4Z" },
+    { url = "https://files.pythonhosted.org/packages/32/91/d024616abdba99e83120e07a20658976f6a343646710760c4a51df126029/matplotlib-3.10.9-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ae20801130378b82d647ff5047c07316295b68dc054ca6b3c13519d0ea624285", size = 8789336, upload-time = "2026-04-24T00:12:26.096Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/04/030a2f61ef2158f5e4c259487a92ac877732499fb33d871585d89e03c42d/matplotlib-3.10.9-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6c63ebcd8b4b169eb2f5c200552ae6b8be8999a005b6b507ed76fb8d7d674fe2", size = 9604602, upload-time = "2026-04-24T00:12:29.052Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/c2/541e4d09d87bb6b5830fc28b4c887a9a8cf4e1c6cee698a8c05552ae2003/matplotlib-3.10.9-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:d75d11c949914165976c621b2324f9ef162af7ebf4b057ddf95dd1dba7e5edcf", size = 9670966, upload-time = "2026-04-24T00:12:32.131Z" },
+    { url = "https://files.pythonhosted.org/packages/04/a1/4571fc46e7702de8d0c2dc54ad1b2f8e29328dea3ee90831181f7353d93c/matplotlib-3.10.9-cp312-cp312-win_amd64.whl", hash = "sha256:d091f9d758b34aaaaa6331d13574bf01891d903b3dec59bfff458ef7551de5d6", size = 8217462, upload-time = "2026-04-24T00:12:35.226Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/d0/2269edb12aa30c13c8bcc9382892e39943ce1d28aab4ec296e0381798e81/matplotlib-3.10.9-cp312-cp312-win_arm64.whl", hash = "sha256:10cc5ce06d10231c36f40e875f3c7e8050362a4ee8f0ee5d29a6b3277d57bb42", size = 8136688, upload-time = "2026-04-24T00:12:37.442Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/d3/8d4f6afbecb49fc04e060a57c0fce39ea51cc163a6bd87303ccd698e4fa6/matplotlib-3.10.9-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b580440f1ff81a0e34122051a3dfabb7e4b7f9e380629929bde0eff9af72165f", size = 8320331, upload-time = "2026-04-24T00:12:39.688Z" },
+    { url = "https://files.pythonhosted.org/packages/63/d9/9e14bc7564bf92d5ffa801ae5fac819ce74b925dfb55e3ebde61a3bbad3e/matplotlib-3.10.9-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:b1b745c489cd1a77a0dc1120a05dc87af9798faebc913601feb8c73d89bf2d1e", size = 8216461, upload-time = "2026-04-24T00:12:42.494Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/17/4402d0d14ccf1dfc70932600b68097fbbf9c898a4871d2cbbe79c7801a32/matplotlib-3.10.9-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8f3bcac1ca5ed000a6f4337d47ba67dfddf37ed6a46c15fd7f014997f7bf865f", size = 8790091, upload-time = "2026-04-24T00:12:44.789Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/0b/322aeec06dd9b91411f92028b37d447342770a24392aa4813e317064dad5/matplotlib-3.10.9-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7a8d66a55def891c33147ba3ba9bfcabf0b526a43764c818acbb4525e5ed0838", size = 9605027, upload-time = "2026-04-24T00:12:47.583Z" },
+    { url = "https://files.pythonhosted.org/packages/74/88/5f13482f55e7b00bcfc09838b093c2456e1379978d2a146844aae05350ad/matplotlib-3.10.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:d843374407c4017a6403b59c6c81606773d136f3259d5b6da3131bc814542cc2", size = 9671269, upload-time = "2026-04-24T00:12:50.878Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/e0/0840fd2f93da988ec660b8ad1984abe9f25d2aed22a5e394ff1c68c88307/matplotlib-3.10.9-cp313-cp313-win_amd64.whl", hash = "sha256:f4399f64b3e94cd500195490972ae1ee81170df1636fa15364d157d5bdd7b921", size = 8217588, upload-time = "2026-04-24T00:12:53.784Z" },
+    { url = "https://files.pythonhosted.org/packages/47/b9/d706d06dd605c49b9f83a2aed8c13e3e5db70697d7a80b7e3d7915de6b17/matplotlib-3.10.9-cp313-cp313-win_arm64.whl", hash = "sha256:ba7b3b8ef09eab7df0e86e9ae086faa433efbfbdb46afcb3aa16aabf779469a8", size = 8136913, upload-time = "2026-04-24T00:12:56.501Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/45/6e32d96978264c8ca8c4b1010adb955a1a49cfaf314e212bbc8908f04a61/matplotlib-3.10.9-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:09218df8a93712bd6ea133e83a153c755448cf7868316c531cffcc43f69d1cc9", size = 8368019, upload-time = "2026-04-24T00:12:58.896Z" },
+    { url = "https://files.pythonhosted.org/packages/86/0a/c8e3d3bba245f0f7fc424937f8ff7ef77291a36af3edb97ccd78aa93d84f/matplotlib-3.10.9-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:82368699727bfb7b0182e1aa13082e3c08e092fa1a25d3e1fd92405bff96f6d4", size = 8264645, upload-time = "2026-04-24T00:13:01.406Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/aa/5bf5a14fe4fed73a4209a155606f8096ff797aad89c6c35179026571133e/matplotlib-3.10.9-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3225f4e1edcb8c86c884ddf79ebe20ecd0a67d30188f279897554ccd8fded4dc", size = 8802194, upload-time = "2026-04-24T00:13:03.702Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/5e/b4be852d6bba6fd15893fadf91ff26ae49cb91aac789e95dde9d342e664f/matplotlib-3.10.9-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:de2445a0c6690d21b7eb6ce071cebad6d40a2e9bdf10d039074a96ba19797b99", size = 9622684, upload-time = "2026-04-24T00:13:06.647Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/3d/ed428c971139112ef730f62770654d609467346d09d4b62617e1afd68a5a/matplotlib-3.10.9-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:b2b9516251cb89ff618d757daec0e2ed1bf21248013844a853d87ef85ab3081d", size = 9680790, upload-time = "2026-04-24T00:13:10.009Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/09/052e884aaf2b985c63cb79f715f1d5b6a3eaa7de78f6a52b9dbc077d5b53/matplotlib-3.10.9-cp313-cp313t-win_amd64.whl", hash = "sha256:e9fae004b941b23ff2edcf1567a857ed77bafc8086ffa258190462328434faf8", size = 8287571, upload-time = "2026-04-24T00:13:13.087Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/38/ae27288e788c35a4250491422f3db7750366fc8c97d6f36fbdecfc1f5518/matplotlib-3.10.9-cp313-cp313t-win_arm64.whl", hash = "sha256:6b63d9c7c769b88ab81e10dc86e4e0607cf56817b9f9e6cf24b2a5f1693b8e38", size = 8188292, upload-time = "2026-04-24T00:13:15.546Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/e6/3bd8afd04949f02eabc1c17115ea5255e19cacd4d06fc5abdde4eeb0052c/matplotlib-3.10.9-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:172db52c9e683f5d12eaf57f0f54834190e12581fe1cc2a19595a8f5acb4e77d", size = 8321276, upload-time = "2026-04-24T00:13:18.318Z" },
+    { url = "https://files.pythonhosted.org/packages/41/86/86231232fff41c9f8e4a1a7d7a597d349a02527109c3af7d618366122139/matplotlib-3.10.9-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:97e35e8d39ccc85859095e01a53847432ba9a53ddf7986f7a54a11b73d0e143f", size = 8218218, upload-time = "2026-04-24T00:13:20.974Z" },
+    { url = "https://files.pythonhosted.org/packages/85/8f/becc9722cafc64f5d2eb0b7c1bf5f585271c618a45dbd8fabeb021f898b6/matplotlib-3.10.9-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aba1615dabe83188e19d4f75a253c6a08423e04c1425e64039f800050a69de6b", size = 9608145, upload-time = "2026-04-24T00:13:23.228Z" },
+    { url = "https://files.pythonhosted.org/packages/32/5d/f7e914f7d9325abff4057cee62c0fa70263683189f774473cbfb534cd13b/matplotlib-3.10.9-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:34cf8167e023ad956c15f36302911d5406bd99a9862c1a8499ea6f7c0e015dc2", size = 9885085, upload-time = "2026-04-24T00:13:25.849Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/fd/fa69f2221534e80cc5772ac2b7d222011a2acafc2ec7216d5dd174c864ae/matplotlib-3.10.9-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:59476c6d29d612b8e9bb6ce8c5b631be6ba8f9e3a2421f22a02b192c7dd28716", size = 9672358, upload-time = "2026-04-24T00:13:28.906Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/1a/5a4f747a8b271cbb024946d2dd3c913ab5032ba430626f8c3528ada96b4b/matplotlib-3.10.9-cp314-cp314-win_amd64.whl", hash = "sha256:336b9acc64d309063126edcdaca00db9373af3c476bb94388fe9c5a53ad13e6f", size = 8349970, upload-time = "2026-04-24T00:13:31.904Z" },
+    { url = "https://files.pythonhosted.org/packages/64/dc/95d60ecaefe30680a154b52ea96ab4b0dab547f1fd6aa12f5fb655e89cae/matplotlib-3.10.9-cp314-cp314-win_arm64.whl", hash = "sha256:2dc9477819ffd78ad12a20df1d9d6a6bd4fec6aaa9072681465fddca052f1456", size = 8272785, upload-time = "2026-04-24T00:13:34.511Z" },
+    { url = "https://files.pythonhosted.org/packages/70/a0/005d68bc8b8418300ce6591f18586910a8526806e2ab663933d9f20a41e9/matplotlib-3.10.9-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:da4e09638420548f31c354032a6250e473c68e5a4e96899b4844cf39ddea23fe", size = 8367999, upload-time = "2026-04-24T00:13:36.962Z" },
+    { url = "https://files.pythonhosted.org/packages/22/05/1236cc9290be70b2498af20ca348add76e3fffe7f67b477db5133a84f3ea/matplotlib-3.10.9-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:345f6f68ecc8da0ca56fad2ea08fde1a115eda530079eca185d50a7bc3e146c6", size = 8264543, upload-time = "2026-04-24T00:13:39.851Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/c2/071f5a5ff6c5bd63aaaf2f45c811d9bf2ced94bde188d9e1a519e21d0cba/matplotlib-3.10.9-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4edcfbd8565339aa62f1cd4012f7180926fdbe71850f7b0d3c379c175cd6b66c", size = 9622800, upload-time = "2026-04-24T00:13:42.296Z" },
+    { url = "https://files.pythonhosted.org/packages/95/57/da7d1f10a85624b9e7db68e069dd94e58dc41dbf9463c5921632ecbe3661/matplotlib-3.10.9-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6be157fe17fc37cb95ac1d7374cf717ce9259616edec911a78d9d26dae8522d4", size = 9888561, upload-time = "2026-04-24T00:13:45.026Z" },
+    { url = "https://files.pythonhosted.org/packages/67/b2/ef8d6bb59b0edb6c16c968b70f548aa13b54348972def5aa6ac85df67145/matplotlib-3.10.9-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4e42042d54db34fda4e95a7bd3e5789c2a995d2dad3eb8850232ee534092fbbf", size = 9680884, upload-time = "2026-04-24T00:13:48.066Z" },
+    { url = "https://files.pythonhosted.org/packages/61/1c/d21bfeb9931881ebe96bcfcff27c7ae4b160ae0ec291a714c42641a56d75/matplotlib-3.10.9-cp314-cp314t-win_amd64.whl", hash = "sha256:c27df8b3848f32a83d1767566595e43cfaa4460380974da06f4279a7ec143c39", size = 8432333, upload-time = "2026-04-24T00:13:51.008Z" },
+    { url = "https://files.pythonhosted.org/packages/78/23/92493c3e6e1b635ccfff146f7b99e674808787915420373ac399283764c2/matplotlib-3.10.9-cp314-cp314t-win_arm64.whl", hash = "sha256:a49f1eadc84ca85fd72fa4e89e70e61bf86452df6f971af04b12c60761a0772c", size = 8324785, upload-time = "2026-04-24T00:13:53.633Z" },
+]
+
+[[package]]
+name = "matplotlib-inline"
+version = "0.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bd/c0/9f7c9a46090390368a4d7bcb76bb87a4a36c421e4c0792cdb53486ffac7a/matplotlib_inline-0.2.2.tar.gz", hash = "sha256:72f3fe8fce36b70d4a5b612f899090cd0401deddc4ea90e1572b9f4bfb058c79", size = 8150, upload-time = "2026-05-08T17:33:33.49Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/09/5b161152e2d90f7b87f781c2e1267494aef9c32498df793f73ad0a0a494a/matplotlib_inline-0.2.2-py3-none-any.whl", hash = "sha256:3c821cf1c209f59fb2d2d64abbf5b23b67bcb2210d663f9918dd851c6da1fcf6", size = 9534, upload-time = "2026-05-08T17:33:32.055Z" },
+]
+
+[[package]]
+name = "mistune"
+version = "3.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/84/620cc3f7e3adf6f5067e10f4dbae71295d8f9e16d5d3f9ef97c40f2f592c/mistune-3.2.1.tar.gz", hash = "sha256:7c8e5501d38bac1582e067e46c8343f17d57ea1aaa735823f3aba1fd59c88a28", size = 98003, upload-time = "2026-05-03T14:33:22.312Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/7f/a946aa4f8752b37102b41e64dca18a1976ac705c3a0d1dfe74d820a02552/mistune-3.2.1-py3-none-any.whl", hash = "sha256:78cdb0ba5e938053ccf63651b352508d2efa9411dc8810bfb05f2dc5140c0048", size = 53749, upload-time = "2026-05-03T14:33:20.551Z" },
+]
+
+[[package]]
 name = "nanobind"
 version = "2.12.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c6/5c/3b69bc3933ad3c3668ba029ad410ba8ecfdc8ee7262ff1009f3304f3c562/nanobind-2.12.0.tar.gz", hash = "sha256:0ae77c1a88f27153fa57045ee00f7b0a7b06b1cd3df942e95a34b38c5d0a5bee", size = 1002704, upload-time = "2026-02-25T09:41:54.691Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/bf/1a54e3573736f3ad15fc599c5dde007937234652a1a7efd62573b4ce3a7e/nanobind-2.12.0-py3-none-any.whl", hash = "sha256:a10d3d88e691dcdf22696f9acd893fda3c5a05635763aea238829d274fcad480", size = 249512, upload-time = "2026-02-25T09:41:52.908Z" },
+]
+
+[[package]]
+name = "nbclient"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jupyter-client" },
+    { name = "jupyter-core" },
+    { name = "nbformat" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/56/91/1c1d5a4b9a9ebba2b4e32b8c852c2975c872aec1fe42ab5e516b2cecd193/nbclient-0.10.4.tar.gz", hash = "sha256:1e54091b16e6da39e297b0ece3e10f6f29f4ac4e8ee515d29f8a7099bd6553c9", size = 62554, upload-time = "2025-12-23T07:45:46.369Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/a0/5b0c2f11142ed1dddec842457d3f65eaf71a0080894eb6f018755b319c3a/nbclient-0.10.4-py3-none-any.whl", hash = "sha256:9162df5a7373d70d606527300a95a975a47c137776cd942e52d9c7e29ff83440", size = 25465, upload-time = "2025-12-23T07:45:44.51Z" },
+]
+
+[[package]]
+name = "nbconvert"
+version = "7.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "bleach", extra = ["css"] },
+    { name = "defusedxml" },
+    { name = "jinja2" },
+    { name = "jupyter-core" },
+    { name = "jupyterlab-pygments" },
+    { name = "markupsafe" },
+    { name = "mistune" },
+    { name = "nbclient" },
+    { name = "nbformat" },
+    { name = "packaging" },
+    { name = "pandocfilters" },
+    { name = "pygments" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/01/b1/708e53fe2e429c103c6e6e159106bcf0357ac41aa4c28772bd8402339051/nbconvert-7.17.1.tar.gz", hash = "sha256:34d0d0a7e73ce3cbab6c5aae8f4f468797280b01fd8bd2ca746da8569eddd7d2", size = 865311, upload-time = "2026-04-08T00:44:14.914Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/f8/bb0a9d5f46819c821dc1f004aa2cc29b1d91453297dbf5ff20470f00f193/nbconvert-7.17.1-py3-none-any.whl", hash = "sha256:aa85c087b435e7bf1ffd03319f658e285f2b89eccab33bc1ba7025495ab3e7c8", size = 261927, upload-time = "2026-04-08T00:44:12.845Z" },
+]
+
+[[package]]
+name = "nbformat"
+version = "5.10.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "fastjsonschema" },
+    { name = "jsonschema" },
+    { name = "jupyter-core" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6d/fd/91545e604bc3dad7dca9ed03284086039b294c6b3d75c0d2fa45f9e9caf3/nbformat-5.10.4.tar.gz", hash = "sha256:322168b14f937a5d11362988ecac2a4952d3d8e3a2cbeb2319584631226d5b3a", size = 142749, upload-time = "2024-04-04T11:20:37.371Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/82/0340caa499416c78e5d8f5f05947ae4bc3cba53c9f038ab6e9ed964e22f1/nbformat-5.10.4-py3-none-any.whl", hash = "sha256:3b48d6c8fbca4b299bf3982ea7db1af21580e4fec269ad087b9e81588891200b", size = 78454, upload-time = "2024-04-04T11:20:34.895Z" },
+]
+
+[[package]]
+name = "nest-asyncio"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/83/f8/51569ac65d696c8ecbee95938f89d4abf00f47d58d48f6fbabfe8f0baefe/nest_asyncio-1.6.0.tar.gz", hash = "sha256:6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe", size = 7418, upload-time = "2024-01-21T14:25:19.227Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl", hash = "sha256:87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c", size = 5195, upload-time = "2024-01-21T14:25:17.223Z" },
+]
+
+[[package]]
+name = "notebook"
+version = "7.5.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jupyter-server" },
+    { name = "jupyterlab" },
+    { name = "jupyterlab-server" },
+    { name = "notebook-shim" },
+    { name = "tornado" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2a/c2/cf59bd2e6f2c8b976b52477e3e53bf6f97bc714ed046a51821afb428eaee/notebook-7.5.6.tar.gz", hash = "sha256:621174aade80108f0020b0f00738000b215f75fa3cd90771ad7aa0f24536a4e1", size = 14170814, upload-time = "2026-04-30T11:46:26.613Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/d6/1fd0646b9bbd9efbb0b8ae21b2325fbef515769a5621c03e31d8eb8da587/notebook-7.5.6-py3-none-any.whl", hash = "sha256:4dde3f8fb55fa8fb7946d58c6e869ce9baf46d00fc070664f62604569d0faca0", size = 14581730, upload-time = "2026-04-30T11:46:22.342Z" },
+]
+
+[[package]]
+name = "notebook-shim"
+version = "0.2.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jupyter-server" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/54/d2/92fa3243712b9a3e8bafaf60aac366da1cada3639ca767ff4b5b3654ec28/notebook_shim-0.2.4.tar.gz", hash = "sha256:b4b2cfa1b65d98307ca24361f5b30fe785b53c3fd07b7a47e89acb5e6ac638cb", size = 13167, upload-time = "2024-02-14T23:35:18.353Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/33/bd5b9137445ea4b680023eb0469b2bb969d61303dedb2aac6560ff3d14a1/notebook_shim-0.2.4-py3-none-any.whl", hash = "sha256:411a5be4e9dc882a074ccbcae671eda64cceb068767e9a3419096986560e1cef", size = 13307, upload-time = "2024-02-14T23:35:16.286Z" },
 ]
 
 [[package]]
@@ -217,6 +1444,114 @@ wheels = [
 ]
 
 [[package]]
+name = "pandocfilters"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/70/6f/3dd4940bbe001c06a65f88e36bad298bc7a0de5036115639926b0c5c0458/pandocfilters-1.5.1.tar.gz", hash = "sha256:002b4a555ee4ebc03f8b66307e287fa492e4a77b4ea14d3f934328297bb4939e", size = 8454, upload-time = "2024-01-18T20:08:13.726Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/af/4fbc8cab944db5d21b7e2a5b8e9211a03a79852b1157e2c102fcc61ac440/pandocfilters-1.5.1-py2.py3-none-any.whl", hash = "sha256:93be382804a9cdb0a7267585f157e5d1731bbe5545a85b268d6f5fe6232de2bc", size = 8663, upload-time = "2024-01-18T20:08:11.28Z" },
+]
+
+[[package]]
+name = "parso"
+version = "0.8.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/4b/90c937815137d43ce71ba043cd3566221e9df6b9c805f24b5d138c9d40a7/parso-0.8.7.tar.gz", hash = "sha256:eaaac4c9fdd5e9e8852dc778d2d7405897ec510f2a298071453e5e3a07914bb1", size = 401824, upload-time = "2026-05-01T23:13:02.138Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/5d/8268b644392ee874ee82a635cd0df1773de230bde356c38de28e298392cc/parso-0.8.7-py2.py3-none-any.whl", hash = "sha256:a8926eb2a1b915486941fdbd31e86a4baf88fe8c210f25f2f35ecec5b574ca1c", size = 107025, upload-time = "2026-05-01T23:12:58.867Z" },
+]
+
+[[package]]
+name = "pexpect"
+version = "4.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ptyprocess" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/c3/059298687310d527a58bb01f3b1965787ee3b40dce76752eda8b44e9a2c5/pexpect-4.9.0-py2.py3-none-any.whl", hash = "sha256:7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523", size = 63772, upload-time = "2023-11-25T06:56:14.81Z" },
+]
+
+[[package]]
+name = "pillow"
+version = "12.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/21/c2bcdd5906101a30244eaffc1b6e6ce71a31bd0742a01eb89e660ebfac2d/pillow-12.2.0.tar.gz", hash = "sha256:a830b1a40919539d07806aa58e1b114df53ddd43213d9c8b75847eee6c0182b5", size = 46987819, upload-time = "2026-04-01T14:46:17.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/be/7482c8a5ebebbc6470b3eb791812fff7d5e0216c2be3827b30b8bb6603ed/pillow-12.2.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2d192a155bbcec180f8564f693e6fd9bccff5a7af9b32e2e4bf8c9c69dbad6b5", size = 5308279, upload-time = "2026-04-01T14:43:13.246Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/95/0a351b9289c2b5cbde0bacd4a83ebc44023e835490a727b2a3bd60ddc0f4/pillow-12.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f3f40b3c5a968281fd507d519e444c35f0ff171237f4fdde090dd60699458421", size = 4695490, upload-time = "2026-04-01T14:43:15.584Z" },
+    { url = "https://files.pythonhosted.org/packages/de/af/4e8e6869cbed569d43c416fad3dc4ecb944cb5d9492defaed89ddd6fe871/pillow-12.2.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:03e7e372d5240cc23e9f07deca4d775c0817bffc641b01e9c3af208dbd300987", size = 6284462, upload-time = "2026-04-01T14:43:18.268Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/9e/c05e19657fd57841e476be1ab46c4d501bffbadbafdc31a6d665f8b737b6/pillow-12.2.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b86024e52a1b269467a802258c25521e6d742349d760728092e1bc2d135b4d76", size = 8094744, upload-time = "2026-04-01T14:43:20.716Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/54/1789c455ed10176066b6e7e6da1b01e50e36f94ba584dc68d9eebfe9156d/pillow-12.2.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7371b48c4fa448d20d2714c9a1f775a81155050d383333e0a6c15b1123dda005", size = 6398371, upload-time = "2026-04-01T14:43:23.443Z" },
+    { url = "https://files.pythonhosted.org/packages/43/e3/fdc657359e919462369869f1c9f0e973f353f9a9ee295a39b1fea8ee1a77/pillow-12.2.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:62f5409336adb0663b7caa0da5c7d9e7bdbaae9ce761d34669420c2a801b2780", size = 7087215, upload-time = "2026-04-01T14:43:26.758Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/f8/2f6825e441d5b1959d2ca5adec984210f1ec086435b0ed5f52c19b3b8a6e/pillow-12.2.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:01afa7cf67f74f09523699b4e88c73fb55c13346d212a59a2db1f86b0a63e8c5", size = 6509783, upload-time = "2026-04-01T14:43:29.56Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f9/029a27095ad20f854f9dba026b3ea6428548316e057e6fc3545409e86651/pillow-12.2.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fc3d34d4a8fbec3e88a79b92e5465e0f9b842b628675850d860b8bd300b159f5", size = 7212112, upload-time = "2026-04-01T14:43:32.091Z" },
+    { url = "https://files.pythonhosted.org/packages/be/42/025cfe05d1be22dbfdb4f264fe9de1ccda83f66e4fc3aac94748e784af04/pillow-12.2.0-cp312-cp312-win32.whl", hash = "sha256:58f62cc0f00fd29e64b29f4fd923ffdb3859c9f9e6105bfc37ba1d08994e8940", size = 6378489, upload-time = "2026-04-01T14:43:34.601Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/7b/25a221d2c761c6a8ae21bfa3874988ff2583e19cf8a27bf2fee358df7942/pillow-12.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:7f84204dee22a783350679a0333981df803dac21a0190d706a50475e361c93f5", size = 7084129, upload-time = "2026-04-01T14:43:37.213Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e1/542a474affab20fd4a0f1836cb234e8493519da6b76899e30bcc5d990b8b/pillow-12.2.0-cp312-cp312-win_arm64.whl", hash = "sha256:af73337013e0b3b46f175e79492d96845b16126ddf79c438d7ea7ff27783a414", size = 2463612, upload-time = "2026-04-01T14:43:39.421Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/01/53d10cf0dbad820a8db274d259a37ba50b88b24768ddccec07355382d5ad/pillow-12.2.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:8297651f5b5679c19968abefd6bb84d95fe30ef712eb1b2d9b2d31ca61267f4c", size = 4100837, upload-time = "2026-04-01T14:43:41.506Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/98/f3a6657ecb698c937f6c76ee564882945f29b79bad496abcba0e84659ec5/pillow-12.2.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:50d8520da2a6ce0af445fa6d648c4273c3eeefbc32d7ce049f22e8b5c3daecc2", size = 4176528, upload-time = "2026-04-01T14:43:43.773Z" },
+    { url = "https://files.pythonhosted.org/packages/69/bc/8986948f05e3ea490b8442ea1c1d4d990b24a7e43d8a51b2c7d8b1dced36/pillow-12.2.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:766cef22385fa1091258ad7e6216792b156dc16d8d3fa607e7545b2b72061f1c", size = 3640401, upload-time = "2026-04-01T14:43:45.87Z" },
+    { url = "https://files.pythonhosted.org/packages/34/46/6c717baadcd62bc8ed51d238d521ab651eaa74838291bda1f86fe1f864c9/pillow-12.2.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5d2fd0fa6b5d9d1de415060363433f28da8b1526c1c129020435e186794b3795", size = 5308094, upload-time = "2026-04-01T14:43:48.438Z" },
+    { url = "https://files.pythonhosted.org/packages/71/43/905a14a8b17fdb1ccb58d282454490662d2cb89a6bfec26af6d3520da5ec/pillow-12.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:56b25336f502b6ed02e889f4ece894a72612fe885889a6e8c4c80239ff6e5f5f", size = 4695402, upload-time = "2026-04-01T14:43:51.292Z" },
+    { url = "https://files.pythonhosted.org/packages/73/dd/42107efcb777b16fa0393317eac58f5b5cf30e8392e266e76e51cff28c3d/pillow-12.2.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f1c943e96e85df3d3478f7b691f229887e143f81fedab9b20205349ab04d73ed", size = 6280005, upload-time = "2026-04-01T14:43:54.242Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/68/b93e09e5e8549019e61acf49f65b1a8530765a7f812c77a7461bca7e4494/pillow-12.2.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:03f6fab9219220f041c74aeaa2939ff0062bd5c364ba9ce037197f4c6d498cd9", size = 8090669, upload-time = "2026-04-01T14:43:57.335Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/6e/3ccb54ce8ec4ddd1accd2d89004308b7b0b21c4ac3d20fa70af4760a4330/pillow-12.2.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5cdfebd752ec52bf5bb4e35d9c64b40826bc5b40a13df7c3cda20a2c03a0f5ed", size = 6395194, upload-time = "2026-04-01T14:43:59.864Z" },
+    { url = "https://files.pythonhosted.org/packages/67/ee/21d4e8536afd1a328f01b359b4d3997b291ffd35a237c877b331c1c3b71c/pillow-12.2.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eedf4b74eda2b5a4b2b2fb4c006d6295df3bf29e459e198c90ea48e130dc75c3", size = 7082423, upload-time = "2026-04-01T14:44:02.74Z" },
+    { url = "https://files.pythonhosted.org/packages/78/5f/e9f86ab0146464e8c133fe85df987ed9e77e08b29d8d35f9f9f4d6f917ba/pillow-12.2.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:00a2865911330191c0b818c59103b58a5e697cae67042366970a6b6f1b20b7f9", size = 6505667, upload-time = "2026-04-01T14:44:05.381Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/1e/409007f56a2fdce61584fd3acbc2bbc259857d555196cedcadc68c015c82/pillow-12.2.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1e1757442ed87f4912397c6d35a0db6a7b52592156014706f17658ff58bbf795", size = 7208580, upload-time = "2026-04-01T14:44:08.39Z" },
+    { url = "https://files.pythonhosted.org/packages/23/c4/7349421080b12fb35414607b8871e9534546c128a11965fd4a7002ccfbee/pillow-12.2.0-cp313-cp313-win32.whl", hash = "sha256:144748b3af2d1b358d41286056d0003f47cb339b8c43a9ea42f5fea4d8c66b6e", size = 6375896, upload-time = "2026-04-01T14:44:11.197Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/82/8a3739a5e470b3c6cbb1d21d315800d8e16bff503d1f16b03a4ec3212786/pillow-12.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:390ede346628ccc626e5730107cde16c42d3836b89662a115a921f28440e6a3b", size = 7081266, upload-time = "2026-04-01T14:44:13.947Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/25/f968f618a062574294592f668218f8af564830ccebdd1fa6200f598e65c5/pillow-12.2.0-cp313-cp313-win_arm64.whl", hash = "sha256:8023abc91fba39036dbce14a7d6535632f99c0b857807cbbbf21ecc9f4717f06", size = 2463508, upload-time = "2026-04-01T14:44:16.312Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/a4/b342930964e3cb4dce5038ae34b0eab4653334995336cd486c5a8c25a00c/pillow-12.2.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:042db20a421b9bafecc4b84a8b6e444686bd9d836c7fd24542db3e7df7baad9b", size = 5309927, upload-time = "2026-04-01T14:44:18.89Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/de/23198e0a65a9cf06123f5435a5d95cea62a635697f8f03d134d3f3a96151/pillow-12.2.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:dd025009355c926a84a612fecf58bb315a3f6814b17ead51a8e48d3823d9087f", size = 4698624, upload-time = "2026-04-01T14:44:21.115Z" },
+    { url = "https://files.pythonhosted.org/packages/01/a6/1265e977f17d93ea37aa28aa81bad4fa597933879fac2520d24e021c8da3/pillow-12.2.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:88ddbc66737e277852913bd1e07c150cc7bb124539f94c4e2df5344494e0a612", size = 6321252, upload-time = "2026-04-01T14:44:23.663Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/83/5982eb4a285967baa70340320be9f88e57665a387e3a53a7f0db8231a0cd/pillow-12.2.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d362d1878f00c142b7e1a16e6e5e780f02be8195123f164edf7eddd911eefe7c", size = 8126550, upload-time = "2026-04-01T14:44:26.772Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/48/6ffc514adce69f6050d0753b1a18fd920fce8cac87620d5a31231b04bfc5/pillow-12.2.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c727a6d53cb0018aadd8018c2b938376af27914a68a492f59dfcaca650d5eea", size = 6433114, upload-time = "2026-04-01T14:44:29.615Z" },
+    { url = "https://files.pythonhosted.org/packages/36/a3/f9a77144231fb8d40ee27107b4463e205fa4677e2ca2548e14da5cf18dce/pillow-12.2.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:efd8c21c98c5cc60653bcb311bef2ce0401642b7ce9d09e03a7da87c878289d4", size = 7115667, upload-time = "2026-04-01T14:44:32.773Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/fc/ac4ee3041e7d5a565e1c4fd72a113f03b6394cc72ab7089d27608f8aaccb/pillow-12.2.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9f08483a632889536b8139663db60f6724bfcb443c96f1b18855860d7d5c0fd4", size = 6538966, upload-time = "2026-04-01T14:44:35.252Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/a8/27fb307055087f3668f6d0a8ccb636e7431d56ed0750e07a60547b1e083e/pillow-12.2.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:dac8d77255a37e81a2efcbd1fc05f1c15ee82200e6c240d7e127e25e365c39ea", size = 7238241, upload-time = "2026-04-01T14:44:37.875Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/4b/926ab182c07fccae9fcb120043464e1ff1564775ec8864f21a0ebce6ac25/pillow-12.2.0-cp313-cp313t-win32.whl", hash = "sha256:ee3120ae9dff32f121610bb08e4313be87e03efeadfc6c0d18f89127e24d0c24", size = 6379592, upload-time = "2026-04-01T14:44:40.336Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c4/f9e476451a098181b30050cc4c9a3556b64c02cf6497ea421ac047e89e4b/pillow-12.2.0-cp313-cp313t-win_amd64.whl", hash = "sha256:325ca0528c6788d2a6c3d40e3568639398137346c3d6e66bb61db96b96511c98", size = 7085542, upload-time = "2026-04-01T14:44:43.251Z" },
+    { url = "https://files.pythonhosted.org/packages/00/a4/285f12aeacbe2d6dc36c407dfbbe9e96d4a80b0fb710a337f6d2ad978c75/pillow-12.2.0-cp313-cp313t-win_arm64.whl", hash = "sha256:2e5a76d03a6c6dcef67edabda7a52494afa4035021a79c8558e14af25313d453", size = 2465765, upload-time = "2026-04-01T14:44:45.996Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/98/4595daa2365416a86cb0d495248a393dfc84e96d62ad080c8546256cb9c0/pillow-12.2.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:3adc9215e8be0448ed6e814966ecf3d9952f0ea40eb14e89a102b87f450660d8", size = 4100848, upload-time = "2026-04-01T14:44:48.48Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/79/40184d464cf89f6663e18dfcf7ca21aae2491fff1a16127681bf1fa9b8cf/pillow-12.2.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:6a9adfc6d24b10f89588096364cc726174118c62130c817c2837c60cf08a392b", size = 4176515, upload-time = "2026-04-01T14:44:51.353Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/63/703f86fd4c422a9cf722833670f4f71418fb116b2853ff7da722ea43f184/pillow-12.2.0-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:6a6e67ea2e6feda684ed370f9a1c52e7a243631c025ba42149a2cc5934dec295", size = 3640159, upload-time = "2026-04-01T14:44:53.588Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e0/fb22f797187d0be2270f83500aab851536101b254bfa1eae10795709d283/pillow-12.2.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:2bb4a8d594eacdfc59d9e5ad972aa8afdd48d584ffd5f13a937a664c3e7db0ed", size = 5312185, upload-time = "2026-04-01T14:44:56.039Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/8c/1a9e46228571de18f8e28f16fabdfc20212a5d019f3e3303452b3f0a580d/pillow-12.2.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:80b2da48193b2f33ed0c32c38140f9d3186583ce7d516526d462645fd98660ae", size = 4695386, upload-time = "2026-04-01T14:44:58.663Z" },
+    { url = "https://files.pythonhosted.org/packages/70/62/98f6b7f0c88b9addd0e87c217ded307b36be024d4ff8869a812b241d1345/pillow-12.2.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:22db17c68434de69d8ecfc2fe821569195c0c373b25cccb9cbdacf2c6e53c601", size = 6280384, upload-time = "2026-04-01T14:45:01.5Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/03/688747d2e91cfbe0e64f316cd2e8005698f76ada3130d0194664174fa5de/pillow-12.2.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7b14cc0106cd9aecda615dd6903840a058b4700fcb817687d0ee4fc8b6e389be", size = 8091599, upload-time = "2026-04-01T14:45:04.5Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/35/577e22b936fcdd66537329b33af0b4ccfefaeabd8aec04b266528cddb33c/pillow-12.2.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8cbeb542b2ebc6fcdacabf8aca8c1a97c9b3ad3927d46b8723f9d4f033288a0f", size = 6396021, upload-time = "2026-04-01T14:45:07.117Z" },
+    { url = "https://files.pythonhosted.org/packages/11/8d/d2532ad2a603ca2b93ad9f5135732124e57811d0168155852f37fbce2458/pillow-12.2.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4bfd07bc812fbd20395212969e41931001fd59eb55a60658b0e5710872e95286", size = 7083360, upload-time = "2026-04-01T14:45:09.763Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/26/d325f9f56c7e039034897e7380e9cc202b1e368bfd04d4cbe6a441f02885/pillow-12.2.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9aba9a17b623ef750a4d11b742cbafffeb48a869821252b30ee21b5e91392c50", size = 6507628, upload-time = "2026-04-01T14:45:12.378Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/f7/769d5632ffb0988f1c5e7660b3e731e30f7f8ec4318e94d0a5d674eb65a4/pillow-12.2.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:deede7c263feb25dba4e82ea23058a235dcc2fe1f6021025dc71f2b618e26104", size = 7209321, upload-time = "2026-04-01T14:45:15.122Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/7a/c253e3c645cd47f1aceea6a8bacdba9991bf45bb7dfe927f7c893e89c93c/pillow-12.2.0-cp314-cp314-win32.whl", hash = "sha256:632ff19b2778e43162304d50da0181ce24ac5bb8180122cbe1bf4673428328c7", size = 6479723, upload-time = "2026-04-01T14:45:17.797Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/8b/601e6566b957ca50e28725cb6c355c59c2c8609751efbecd980db44e0349/pillow-12.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:4e6c62e9d237e9b65fac06857d511e90d8461a32adcc1b9065ea0c0fa3a28150", size = 7217400, upload-time = "2026-04-01T14:45:20.529Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/94/220e46c73065c3e2951bb91c11a1fb636c8c9ad427ac3ce7d7f3359b9b2f/pillow-12.2.0-cp314-cp314-win_arm64.whl", hash = "sha256:b1c1fbd8a5a1af3412a0810d060a78b5136ec0836c8a4ef9aa11807f2a22f4e1", size = 2554835, upload-time = "2026-04-01T14:45:23.162Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/ab/1b426a3974cb0e7da5c29ccff4807871d48110933a57207b5a676cccc155/pillow-12.2.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:57850958fe9c751670e49b2cecf6294acc99e562531f4bd317fa5ddee2068463", size = 5314225, upload-time = "2026-04-01T14:45:25.637Z" },
+    { url = "https://files.pythonhosted.org/packages/19/1e/dce46f371be2438eecfee2a1960ee2a243bbe5e961890146d2dee1ff0f12/pillow-12.2.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:d5d38f1411c0ed9f97bcb49b7bd59b6b7c314e0e27420e34d99d844b9ce3b6f3", size = 4698541, upload-time = "2026-04-01T14:45:28.355Z" },
+    { url = "https://files.pythonhosted.org/packages/55/c3/7fbecf70adb3a0c33b77a300dc52e424dc22ad8cdc06557a2e49523b703d/pillow-12.2.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5c0a9f29ca8e79f09de89293f82fc9b0270bb4af1d58bc98f540cc4aedf03166", size = 6322251, upload-time = "2026-04-01T14:45:30.924Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/3c/7fbc17cfb7e4fe0ef1642e0abc17fc6c94c9f7a16be41498e12e2ba60408/pillow-12.2.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1610dd6c61621ae1cf811bef44d77e149ce3f7b95afe66a4512f8c59f25d9ebe", size = 8127807, upload-time = "2026-04-01T14:45:33.908Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/c3/a8ae14d6defd2e448493ff512fae903b1e9bd40b72efb6ec55ce0048c8ce/pillow-12.2.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0a34329707af4f73cf1782a36cd2289c0368880654a2c11f027bcee9052d35dd", size = 6433935, upload-time = "2026-04-01T14:45:36.623Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/32/2880fb3a074847ac159d8f902cb43278a61e85f681661e7419e6596803ed/pillow-12.2.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e9c4f5b3c546fa3458a29ab22646c1c6c787ea8f5ef51300e5a60300736905e", size = 7116720, upload-time = "2026-04-01T14:45:39.258Z" },
+    { url = "https://files.pythonhosted.org/packages/46/87/495cc9c30e0129501643f24d320076f4cc54f718341df18cc70ec94c44e1/pillow-12.2.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fb043ee2f06b41473269765c2feae53fc2e2fbf96e5e22ca94fb5ad677856f06", size = 6540498, upload-time = "2026-04-01T14:45:41.879Z" },
+    { url = "https://files.pythonhosted.org/packages/18/53/773f5edca692009d883a72211b60fdaf8871cbef075eaa9d577f0a2f989e/pillow-12.2.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:f278f034eb75b4e8a13a54a876cc4a5ab39173d2cdd93a638e1b467fc545ac43", size = 7239413, upload-time = "2026-04-01T14:45:44.705Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/e4/4b64a97d71b2a83158134abbb2f5bd3f8a2ea691361282f010998f339ec7/pillow-12.2.0-cp314-cp314t-win32.whl", hash = "sha256:6bb77b2dcb06b20f9f4b4a8454caa581cd4dd0643a08bacf821216a16d9c8354", size = 6482084, upload-time = "2026-04-01T14:45:47.568Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/13/306d275efd3a3453f72114b7431c877d10b1154014c1ebbedd067770d629/pillow-12.2.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6562ace0d3fb5f20ed7290f1f929cae41b25ae29528f2af1722966a0a02e2aa1", size = 7225152, upload-time = "2026-04-01T14:45:50.032Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/6e/cf826fae916b8658848d7b9f38d88da6396895c676e8086fc0988073aaf8/pillow-12.2.0-cp314-cp314t-win_arm64.whl", hash = "sha256:aa88ccfe4e32d362816319ed727a004423aab09c5cea43c01a4b435643fa34eb", size = 2556579, upload-time = "2026-04-01T14:45:52.529Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.9.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400, upload-time = "2026-04-09T00:04:10.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348, upload-time = "2026-04-09T00:04:09.463Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -226,12 +1561,97 @@ wheels = [
 ]
 
 [[package]]
+name = "prometheus-client"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/fb/d9aa83ffe43ce1f19e557c0971d04b90561b0cfd50762aafb01968285553/prometheus_client-0.25.0.tar.gz", hash = "sha256:5e373b75c31afb3c86f1a52fa1ad470c9aace18082d39ec0d2f918d11cc9ba28", size = 86035, upload-time = "2026-04-09T19:53:42.359Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/9b/d4b1e644385499c8346fa9b622a3f030dce14cd6ef8a1871c221a17a67e7/prometheus_client-0.25.0-py3-none-any.whl", hash = "sha256:d5aec89e349a6ec230805d0df882f3807f74fd6c1a2fa86864e3c2279059fed1", size = 64154, upload-time = "2026-04-09T19:53:41.324Z" },
+]
+
+[[package]]
+name = "prompt-toolkit"
+version = "3.0.52"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
+]
+
+[[package]]
+name = "psutil"
+version = "7.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/08/510cbdb69c25a96f4ae523f733cdc963ae654904e8db864c07585ef99875/psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b", size = 130595, upload-time = "2026-01-28T18:14:57.293Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f5/97baea3fe7a5a9af7436301f85490905379b1c6f2dd51fe3ecf24b4c5fbf/psutil-7.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78c8603dcd9a04c7364f1a3e670cea95d51ee865e4efb3556a3a63adef958ea", size = 131082, upload-time = "2026-01-28T18:14:59.732Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d6/246513fbf9fa174af531f28412297dd05241d97a75911ac8febefa1a53c6/psutil-7.2.2-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a571f2330c966c62aeda00dd24620425d4b0cc86881c89861fbc04549e5dc63", size = 181476, upload-time = "2026-01-28T18:15:01.884Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/b5/9182c9af3836cca61696dabe4fd1304e17bc56cb62f17439e1154f225dd3/psutil-7.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:917e891983ca3c1887b4ef36447b1e0873e70c933afc831c6b6da078ba474312", size = 184062, upload-time = "2026-01-28T18:15:04.436Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ba/0756dca669f5a9300d0cbcbfae9a4c30e446dfc7440ffe43ded5724bfd93/psutil-7.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:ab486563df44c17f5173621c7b198955bd6b613fb87c71c161f827d3fb149a9b", size = 139893, upload-time = "2026-01-28T18:15:06.378Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/61/8fa0e26f33623b49949346de05ec1ddaad02ed8ba64af45f40a147dbfa97/psutil-7.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:ae0aefdd8796a7737eccea863f80f81e468a1e4cf14d926bd9b6f5f2d5f90ca9", size = 135589, upload-time = "2026-01-28T18:15:08.03Z" },
+    { url = "https://files.pythonhosted.org/packages/81/69/ef179ab5ca24f32acc1dac0c247fd6a13b501fd5534dbae0e05a1c48b66d/psutil-7.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:eed63d3b4d62449571547b60578c5b2c4bcccc5387148db46e0c2313dad0ee00", size = 130664, upload-time = "2026-01-28T18:15:09.469Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/64/665248b557a236d3fa9efc378d60d95ef56dd0a490c2cd37dafc7660d4a9/psutil-7.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7b6d09433a10592ce39b13d7be5a54fbac1d1228ed29abc880fb23df7cb694c9", size = 131087, upload-time = "2026-01-28T18:15:11.724Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2e/e6782744700d6759ebce3043dcfa661fb61e2fb752b91cdeae9af12c2178/psutil-7.2.2-cp314-cp314t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fa4ecf83bcdf6e6c8f4449aff98eefb5d0604bf88cb883d7da3d8d2d909546a", size = 182383, upload-time = "2026-01-28T18:15:13.445Z" },
+    { url = "https://files.pythonhosted.org/packages/57/49/0a41cefd10cb7505cdc04dab3eacf24c0c2cb158a998b8c7b1d27ee2c1f5/psutil-7.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e452c464a02e7dc7822a05d25db4cde564444a67e58539a00f929c51eddda0cf", size = 185210, upload-time = "2026-01-28T18:15:16.002Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/2c/ff9bfb544f283ba5f83ba725a3c5fec6d6b10b8f27ac1dc641c473dc390d/psutil-7.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c7663d4e37f13e884d13994247449e9f8f574bc4655d509c3b95e9ec9e2b9dc1", size = 141228, upload-time = "2026-01-28T18:15:18.385Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/fc/f8d9c31db14fcec13748d373e668bc3bed94d9077dbc17fb0eebc073233c/psutil-7.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:11fe5a4f613759764e79c65cf11ebdf26e33d6dd34336f8a337aa2996d71c841", size = 136284, upload-time = "2026-01-28T18:15:19.912Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
+    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
+    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
+]
+
+[[package]]
+name = "ptyprocess"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/e5/16ff212c1e452235a90aeb09066144d0c5a6a8c0834397e03f5224495c4e/ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220", size = 70762, upload-time = "2020-12-28T15:15:30.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/a6/858897256d0deac81a172289110f31629fc4cee19b6f01283303e18c8db3/ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35", size = 13993, upload-time = "2020-12-28T15:15:28.35Z" },
+]
+
+[[package]]
+name = "pure-eval"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/05/0a34433a064256a578f1783a10da6df098ceaa4a57bbeaa96a6c0352786b/pure_eval-0.2.3.tar.gz", hash = "sha256:5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42", size = 19752, upload-time = "2024-07-21T12:58:21.801Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl", hash = "sha256:1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0", size = 11842, upload-time = "2024-07-21T12:58:20.04Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyparsing"
+version = "3.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
 ]
 
 [[package]]
@@ -262,4 +1682,458 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-json-logger"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/ff/3cc9165fd44106973cd7ac9facb674a65ed853494592541d339bdc9a30eb/python_json_logger-4.1.0.tar.gz", hash = "sha256:b396b9e3ed782b09ff9d6e4f1683d46c83ad0d35d2e407c09a9ebbf038f88195", size = 17573, upload-time = "2026-03-29T04:39:56.805Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/be/0631a861af4d1c875f096c07d34e9a63639560a717130e7a87cbc82b7e3f/python_json_logger-4.1.0-py3-none-any.whl", hash = "sha256:132994765cf75bf44554be9aa49b06ef2345d23661a96720262716438141b6b2", size = 15021, upload-time = "2026-03-29T04:39:55.266Z" },
+]
+
+[[package]]
+name = "pywinpty"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/54/37c7370ba91f579235049dc26cd2c5e657d2a943e01820844ffc81f32176/pywinpty-3.0.3.tar.gz", hash = "sha256:523441dc34d231fb361b4b00f8c99d3f16de02f5005fd544a0183112bcc22412", size = 31309, upload-time = "2026-02-04T21:51:09.524Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/d4/aeb5e1784d2c5bff6e189138a9ca91a090117459cea0c30378e1f2db3d54/pywinpty-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:c9081df0e49ffa86d15db4a6ba61530630e48707f987df42c9d3313537e81fc0", size = 2113098, upload-time = "2026-02-04T21:54:37.711Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/53/7278223c493ccfe4883239cf06c823c56460a8010e0fc778eef67858dc14/pywinpty-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:15e79d870e18b678fb8a5a6105fd38496b55697c66e6fc0378236026bc4d59e9", size = 234901, upload-time = "2026-02-04T21:53:31.35Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/cb/58d6ed3fd429c96a90ef01ac9a617af10a6d41469219c25e7dc162abbb71/pywinpty-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9c91dbb026050c77bdcef964e63a4f10f01a639113c4d3658332614544c467ab", size = 2112686, upload-time = "2026-02-04T21:52:03.035Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/50/724ed5c38c504d4e58a88a072776a1e880d970789deaeb2b9f7bd9a5141a/pywinpty-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:fe1f7911805127c94cf51f89ab14096c6f91ffdcacf993d2da6082b2142a2523", size = 234591, upload-time = "2026-02-04T21:52:29.821Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/ad/90a110538696b12b39fd8758a06d70ded899308198ad2305ac68e361126e/pywinpty-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:3f07a6cf1c1d470d284e614733c3d0f726d2c85e78508ea10a403140c3c0c18a", size = 2112360, upload-time = "2026-02-04T21:55:33.397Z" },
+    { url = "https://files.pythonhosted.org/packages/44/0f/7ffa221757a220402bc79fda44044c3f2cc57338d878ab7d622add6f4581/pywinpty-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:15c7c0b6f8e9d87aabbaff76468dabf6e6121332c40fc1d83548d02a9d6a3759", size = 233107, upload-time = "2026-02-04T21:51:45.455Z" },
+    { url = "https://files.pythonhosted.org/packages/28/88/2ff917caff61e55f38bcdb27de06ee30597881b2cae44fbba7627be015c4/pywinpty-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:d4b6b7b0fe0cdcd02e956bd57cfe9f4e5a06514eecf3b5ae174da4f951b58be9", size = 2113282, upload-time = "2026-02-04T21:52:08.188Z" },
+    { url = "https://files.pythonhosted.org/packages/63/32/40a775343ace542cc43ece3f1d1fce454021521ecac41c4c4573081c2336/pywinpty-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:34789d685fc0d547ce0c8a65e5a70e56f77d732fa6e03c8f74fefb8cbb252019", size = 234207, upload-time = "2026-02-04T21:51:58.687Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/54/5d5e52f4cb75028104ca6faf36c10f9692389b1986d34471663b4ebebd6d/pywinpty-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:0c37e224a47a971d1a6e08649a1714dac4f63c11920780977829ed5c8cadead1", size = 2112910, upload-time = "2026-02-04T21:52:30.976Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/44/dcd184824e21d4620b06c7db9fbb15c3ad0a0f1fa2e6de79969fb82647ec/pywinpty-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:c4e9c3dff7d86ba81937438d5819f19f385a39d8f592d4e8af67148ceb4f6ab5", size = 233425, upload-time = "2026-02-04T21:51:56.754Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "pyzmq"
+version = "27.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "implementation_name == 'pypy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/0b/3c9baedbdf613ecaa7aa07027780b8867f57b6293b6ee50de316c9f3222b/pyzmq-27.1.0.tar.gz", hash = "sha256:ac0765e3d44455adb6ddbf4417dcce460fc40a05978c08efdf2948072f6db540", size = 281750, upload-time = "2025-09-08T23:10:18.157Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/e7/038aab64a946d535901103da16b953c8c9cc9c961dadcbf3609ed6428d23/pyzmq-27.1.0-cp312-abi3-macosx_10_15_universal2.whl", hash = "sha256:452631b640340c928fa343801b0d07eb0c3789a5ffa843f6e1a9cee0ba4eb4fc", size = 1306279, upload-time = "2025-09-08T23:08:03.807Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/5e/c3c49fdd0f535ef45eefcc16934648e9e59dace4a37ee88fc53f6cd8e641/pyzmq-27.1.0-cp312-abi3-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:1c179799b118e554b66da67d88ed66cd37a169f1f23b5d9f0a231b4e8d44a113", size = 895645, upload-time = "2025-09-08T23:08:05.301Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e5/b0b2504cb4e903a74dcf1ebae157f9e20ebb6ea76095f6cfffea28c42ecd/pyzmq-27.1.0-cp312-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3837439b7f99e60312f0c926a6ad437b067356dc2bc2ec96eb395fd0fe804233", size = 652574, upload-time = "2025-09-08T23:08:06.828Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/9b/c108cdb55560eaf253f0cbdb61b29971e9fb34d9c3499b0e96e4e60ed8a5/pyzmq-27.1.0-cp312-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43ad9a73e3da1fab5b0e7e13402f0b2fb934ae1c876c51d0afff0e7c052eca31", size = 840995, upload-time = "2025-09-08T23:08:08.396Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/bb/b79798ca177b9eb0825b4c9998c6af8cd2a7f15a6a1a4272c1d1a21d382f/pyzmq-27.1.0-cp312-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:0de3028d69d4cdc475bfe47a6128eb38d8bc0e8f4d69646adfbcd840facbac28", size = 1642070, upload-time = "2025-09-08T23:08:09.989Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/80/2df2e7977c4ede24c79ae39dcef3899bfc5f34d1ca7a5b24f182c9b7a9ca/pyzmq-27.1.0-cp312-abi3-musllinux_1_2_i686.whl", hash = "sha256:cf44a7763aea9298c0aa7dbf859f87ed7012de8bda0f3977b6fb1d96745df856", size = 2021121, upload-time = "2025-09-08T23:08:11.907Z" },
+    { url = "https://files.pythonhosted.org/packages/46/bd/2d45ad24f5f5ae7e8d01525eb76786fa7557136555cac7d929880519e33a/pyzmq-27.1.0-cp312-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:f30f395a9e6fbca195400ce833c731e7b64c3919aa481af4d88c3759e0cb7496", size = 1878550, upload-time = "2025-09-08T23:08:13.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/2f/104c0a3c778d7c2ab8190e9db4f62f0b6957b53c9d87db77c284b69f33ea/pyzmq-27.1.0-cp312-abi3-win32.whl", hash = "sha256:250e5436a4ba13885494412b3da5d518cd0d3a278a1ae640e113c073a5f88edd", size = 559184, upload-time = "2025-09-08T23:08:15.163Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/7f/a21b20d577e4100c6a41795842028235998a643b1ad406a6d4163ea8f53e/pyzmq-27.1.0-cp312-abi3-win_amd64.whl", hash = "sha256:9ce490cf1d2ca2ad84733aa1d69ce6855372cb5ce9223802450c9b2a7cba0ccf", size = 619480, upload-time = "2025-09-08T23:08:17.192Z" },
+    { url = "https://files.pythonhosted.org/packages/78/c2/c012beae5f76b72f007a9e91ee9401cb88c51d0f83c6257a03e785c81cc2/pyzmq-27.1.0-cp312-abi3-win_arm64.whl", hash = "sha256:75a2f36223f0d535a0c919e23615fc85a1e23b71f40c7eb43d7b1dedb4d8f15f", size = 552993, upload-time = "2025-09-08T23:08:18.926Z" },
+    { url = "https://files.pythonhosted.org/packages/60/cb/84a13459c51da6cec1b7b1dc1a47e6db6da50b77ad7fd9c145842750a011/pyzmq-27.1.0-cp313-cp313-android_24_arm64_v8a.whl", hash = "sha256:93ad4b0855a664229559e45c8d23797ceac03183c7b6f5b4428152a6b06684a5", size = 1122436, upload-time = "2025-09-08T23:08:20.801Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/b6/94414759a69a26c3dd674570a81813c46a078767d931a6c70ad29fc585cb/pyzmq-27.1.0-cp313-cp313-android_24_x86_64.whl", hash = "sha256:fbb4f2400bfda24f12f009cba62ad5734148569ff4949b1b6ec3b519444342e6", size = 1156301, upload-time = "2025-09-08T23:08:22.47Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/ad/15906493fd40c316377fd8a8f6b1f93104f97a752667763c9b9c1b71d42d/pyzmq-27.1.0-cp313-cp313t-macosx_10_15_universal2.whl", hash = "sha256:e343d067f7b151cfe4eb3bb796a7752c9d369eed007b91231e817071d2c2fec7", size = 1341197, upload-time = "2025-09-08T23:08:24.286Z" },
+    { url = "https://files.pythonhosted.org/packages/14/1d/d343f3ce13db53a54cb8946594e567410b2125394dafcc0268d8dda027e0/pyzmq-27.1.0-cp313-cp313t-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:08363b2011dec81c354d694bdecaef4770e0ae96b9afea70b3f47b973655cc05", size = 897275, upload-time = "2025-09-08T23:08:26.063Z" },
+    { url = "https://files.pythonhosted.org/packages/69/2d/d83dd6d7ca929a2fc67d2c3005415cdf322af7751d773524809f9e585129/pyzmq-27.1.0-cp313-cp313t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d54530c8c8b5b8ddb3318f481297441af102517602b569146185fa10b63f4fa9", size = 660469, upload-time = "2025-09-08T23:08:27.623Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/cd/9822a7af117f4bc0f1952dbe9ef8358eb50a24928efd5edf54210b850259/pyzmq-27.1.0-cp313-cp313t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6f3afa12c392f0a44a2414056d730eebc33ec0926aae92b5ad5cf26ebb6cc128", size = 847961, upload-time = "2025-09-08T23:08:29.672Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/12/f003e824a19ed73be15542f172fd0ec4ad0b60cf37436652c93b9df7c585/pyzmq-27.1.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c65047adafe573ff023b3187bb93faa583151627bc9c51fc4fb2c561ed689d39", size = 1650282, upload-time = "2025-09-08T23:08:31.349Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/4a/e82d788ed58e9a23995cee70dbc20c9aded3d13a92d30d57ec2291f1e8a3/pyzmq-27.1.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:90e6e9441c946a8b0a667356f7078d96411391a3b8f80980315455574177ec97", size = 2024468, upload-time = "2025-09-08T23:08:33.543Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/94/2da0a60841f757481e402b34bf4c8bf57fa54a5466b965de791b1e6f747d/pyzmq-27.1.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:add071b2d25f84e8189aaf0882d39a285b42fa3853016ebab234a5e78c7a43db", size = 1885394, upload-time = "2025-09-08T23:08:35.51Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/6f/55c10e2e49ad52d080dc24e37adb215e5b0d64990b57598abc2e3f01725b/pyzmq-27.1.0-cp313-cp313t-win32.whl", hash = "sha256:7ccc0700cfdf7bd487bea8d850ec38f204478681ea02a582a8da8171b7f90a1c", size = 574964, upload-time = "2025-09-08T23:08:37.178Z" },
+    { url = "https://files.pythonhosted.org/packages/87/4d/2534970ba63dd7c522d8ca80fb92777f362c0f321900667c615e2067cb29/pyzmq-27.1.0-cp313-cp313t-win_amd64.whl", hash = "sha256:8085a9fba668216b9b4323be338ee5437a235fe275b9d1610e422ccc279733e2", size = 641029, upload-time = "2025-09-08T23:08:40.595Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/fa/f8aea7a28b0641f31d40dea42d7ef003fded31e184ef47db696bc74cd610/pyzmq-27.1.0-cp313-cp313t-win_arm64.whl", hash = "sha256:6bb54ca21bcfe361e445256c15eedf083f153811c37be87e0514934d6913061e", size = 561541, upload-time = "2025-09-08T23:08:42.668Z" },
+    { url = "https://files.pythonhosted.org/packages/87/45/19efbb3000956e82d0331bafca5d9ac19ea2857722fa2caacefb6042f39d/pyzmq-27.1.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:ce980af330231615756acd5154f29813d553ea555485ae712c491cd483df6b7a", size = 1341197, upload-time = "2025-09-08T23:08:44.973Z" },
+    { url = "https://files.pythonhosted.org/packages/48/43/d72ccdbf0d73d1343936296665826350cb1e825f92f2db9db3e61c2162a2/pyzmq-27.1.0-cp314-cp314t-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:1779be8c549e54a1c38f805e56d2a2e5c009d26de10921d7d51cfd1c8d4632ea", size = 897175, upload-time = "2025-09-08T23:08:46.601Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/2e/a483f73a10b65a9ef0161e817321d39a770b2acf8bcf3004a28d90d14a94/pyzmq-27.1.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7200bb0f03345515df50d99d3db206a0a6bee1955fbb8c453c76f5bf0e08fb96", size = 660427, upload-time = "2025-09-08T23:08:48.187Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/d2/5f36552c2d3e5685abe60dfa56f91169f7a2d99bbaf67c5271022ab40863/pyzmq-27.1.0-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01c0e07d558b06a60773744ea6251f769cd79a41a97d11b8bf4ab8f034b0424d", size = 847929, upload-time = "2025-09-08T23:08:49.76Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/2a/404b331f2b7bf3198e9945f75c4c521f0c6a3a23b51f7a4a401b94a13833/pyzmq-27.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:80d834abee71f65253c91540445d37c4c561e293ba6e741b992f20a105d69146", size = 1650193, upload-time = "2025-09-08T23:08:51.7Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/0b/f4107e33f62a5acf60e3ded67ed33d79b4ce18de432625ce2fc5093d6388/pyzmq-27.1.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:544b4e3b7198dde4a62b8ff6685e9802a9a1ebf47e77478a5eb88eca2a82f2fd", size = 2024388, upload-time = "2025-09-08T23:08:53.393Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/01/add31fe76512642fd6e40e3a3bd21f4b47e242c8ba33efb6809e37076d9b/pyzmq-27.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cedc4c68178e59a4046f97eca31b148ddcf51e88677de1ef4e78cf06c5376c9a", size = 1885316, upload-time = "2025-09-08T23:08:55.702Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/59/a5f38970f9bf07cee96128de79590bb354917914a9be11272cfc7ff26af0/pyzmq-27.1.0-cp314-cp314t-win32.whl", hash = "sha256:1f0b2a577fd770aa6f053211a55d1c47901f4d537389a034c690291485e5fe92", size = 587472, upload-time = "2025-09-08T23:08:58.18Z" },
+    { url = "https://files.pythonhosted.org/packages/70/d8/78b1bad170f93fcf5e3536e70e8fadac55030002275c9a29e8f5719185de/pyzmq-27.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:19c9468ae0437f8074af379e986c5d3d7d7bfe033506af442e8c879732bedbe0", size = 661401, upload-time = "2025-09-08T23:08:59.802Z" },
+    { url = "https://files.pythonhosted.org/packages/81/d6/4bfbb40c9a0b42fc53c7cf442f6385db70b40f74a783130c5d0a5aa62228/pyzmq-27.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:dc5dbf68a7857b59473f7df42650c621d7e8923fb03fa74a526890f4d33cc4d7", size = 575170, upload-time = "2025-09-08T23:09:01.418Z" },
+]
+
+[[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.33.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
+]
+
+[[package]]
+name = "rfc3339-validator"
+version = "0.1.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/28/ea/a9387748e2d111c3c2b275ba970b735e04e15cdb1eb30693b6b5708c4dbd/rfc3339_validator-0.1.4.tar.gz", hash = "sha256:138a2abdf93304ad60530167e51d2dfb9549521a836871b88d7f4695d0022f6b", size = 5513, upload-time = "2021-05-12T16:37:54.178Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/44/4e421b96b67b2daff264473f7465db72fbdf36a07e05494f50300cc7b0c6/rfc3339_validator-0.1.4-py2.py3-none-any.whl", hash = "sha256:24f6ec1eda14ef823da9e36ec7113124b39c04d50a4d3d3a3c2859577e7791fa", size = 3490, upload-time = "2021-05-12T16:37:52.536Z" },
+]
+
+[[package]]
+name = "rfc3986-validator"
+version = "0.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/88/f270de456dd7d11dcc808abfa291ecdd3f45ff44e3b549ffa01b126464d0/rfc3986_validator-0.1.1.tar.gz", hash = "sha256:3d44bde7921b3b9ec3ae4e3adca370438eccebc676456449b145d533b240d055", size = 6760, upload-time = "2019-10-28T16:00:19.144Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/51/17023c0f8f1869d8806b979a2bffa3f861f26a3f1a66b094288323fba52f/rfc3986_validator-0.1.1-py2.py3-none-any.whl", hash = "sha256:2f235c432ef459970b4306369336b9d5dbdda31b510ca1e327636e01f528bfa9", size = 4242, upload-time = "2019-10-28T16:00:13.976Z" },
+]
+
+[[package]]
+name = "rfc3987-syntax"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lark" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2c/06/37c1a5557acf449e8e406a830a05bf885ac47d33270aec454ef78675008d/rfc3987_syntax-1.1.0.tar.gz", hash = "sha256:717a62cbf33cffdd16dfa3a497d81ce48a660ea691b1ddd7be710c22f00b4a0d", size = 14239, upload-time = "2025-07-18T01:05:05.015Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/71/44ce230e1b7fadd372515a97e32a83011f906ddded8d03e3c6aafbdedbb7/rfc3987_syntax-1.1.0-py3-none-any.whl", hash = "sha256:6c3d97604e4c5ce9f714898e05401a0445a641cfa276432b0a648c80856f6a3f", size = 8046, upload-time = "2025-07-18T01:05:03.843Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "0.30.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/af/3f2f423103f1113b36230496629986e0ef7e199d2aa8392452b484b38ced/rpds_py-0.30.0.tar.gz", hash = "sha256:dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84", size = 69469, upload-time = "2025-11-30T20:24:38.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/e7/98a2f4ac921d82f33e03f3835f5bf3a4a40aa1bfdc57975e74a97b2b4bdd/rpds_py-0.30.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a161f20d9a43006833cd7068375a94d035714d73a172b681d8881820600abfad", size = 375086, upload-time = "2025-11-30T20:22:17.93Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/a1/bca7fd3d452b272e13335db8d6b0b3ecde0f90ad6f16f3328c6fb150c889/rpds_py-0.30.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6abc8880d9d036ecaafe709079969f56e876fcf107f7a8e9920ba6d5a3878d05", size = 359053, upload-time = "2025-11-30T20:22:19.297Z" },
+    { url = "https://files.pythonhosted.org/packages/65/1c/ae157e83a6357eceff62ba7e52113e3ec4834a84cfe07fa4b0757a7d105f/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca28829ae5f5d569bb62a79512c842a03a12576375d5ece7d2cadf8abe96ec28", size = 390763, upload-time = "2025-11-30T20:22:21.661Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/36/eb2eb8515e2ad24c0bd43c3ee9cd74c33f7ca6430755ccdb240fd3144c44/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a1010ed9524c73b94d15919ca4d41d8780980e1765babf85f9a2f90d247153dd", size = 408951, upload-time = "2025-11-30T20:22:23.408Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/65/ad8dc1784a331fabbd740ef6f71ce2198c7ed0890dab595adb9ea2d775a1/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f8d1736cfb49381ba528cd5baa46f82fdc65c06e843dab24dd70b63d09121b3f", size = 514622, upload-time = "2025-11-30T20:22:25.16Z" },
+    { url = "https://files.pythonhosted.org/packages/63/8e/0cfa7ae158e15e143fe03993b5bcd743a59f541f5952e1546b1ac1b5fd45/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d948b135c4693daff7bc2dcfc4ec57237a29bd37e60c2fabf5aff2bbacf3e2f1", size = 414492, upload-time = "2025-11-30T20:22:26.505Z" },
+    { url = "https://files.pythonhosted.org/packages/60/1b/6f8f29f3f995c7ffdde46a626ddccd7c63aefc0efae881dc13b6e5d5bb16/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47f236970bccb2233267d89173d3ad2703cd36a0e2a6e92d0560d333871a3d23", size = 394080, upload-time = "2025-11-30T20:22:27.934Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/d5/a266341051a7a3ca2f4b750a3aa4abc986378431fc2da508c5034d081b70/rpds_py-0.30.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:2e6ecb5a5bcacf59c3f912155044479af1d0b6681280048b338b28e364aca1f6", size = 408680, upload-time = "2025-11-30T20:22:29.341Z" },
+    { url = "https://files.pythonhosted.org/packages/10/3b/71b725851df9ab7a7a4e33cf36d241933da66040d195a84781f49c50490c/rpds_py-0.30.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a8fa71a2e078c527c3e9dc9fc5a98c9db40bcc8a92b4e8858e36d329f8684b51", size = 423589, upload-time = "2025-11-30T20:22:31.469Z" },
+    { url = "https://files.pythonhosted.org/packages/00/2b/e59e58c544dc9bd8bd8384ecdb8ea91f6727f0e37a7131baeff8d6f51661/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:73c67f2db7bc334e518d097c6d1e6fed021bbc9b7d678d6cc433478365d1d5f5", size = 573289, upload-time = "2025-11-30T20:22:32.997Z" },
+    { url = "https://files.pythonhosted.org/packages/da/3e/a18e6f5b460893172a7d6a680e86d3b6bc87a54c1f0b03446a3c8c7b588f/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5ba103fb455be00f3b1c2076c9d4264bfcb037c976167a6047ed82f23153f02e", size = 599737, upload-time = "2025-11-30T20:22:34.419Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e2/714694e4b87b85a18e2c243614974413c60aa107fd815b8cbc42b873d1d7/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7cee9c752c0364588353e627da8a7e808a66873672bcb5f52890c33fd965b394", size = 563120, upload-time = "2025-11-30T20:22:35.903Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/ab/d5d5e3bcedb0a77f4f613706b750e50a5a3ba1c15ccd3665ecc636c968fd/rpds_py-0.30.0-cp312-cp312-win32.whl", hash = "sha256:1ab5b83dbcf55acc8b08fc62b796ef672c457b17dbd7820a11d6c52c06839bdf", size = 223782, upload-time = "2025-11-30T20:22:37.271Z" },
+    { url = "https://files.pythonhosted.org/packages/39/3b/f786af9957306fdc38a74cef405b7b93180f481fb48453a114bb6465744a/rpds_py-0.30.0-cp312-cp312-win_amd64.whl", hash = "sha256:a090322ca841abd453d43456ac34db46e8b05fd9b3b4ac0c78bcde8b089f959b", size = 240463, upload-time = "2025-11-30T20:22:39.021Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d2/b91dc748126c1559042cfe41990deb92c4ee3e2b415f6b5234969ffaf0cc/rpds_py-0.30.0-cp312-cp312-win_arm64.whl", hash = "sha256:669b1805bd639dd2989b281be2cfd951c6121b65e729d9b843e9639ef1fd555e", size = 230868, upload-time = "2025-11-30T20:22:40.493Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/dc/d61221eb88ff410de3c49143407f6f3147acf2538c86f2ab7ce65ae7d5f9/rpds_py-0.30.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:f83424d738204d9770830d35290ff3273fbb02b41f919870479fab14b9d303b2", size = 374887, upload-time = "2025-11-30T20:22:41.812Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/32/55fb50ae104061dbc564ef15cc43c013dc4a9f4527a1f4d99baddf56fe5f/rpds_py-0.30.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e7536cd91353c5273434b4e003cbda89034d67e7710eab8761fd918ec6c69cf8", size = 358904, upload-time = "2025-11-30T20:22:43.479Z" },
+    { url = "https://files.pythonhosted.org/packages/58/70/faed8186300e3b9bdd138d0273109784eea2396c68458ed580f885dfe7ad/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2771c6c15973347f50fece41fc447c054b7ac2ae0502388ce3b6738cd366e3d4", size = 389945, upload-time = "2025-11-30T20:22:44.819Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/a8/073cac3ed2c6387df38f71296d002ab43496a96b92c823e76f46b8af0543/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0a59119fc6e3f460315fe9d08149f8102aa322299deaa5cab5b40092345c2136", size = 407783, upload-time = "2025-11-30T20:22:46.103Z" },
+    { url = "https://files.pythonhosted.org/packages/77/57/5999eb8c58671f1c11eba084115e77a8899d6e694d2a18f69f0ba471ec8b/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:76fec018282b4ead0364022e3c54b60bf368b9d926877957a8624b58419169b7", size = 515021, upload-time = "2025-11-30T20:22:47.458Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/af/5ab4833eadc36c0a8ed2bc5c0de0493c04f6c06de223170bd0798ff98ced/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:692bef75a5525db97318e8cd061542b5a79812d711ea03dbc1f6f8dbb0c5f0d2", size = 414589, upload-time = "2025-11-30T20:22:48.872Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/de/f7192e12b21b9e9a68a6d0f249b4af3fdcdff8418be0767a627564afa1f1/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9027da1ce107104c50c81383cae773ef5c24d296dd11c99e2629dbd7967a20c6", size = 394025, upload-time = "2025-11-30T20:22:50.196Z" },
+    { url = "https://files.pythonhosted.org/packages/91/c4/fc70cd0249496493500e7cc2de87504f5aa6509de1e88623431fec76d4b6/rpds_py-0.30.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:9cf69cdda1f5968a30a359aba2f7f9aa648a9ce4b580d6826437f2b291cfc86e", size = 408895, upload-time = "2025-11-30T20:22:51.87Z" },
+    { url = "https://files.pythonhosted.org/packages/58/95/d9275b05ab96556fefff73a385813eb66032e4c99f411d0795372d9abcea/rpds_py-0.30.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a4796a717bf12b9da9d3ad002519a86063dcac8988b030e405704ef7d74d2d9d", size = 422799, upload-time = "2025-11-30T20:22:53.341Z" },
+    { url = "https://files.pythonhosted.org/packages/06/c1/3088fc04b6624eb12a57eb814f0d4997a44b0d208d6cace713033ff1a6ba/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5d4c2aa7c50ad4728a094ebd5eb46c452e9cb7edbfdb18f9e1221f597a73e1e7", size = 572731, upload-time = "2025-11-30T20:22:54.778Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/42/c612a833183b39774e8ac8fecae81263a68b9583ee343db33ab571a7ce55/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ba81a9203d07805435eb06f536d95a266c21e5b2dfbf6517748ca40c98d19e31", size = 599027, upload-time = "2025-11-30T20:22:56.212Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/60/525a50f45b01d70005403ae0e25f43c0384369ad24ffe46e8d9068b50086/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:945dccface01af02675628334f7cf49c2af4c1c904748efc5cf7bbdf0b579f95", size = 563020, upload-time = "2025-11-30T20:22:58.2Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/5d/47c4655e9bcd5ca907148535c10e7d489044243cc9941c16ed7cd53be91d/rpds_py-0.30.0-cp313-cp313-win32.whl", hash = "sha256:b40fb160a2db369a194cb27943582b38f79fc4887291417685f3ad693c5a1d5d", size = 223139, upload-time = "2025-11-30T20:23:00.209Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/e1/485132437d20aa4d3e1d8b3fb5a5e65aa8139f1e097080c2a8443201742c/rpds_py-0.30.0-cp313-cp313-win_amd64.whl", hash = "sha256:806f36b1b605e2d6a72716f321f20036b9489d29c51c91f4dd29a3e3afb73b15", size = 240224, upload-time = "2025-11-30T20:23:02.008Z" },
+    { url = "https://files.pythonhosted.org/packages/24/95/ffd128ed1146a153d928617b0ef673960130be0009c77d8fbf0abe306713/rpds_py-0.30.0-cp313-cp313-win_arm64.whl", hash = "sha256:d96c2086587c7c30d44f31f42eae4eac89b60dabbac18c7669be3700f13c3ce1", size = 230645, upload-time = "2025-11-30T20:23:03.43Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/1b/b10de890a0def2a319a2626334a7f0ae388215eb60914dbac8a3bae54435/rpds_py-0.30.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:eb0b93f2e5c2189ee831ee43f156ed34e2a89a78a66b98cadad955972548be5a", size = 364443, upload-time = "2025-11-30T20:23:04.878Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/bf/27e39f5971dc4f305a4fb9c672ca06f290f7c4e261c568f3dea16a410d47/rpds_py-0.30.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:922e10f31f303c7c920da8981051ff6d8c1a56207dbdf330d9047f6d30b70e5e", size = 353375, upload-time = "2025-11-30T20:23:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/40/58/442ada3bba6e8e6615fc00483135c14a7538d2ffac30e2d933ccf6852232/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cdc62c8286ba9bf7f47befdcea13ea0e26bf294bda99758fd90535cbaf408000", size = 383850, upload-time = "2025-11-30T20:23:07.825Z" },
+    { url = "https://files.pythonhosted.org/packages/14/14/f59b0127409a33c6ef6f5c1ebd5ad8e32d7861c9c7adfa9a624fc3889f6c/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:47f9a91efc418b54fb8190a6b4aa7813a23fb79c51f4bb84e418f5476c38b8db", size = 392812, upload-time = "2025-11-30T20:23:09.228Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/66/e0be3e162ac299b3a22527e8913767d869e6cc75c46bd844aa43fb81ab62/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1f3587eb9b17f3789ad50824084fa6f81921bbf9a795826570bda82cb3ed91f2", size = 517841, upload-time = "2025-11-30T20:23:11.186Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/55/fa3b9cf31d0c963ecf1ba777f7cf4b2a2c976795ac430d24a1f43d25a6ba/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:39c02563fc592411c2c61d26b6c5fe1e51eaa44a75aa2c8735ca88b0d9599daa", size = 408149, upload-time = "2025-11-30T20:23:12.864Z" },
+    { url = "https://files.pythonhosted.org/packages/60/ca/780cf3b1a32b18c0f05c441958d3758f02544f1d613abf9488cd78876378/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51a1234d8febafdfd33a42d97da7a43f5dcb120c1060e352a3fbc0c6d36e2083", size = 383843, upload-time = "2025-11-30T20:23:14.638Z" },
+    { url = "https://files.pythonhosted.org/packages/82/86/d5f2e04f2aa6247c613da0c1dd87fcd08fa17107e858193566048a1e2f0a/rpds_py-0.30.0-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:eb2c4071ab598733724c08221091e8d80e89064cd472819285a9ab0f24bcedb9", size = 396507, upload-time = "2025-11-30T20:23:16.105Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/9a/453255d2f769fe44e07ea9785c8347edaf867f7026872e76c1ad9f7bed92/rpds_py-0.30.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6bdfdb946967d816e6adf9a3d8201bfad269c67efe6cefd7093ef959683c8de0", size = 414949, upload-time = "2025-11-30T20:23:17.539Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/31/622a86cdc0c45d6df0e9ccb6becdba5074735e7033c20e401a6d9d0e2ca0/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c77afbd5f5250bf27bf516c7c4a016813eb2d3e116139aed0096940c5982da94", size = 565790, upload-time = "2025-11-30T20:23:19.029Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/5d/15bbf0fb4a3f58a3b1c67855ec1efcc4ceaef4e86644665fff03e1b66d8d/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:61046904275472a76c8c90c9ccee9013d70a6d0f73eecefd38c1ae7c39045a08", size = 590217, upload-time = "2025-11-30T20:23:20.885Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/61/21b8c41f68e60c8cc3b2e25644f0e3681926020f11d06ab0b78e3c6bbff1/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4c5f36a861bc4b7da6516dbdf302c55313afa09b81931e8280361a4f6c9a2d27", size = 555806, upload-time = "2025-11-30T20:23:22.488Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/39/7e067bb06c31de48de3eb200f9fc7c58982a4d3db44b07e73963e10d3be9/rpds_py-0.30.0-cp313-cp313t-win32.whl", hash = "sha256:3d4a69de7a3e50ffc214ae16d79d8fbb0922972da0356dcf4d0fdca2878559c6", size = 211341, upload-time = "2025-11-30T20:23:24.449Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/4d/222ef0b46443cf4cf46764d9c630f3fe4abaa7245be9417e56e9f52b8f65/rpds_py-0.30.0-cp313-cp313t-win_amd64.whl", hash = "sha256:f14fc5df50a716f7ece6a80b6c78bb35ea2ca47c499e422aa4463455dd96d56d", size = 225768, upload-time = "2025-11-30T20:23:25.908Z" },
+    { url = "https://files.pythonhosted.org/packages/86/81/dad16382ebbd3d0e0328776d8fd7ca94220e4fa0798d1dc5e7da48cb3201/rpds_py-0.30.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:68f19c879420aa08f61203801423f6cd5ac5f0ac4ac82a2368a9fcd6a9a075e0", size = 362099, upload-time = "2025-11-30T20:23:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/60/19f7884db5d5603edf3c6bce35408f45ad3e97e10007df0e17dd57af18f8/rpds_py-0.30.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ec7c4490c672c1a0389d319b3a9cfcd098dcdc4783991553c332a15acf7249be", size = 353192, upload-time = "2025-11-30T20:23:29.151Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/c4/76eb0e1e72d1a9c4703c69607cec123c29028bff28ce41588792417098ac/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f251c812357a3fed308d684a5079ddfb9d933860fc6de89f2b7ab00da481e65f", size = 384080, upload-time = "2025-11-30T20:23:30.785Z" },
+    { url = "https://files.pythonhosted.org/packages/72/87/87ea665e92f3298d1b26d78814721dc39ed8d2c74b86e83348d6b48a6f31/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ac98b175585ecf4c0348fd7b29c3864bda53b805c773cbf7bfdaffc8070c976f", size = 394841, upload-time = "2025-11-30T20:23:32.209Z" },
+    { url = "https://files.pythonhosted.org/packages/77/ad/7783a89ca0587c15dcbf139b4a8364a872a25f861bdb88ed99f9b0dec985/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3e62880792319dbeb7eb866547f2e35973289e7d5696c6e295476448f5b63c87", size = 516670, upload-time = "2025-11-30T20:23:33.742Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/3c/2882bdac942bd2172f3da574eab16f309ae10a3925644e969536553cb4ee/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4e7fc54e0900ab35d041b0601431b0a0eb495f0851a0639b6ef90f7741b39a18", size = 408005, upload-time = "2025-11-30T20:23:35.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/81/9a91c0111ce1758c92516a3e44776920b579d9a7c09b2b06b642d4de3f0f/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47e77dc9822d3ad616c3d5759ea5631a75e5809d5a28707744ef79d7a1bcfcad", size = 382112, upload-time = "2025-11-30T20:23:36.842Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/8e/1da49d4a107027e5fbc64daeab96a0706361a2918da10cb41769244b805d/rpds_py-0.30.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:b4dc1a6ff022ff85ecafef7979a2c6eb423430e05f1165d6688234e62ba99a07", size = 399049, upload-time = "2025-11-30T20:23:38.343Z" },
+    { url = "https://files.pythonhosted.org/packages/df/5a/7ee239b1aa48a127570ec03becbb29c9d5a9eb092febbd1699d567cae859/rpds_py-0.30.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4559c972db3a360808309e06a74628b95eaccbf961c335c8fe0d590cf587456f", size = 415661, upload-time = "2025-11-30T20:23:40.263Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ea/caa143cf6b772f823bc7929a45da1fa83569ee49b11d18d0ada7f5ee6fd6/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0ed177ed9bded28f8deb6ab40c183cd1192aa0de40c12f38be4d59cd33cb5c65", size = 565606, upload-time = "2025-11-30T20:23:42.186Z" },
+    { url = "https://files.pythonhosted.org/packages/64/91/ac20ba2d69303f961ad8cf55bf7dbdb4763f627291ba3d0d7d67333cced9/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ad1fa8db769b76ea911cb4e10f049d80bf518c104f15b3edb2371cc65375c46f", size = 591126, upload-time = "2025-11-30T20:23:44.086Z" },
+    { url = "https://files.pythonhosted.org/packages/21/20/7ff5f3c8b00c8a95f75985128c26ba44503fb35b8e0259d812766ea966c7/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:46e83c697b1f1c72b50e5ee5adb4353eef7406fb3f2043d64c33f20ad1c2fc53", size = 553371, upload-time = "2025-11-30T20:23:46.004Z" },
+    { url = "https://files.pythonhosted.org/packages/72/c7/81dadd7b27c8ee391c132a6b192111ca58d866577ce2d9b0ca157552cce0/rpds_py-0.30.0-cp314-cp314-win32.whl", hash = "sha256:ee454b2a007d57363c2dfd5b6ca4a5d7e2c518938f8ed3b706e37e5d470801ed", size = 215298, upload-time = "2025-11-30T20:23:47.696Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d2/1aaac33287e8cfb07aab2e6b8ac1deca62f6f65411344f1433c55e6f3eb8/rpds_py-0.30.0-cp314-cp314-win_amd64.whl", hash = "sha256:95f0802447ac2d10bcc69f6dc28fe95fdf17940367b21d34e34c737870758950", size = 228604, upload-time = "2025-11-30T20:23:49.501Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/95/ab005315818cc519ad074cb7784dae60d939163108bd2b394e60dc7b5461/rpds_py-0.30.0-cp314-cp314-win_arm64.whl", hash = "sha256:613aa4771c99f03346e54c3f038e4cc574ac09a3ddfb0e8878487335e96dead6", size = 222391, upload-time = "2025-11-30T20:23:50.96Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/68/154fe0194d83b973cdedcdcc88947a2752411165930182ae41d983dcefa6/rpds_py-0.30.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:7e6ecfcb62edfd632e56983964e6884851786443739dbfe3582947e87274f7cb", size = 364868, upload-time = "2025-11-30T20:23:52.494Z" },
+    { url = "https://files.pythonhosted.org/packages/83/69/8bbc8b07ec854d92a8b75668c24d2abcb1719ebf890f5604c61c9369a16f/rpds_py-0.30.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a1d0bc22a7cdc173fedebb73ef81e07faef93692b8c1ad3733b67e31e1b6e1b8", size = 353747, upload-time = "2025-11-30T20:23:54.036Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/00/ba2e50183dbd9abcce9497fa5149c62b4ff3e22d338a30d690f9af970561/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d08f00679177226c4cb8c5265012eea897c8ca3b93f429e546600c971bcbae7", size = 383795, upload-time = "2025-11-30T20:23:55.556Z" },
+    { url = "https://files.pythonhosted.org/packages/05/6f/86f0272b84926bcb0e4c972262f54223e8ecc556b3224d281e6598fc9268/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5965af57d5848192c13534f90f9dd16464f3c37aaf166cc1da1cae1fd5a34898", size = 393330, upload-time = "2025-11-30T20:23:57.033Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/e9/0e02bb2e6dc63d212641da45df2b0bf29699d01715913e0d0f017ee29438/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9a4e86e34e9ab6b667c27f3211ca48f73dba7cd3d90f8d5b11be56e5dbc3fb4e", size = 518194, upload-time = "2025-11-30T20:23:58.637Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ca/be7bca14cf21513bdf9c0606aba17d1f389ea2b6987035eb4f62bd923f25/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e5d3e6b26f2c785d65cc25ef1e5267ccbe1b069c5c21b8cc724efee290554419", size = 408340, upload-time = "2025-11-30T20:24:00.2Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c7/736e00ebf39ed81d75544c0da6ef7b0998f8201b369acf842f9a90dc8fce/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:626a7433c34566535b6e56a1b39a7b17ba961e97ce3b80ec62e6f1312c025551", size = 383765, upload-time = "2025-11-30T20:24:01.759Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/3f/da50dfde9956aaf365c4adc9533b100008ed31aea635f2b8d7b627e25b49/rpds_py-0.30.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:acd7eb3f4471577b9b5a41baf02a978e8bdeb08b4b355273994f8b87032000a8", size = 396834, upload-time = "2025-11-30T20:24:03.687Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/00/34bcc2565b6020eab2623349efbdec810676ad571995911f1abdae62a3a0/rpds_py-0.30.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fe5fa731a1fa8a0a56b0977413f8cacac1768dad38d16b3a296712709476fbd5", size = 415470, upload-time = "2025-11-30T20:24:05.232Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/28/882e72b5b3e6f718d5453bd4d0d9cf8df36fddeb4ddbbab17869d5868616/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:74a3243a411126362712ee1524dfc90c650a503502f135d54d1b352bd01f2404", size = 565630, upload-time = "2025-11-30T20:24:06.878Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/97/04a65539c17692de5b85c6e293520fd01317fd878ea1995f0367d4532fb1/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:3e8eeb0544f2eb0d2581774be4c3410356eba189529a6b3e36bbbf9696175856", size = 591148, upload-time = "2025-11-30T20:24:08.445Z" },
+    { url = "https://files.pythonhosted.org/packages/85/70/92482ccffb96f5441aab93e26c4d66489eb599efdcf96fad90c14bbfb976/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:dbd936cde57abfee19ab3213cf9c26be06d60750e60a8e4dd85d1ab12c8b1f40", size = 556030, upload-time = "2025-11-30T20:24:10.956Z" },
+    { url = "https://files.pythonhosted.org/packages/20/53/7c7e784abfa500a2b6b583b147ee4bb5a2b3747a9166bab52fec4b5b5e7d/rpds_py-0.30.0-cp314-cp314t-win32.whl", hash = "sha256:dc824125c72246d924f7f796b4f63c1e9dc810c7d9e2355864b3c3a73d59ade0", size = 211570, upload-time = "2025-11-30T20:24:12.735Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/02/fa464cdfbe6b26e0600b62c528b72d8608f5cc49f96b8d6e38c95d60c676/rpds_py-0.30.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27f4b0e92de5bfbc6f86e43959e6edd1425c33b5e69aab0984a72047f2bcf1e3", size = 226532, upload-time = "2025-11-30T20:24:14.634Z" },
+]
+
+[[package]]
+name = "send2trash"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c5/f0/184b4b5f8d00f2a92cf96eec8967a3d550b52cf94362dad1100df9e48d57/send2trash-2.1.0.tar.gz", hash = "sha256:1c72b39f09457db3c05ce1d19158c2cbef4c32b8bedd02c155e49282b7ea7459", size = 17255, upload-time = "2026-01-14T06:27:36.056Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/78/504fdd027da3b84ff1aecd9f6957e65f35134534ccc6da8628eb71e76d3f/send2trash-2.1.0-py3-none-any.whl", hash = "sha256:0da2f112e6d6bb22de6aa6daa7e144831a4febf2a87261451c4ad849fe9a873c", size = 17610, upload-time = "2026-01-14T06:27:35.218Z" },
+]
+
+[[package]]
+name = "setuptools"
+version = "82.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.8.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/ae/2d9c981590ed9999a0d91755b47fc74f74de286b0f5cee14c9269041e6c4/soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349", size = 118627, upload-time = "2026-01-20T04:27:02.457Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95", size = 37016, upload-time = "2026-01-20T04:27:01.012Z" },
+]
+
+[[package]]
+name = "stack-data"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asttokens" },
+    { name = "executing" },
+    { name = "pure-eval" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/28/e3/55dcc2cfbc3ca9c29519eb6884dd1415ecb53b0e934862d3559ddcb7e20b/stack_data-0.6.3.tar.gz", hash = "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9", size = 44707, upload-time = "2023-09-30T13:58:05.479Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl", hash = "sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695", size = 24521, upload-time = "2023-09-30T13:58:03.53Z" },
+]
+
+[[package]]
+name = "terminado"
+version = "0.18.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ptyprocess", marker = "os_name != 'nt'" },
+    { name = "pywinpty", marker = "os_name == 'nt'" },
+    { name = "tornado" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8a/11/965c6fd8e5cc254f1fe142d547387da17a8ebfd75a3455f637c663fb38a0/terminado-0.18.1.tar.gz", hash = "sha256:de09f2c4b85de4765f7714688fff57d3e75bad1f909b589fde880460c753fd2e", size = 32701, upload-time = "2024-03-12T14:34:39.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/9e/2064975477fdc887e47ad42157e214526dcad8f317a948dee17e1659a62f/terminado-0.18.1-py3-none-any.whl", hash = "sha256:a4468e1b37bb318f8a86514f65814e1afc977cf29b3992a4500d9dd305dcceb0", size = 14154, upload-time = "2024-03-12T14:34:36.569Z" },
+]
+
+[[package]]
+name = "tinycss2"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "webencodings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7a/fd/7a5ee21fd08ff70d3d33a5781c255cbe779659bd03278feb98b19ee550f4/tinycss2-1.4.0.tar.gz", hash = "sha256:10c0972f6fc0fbee87c3edb76549357415e94548c1ae10ebccdea16fb404a9b7", size = 87085, upload-time = "2024-10-24T14:58:29.895Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/34/ebdc18bae6aa14fbee1a08b63c015c72b64868ff7dae68808ab500c492e2/tinycss2-1.4.0-py3-none-any.whl", hash = "sha256:3a49cf47b7675da0b15d0c6e1df8df4ebd96e9394bb905a5775adb0d884c5289", size = 26610, upload-time = "2024-10-24T14:58:28.029Z" },
+]
+
+[[package]]
+name = "tornado"
+version = "6.5.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/f1/3173dfa4a18db4a9b03e5d55325559dab51ee653763bb8745a75af491286/tornado-6.5.5.tar.gz", hash = "sha256:192b8f3ea91bd7f1f50c06955416ed76c6b72f96779b962f07f911b91e8d30e9", size = 516006, upload-time = "2026-03-10T21:31:02.067Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/8c/77f5097695f4dd8255ecbd08b2a1ed8ba8b953d337804dd7080f199e12bf/tornado-6.5.5-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:487dc9cc380e29f58c7ab88f9e27cdeef04b2140862e5076a66fb6bb68bb1bfa", size = 445983, upload-time = "2026-03-10T21:30:44.28Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/5e/7625b76cd10f98f1516c36ce0346de62061156352353ef2da44e5c21523c/tornado-6.5.5-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:65a7f1d46d4bb41df1ac99f5fcb685fb25c7e61613742d5108b010975a9a6521", size = 444246, upload-time = "2026-03-10T21:30:46.571Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/04/7b5705d5b3c0fab088f434f9c83edac1573830ca49ccf29fb83bf7178eec/tornado-6.5.5-cp39-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:e74c92e8e65086b338fd56333fb9a68b9f6f2fe7ad532645a290a464bcf46be5", size = 447229, upload-time = "2026-03-10T21:30:48.273Z" },
+    { url = "https://files.pythonhosted.org/packages/34/01/74e034a30ef59afb4097ef8659515e96a39d910b712a89af76f5e4e1f93c/tornado-6.5.5-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:435319e9e340276428bbdb4e7fa732c2d399386d1de5686cb331ec8eee754f07", size = 448192, upload-time = "2026-03-10T21:30:51.22Z" },
+    { url = "https://files.pythonhosted.org/packages/be/00/fe9e02c5a96429fce1a1d15a517f5d8444f9c412e0bb9eadfbe3b0fc55bf/tornado-6.5.5-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:3f54aa540bdbfee7b9eb268ead60e7d199de5021facd276819c193c0fb28ea4e", size = 448039, upload-time = "2026-03-10T21:30:53.52Z" },
+    { url = "https://files.pythonhosted.org/packages/82/9e/656ee4cec0398b1d18d0f1eb6372c41c6b889722641d84948351ae19556d/tornado-6.5.5-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:36abed1754faeb80fbd6e64db2758091e1320f6bba74a4cf8c09cd18ccce8aca", size = 447445, upload-time = "2026-03-10T21:30:55.541Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/76/4921c00511f88af86a33de770d64141170f1cfd9c00311aea689949e274e/tornado-6.5.5-cp39-abi3-win32.whl", hash = "sha256:dd3eafaaeec1c7f2f8fdcd5f964e8907ad788fe8a5a32c4426fbbdda621223b7", size = 448582, upload-time = "2026-03-10T21:30:57.142Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/23/f6c6112a04d28eed765e374435fb1a9198f73e1ec4b4024184f21faeb1ad/tornado-6.5.5-cp39-abi3-win_amd64.whl", hash = "sha256:6443a794ba961a9f619b1ae926a2e900ac20c34483eea67be4ed8f1e58d3ef7b", size = 448990, upload-time = "2026-03-10T21:30:58.857Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/c8/876602cbc96469911f0939f703453c1157b0c826ecb05bdd32e023397d4e/tornado-6.5.5-cp39-abi3-win_arm64.whl", hash = "sha256:2c9a876e094109333f888539ddb2de4361743e5d21eece20688e3e351e4990a6", size = 448016, upload-time = "2026-03-10T21:31:00.43Z" },
+]
+
+[[package]]
+name = "traitlets"
+version = "5.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/22/40f55b26baeab80c2d7b3f1db0682f8954e4617fee7d90ce634022ef05c6/traitlets-5.15.0.tar.gz", hash = "sha256:4fead733f81cf1c4c938e06f8ca4633896833c9d89eff878159457f4d4392971", size = 163197, upload-time = "2026-05-06T08:05:58.016Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/98/a9937a969d018a23badfea0b381f66783649d48e0ea6c41923265c3cbeb3/traitlets-5.15.0-py3-none-any.whl", hash = "sha256:fb36a18867a6803deab09f3c5e0fa81bb7b26a5c9e82501c9933f759166eff40", size = 85877, upload-time = "2026-05-06T08:05:55.853Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
+]
+
+[[package]]
+name = "uri-template"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/31/c7/0336f2bd0bcbada6ccef7aaa25e443c118a704f828a0620c6fa0207c1b64/uri-template-1.3.0.tar.gz", hash = "sha256:0e00f8eb65e18c7de20d595a14336e9f337ead580c70934141624b6d1ffdacc7", size = 21678, upload-time = "2023-06-21T01:49:05.374Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl", hash = "sha256:a44a133ea12d44a0c0f06d7d42a52d71282e77e2f937d8abd5655b8d56fc1363", size = 11140, upload-time = "2023-06-21T01:49:03.467Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/ee/afaf0f85a9a18fe47a67f1e4422ed6cf1fe642f0ae0a2f81166231303c52/wcwidth-0.7.0.tar.gz", hash = "sha256:90e3a7ea092341c44b99562e75d09e4d5160fe7a3974c6fb842a101a95e7eed0", size = 182132, upload-time = "2026-05-02T16:04:12.653Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/52/e465037f5375f43533d1a80b6923955201596a99142ed524d77b571a1418/wcwidth-0.7.0-py3-none-any.whl", hash = "sha256:5d69154c429a82910e241c738cd0e2976fac8a2dd47a1a805f4afed1c0f136f2", size = 110825, upload-time = "2026-05-02T16:04:11.033Z" },
+]
+
+[[package]]
+name = "webcolors"
+version = "25.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/7a/eb316761ec35664ea5174709a68bbd3389de60d4a1ebab8808bfc264ed67/webcolors-25.10.0.tar.gz", hash = "sha256:62abae86504f66d0f6364c2a8520de4a0c47b80c03fc3a5f1815fedbef7c19bf", size = 53491, upload-time = "2025-10-31T07:51:03.977Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e2/cc/e097523dd85c9cf5d354f78310927f1656c422bd7b2613b2db3e3f9a0f2c/webcolors-25.10.0-py3-none-any.whl", hash = "sha256:032c727334856fc0b968f63daa252a1ac93d33db2f5267756623c210e57a4f1d", size = 14905, upload-time = "2025-10-31T07:51:01.778Z" },
+]
+
+[[package]]
+name = "webencodings"
+version = "0.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/02/ae6ceac1baeda530866a85075641cec12989bd8d31af6d5ab4a3e8c92f47/webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923", size = 9721, upload-time = "2017-04-05T20:21:34.189Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl", hash = "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78", size = 11774, upload-time = "2017-04-05T20:21:32.581Z" },
+]
+
+[[package]]
+name = "websocket-client"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/41/aa4bf9664e4cda14c3b39865b12251e8e7d239f4cd0e3cc1b6c2ccde25c1/websocket_client-1.9.0.tar.gz", hash = "sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98", size = 70576, upload-time = "2025-10-07T21:16:36.495Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl", hash = "sha256:af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef", size = 82616, upload-time = "2025-10-07T21:16:34.951Z" },
+]
+
+[[package]]
+name = "widgetsnbextension"
+version = "4.0.15"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/f4/c67440c7fb409a71b7404b7aefcd7569a9c0d6bd071299bf4198ae7a5d95/widgetsnbextension-4.0.15.tar.gz", hash = "sha256:de8610639996f1567952d763a5a41af8af37f2575a41f9852a38f947eb82a3b9", size = 1097402, upload-time = "2025-11-01T21:15:55.178Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/0e/fa3b193432cfc60c93b42f3be03365f5f909d2b3ea410295cf36df739e31/widgetsnbextension-4.0.15-py3-none-any.whl", hash = "sha256:8156704e4346a571d9ce73b84bee86a29906c9abfd7223b7228a28899ccf3366", size = 2196503, upload-time = "2025-11-01T21:15:53.565Z" },
 ]


### PR DESCRIPTION
## Summary

- **`CoreLatencyCounters`**: replace scalar `compute_cycles`/`total_flops` with `flops_by_category`/`cycles_by_category` dicts keyed by `LatencyCategory` string (`compute_matmul`, `compute_float`, `compute_transcendental`, `compute_int`). Old scalar names remain as computed properties for backward compatibility.
- **`_estimate()`**: emit full `LatencyCategory` strings instead of coarse `"compute"`, enabling per-unit accounting.
- **`roofline()`**: breaking change — new dict shape adds `dominant_unit` / `units` (per-unit achieved/ceiling/ridge/efficiency for systolic and simd). Old flat fields (`peak_gflops`, `achieved_gflops`, `ceiling_gflops`, `ridge_point`) are removed.
- **`LatencyReport.__str__()`**: per-unit roofline table, `*` marks dominant unit.
- **`notebooks/latency_demo.ipynb`**: new demo notebook covering regex/MLIR parsers, `HardwareConfig` tuning, `LatencyReport` breakdown, and roofline plot.

cc @nwang-ibm @WarningRan