### PR TITLE
[Feature] Add tensor.extract_slice and tensor.insert_slice ops

### DIFF
--- a/ktir_cpu/dialects/tensor_ops.py
+++ b/ktir_cpu/dialects/tensor_ops.py
@@ -238,7 +238,7 @@ def tensor__extract_slice(op, context, env):
     strides = _resolve_dynamic(static_strides, dyn_st_ops,  context)
 
     idx = tuple(
-        slice(off, off + sz, st)
+        slice(off, off + sz * st, st)
         for off, sz, st in zip(offsets, sizes, strides)
     )
     sliced = src.data[idx]
@@ -282,7 +282,7 @@ def tensor__insert_slice(op, context, env):
     strides = _resolve_dynamic(static_strides, dyn_st_ops,  context)
 
     idx = tuple(
-        slice(off, off + sz, st)
+        slice(off, off + sz * st, st)
         for off, sz, st in zip(offsets, sizes, strides)
     )
     result_data = dst.data.copy()

--- a/ktir_cpu/dialects/tensor_ops.py
+++ b/ktir_cpu/dialects/tensor_ops.py
@@ -184,6 +184,65 @@ def tensor__yield(op, context, env):
     return ControlOps.yield_op(values)
 
 
+@register("tensor.extract_slice")
+def tensor__extract_slice(op, context, env):
+    """Slice a sub-tensor and reshape to the result type's shape.
+
+    Implements MLIR's tensor.extract_slice: all offsets/sizes/strides are
+    static (dynamic dims are not supported here). The NumPy slice covers the
+    full static extent; the result is then reshaped to the declared result
+    shape (dropping size-1 dims as extract_slice does in MLIR).
+    """
+    src = context.get_value(op.operands[0])
+    if not isinstance(src, Tile):
+        raise ValueError(f"tensor.extract_slice: expected Tile source, got {type(src)}")
+
+    offsets = op.attributes["static_offsets"]
+    sizes = op.attributes["static_sizes"]
+    strides = op.attributes["static_strides"]
+    result_shape = tuple(op.attributes["result_shape"])
+    dtype_str = op.attributes["dtype"]
+
+    idx = tuple(
+        slice(int(off), int(off) + int(sz), int(st))
+        for off, sz, st in zip(offsets, sizes, strides)
+    )
+    sliced = src.data[idx]
+    reshaped = sliced.reshape(result_shape)
+    return Tile(reshaped, dtype_str, result_shape)
+
+
+@register("tensor.insert_slice")
+def tensor__insert_slice(op, context, env):
+    """Insert a sub-tensor into a destination tensor and return the result.
+
+    Implements MLIR's tensor.insert_slice: operands[0] is the source (slice),
+    operands[1] is the destination. All offsets/sizes/strides are static.
+    Returns a copy of dest with the source inserted at the given region.
+    """
+    src = context.get_value(op.operands[0])
+    dst = context.get_value(op.operands[1])
+
+    if not isinstance(src, Tile):
+        raise ValueError(f"tensor.insert_slice: expected Tile source, got {type(src)}")
+    if not isinstance(dst, Tile):
+        raise ValueError(f"tensor.insert_slice: expected Tile dest, got {type(dst)}")
+
+    offsets = op.attributes["static_offsets"]
+    sizes = op.attributes["static_sizes"]
+    strides = op.attributes["static_strides"]
+    result_shape = tuple(op.attributes["result_shape"])
+    dtype_str = op.attributes["dtype"]
+
+    idx = tuple(
+        slice(int(off), int(off) + int(sz), int(st))
+        for off, sz, st in zip(offsets, sizes, strides)
+    )
+    result_data = dst.data.copy()
+    result_data[idx] = src.data.reshape([int(sz) for sz in sizes])
+    return Tile(result_data, dtype_str, result_shape)
+
+
 @register("tensor.generate")
 def tensor__generate(op, context, env):
     """Generate a tensor by evaluating a region body at each index.
@@ -305,7 +364,7 @@ def parse_tensor_splat(op_text, parse_ctx):
     )
 
 
-@register_parser("tensor.extract")
+@register_parser("tensor.extract ")
 def parse_tensor_extract(op_text, parse_ctx):
     # %scalar = tensor.extract %tensor[%i0, %i1] : tensor<...>
     result_match = re.match(r'(%\w+)\s*=\s*tensor\.extract\s+(%\w+)', op_text)
@@ -529,4 +588,105 @@ def parse_tensor_from_elements(op_text, parse_ctx):
             "dtype": info["dtype"],
         },
         result_type=type_str,
+    )
+
+
+def _parse_static_index_lists(op_text):
+    """Parse all [...] bracket groups in op_text as lists of integers.
+
+    Returns a list-of-lists, one per bracket group found.
+    """
+    groups = []
+    for m in re.finditer(r'\[([^\]]*)\]', op_text):
+        content = m.group(1).strip()
+        groups.append([int(x.strip()) for x in content.split(',') if x.strip()])
+    return groups
+
+
+@register_parser("tensor.extract_slice")
+def parse_tensor_extract_slice(op_text, parse_ctx):
+    """Parse `%r = tensor.extract_slice %src[offsets][sizes][strides] : T to T`."""
+    from ..parser_utils import parse_tensor_type
+    m = re.match(
+        r'(%\w+)\s*=\s*tensor\.extract_slice\s+(%\w+)', op_text
+    )
+    if not m:
+        return None
+    result_name = m.group(1)
+    src_operand = m.group(2)
+
+    groups = _parse_static_index_lists(op_text)
+    if len(groups) < 3:
+        raise ValueError(
+            f"tensor.extract_slice: expected [offsets][sizes][strides], got {op_text!r}"
+        )
+    offsets, sizes, strides = groups[0], groups[1], groups[2]
+
+    result_type_m = re.search(r'\bto\s+(tensor<[^>]+>)\s*$', op_text)
+    if not result_type_m:
+        raise ValueError(f"tensor.extract_slice: missing result type in {op_text!r}")
+    result_type = result_type_m.group(1)
+    info = parse_tensor_type(result_type)
+    if info is None:
+        raise ValueError(
+            f"tensor.extract_slice: cannot parse result type {result_type!r}"
+        )
+
+    return Operation(
+        result=result_name,
+        op_type="tensor.extract_slice",
+        operands=[src_operand],
+        attributes={
+            "static_offsets": offsets,
+            "static_sizes": sizes,
+            "static_strides": strides,
+            "result_shape": info["shape"],
+            "dtype": info["dtype"],
+        },
+        result_type=result_type,
+    )
+
+
+@register_parser("tensor.insert_slice")
+def parse_tensor_insert_slice(op_text, parse_ctx):
+    """Parse `%r = tensor.insert_slice %src into %dst[offsets][sizes][strides] : T into T`."""
+    from ..parser_utils import parse_tensor_type
+    m = re.match(
+        r'(%\w+)\s*=\s*tensor\.insert_slice\s+(%\w+)\s+into\s+(%\w+)', op_text
+    )
+    if not m:
+        return None
+    result_name = m.group(1)
+    src_operand = m.group(2)
+    dst_operand = m.group(3)
+
+    groups = _parse_static_index_lists(op_text)
+    if len(groups) < 3:
+        raise ValueError(
+            f"tensor.insert_slice: expected [offsets][sizes][strides], got {op_text!r}"
+        )
+    offsets, sizes, strides = groups[0], groups[1], groups[2]
+
+    result_type_m = re.search(r'\binto\s+(tensor<[^>]+>)\s*$', op_text)
+    if not result_type_m:
+        raise ValueError(f"tensor.insert_slice: missing result type in {op_text!r}")
+    result_type = result_type_m.group(1)
+    info = parse_tensor_type(result_type)
+    if info is None:
+        raise ValueError(
+            f"tensor.insert_slice: cannot parse result type {result_type!r}"
+        )
+
+    return Operation(
+        result=result_name,
+        op_type="tensor.insert_slice",
+        operands=[src_operand, dst_operand],
+        attributes={
+            "static_offsets": offsets,
+            "static_sizes": sizes,
+            "static_strides": strides,
+            "result_shape": info["shape"],
+            "dtype": info["dtype"],
+        },
+        result_type=result_type,
     )

--- a/ktir_cpu/dialects/tensor_ops.py
+++ b/ktir_cpu/dialects/tensor_ops.py
@@ -184,27 +184,61 @@ def tensor__yield(op, context, env):
     return ControlOps.yield_op(values)
 
 
+_KDYNAMIC = -(1 << 63)  # ShapedType::kDynamic sentinel
+
+
+def _resolve_dynamic(static_list, dynamic_operands, context):
+    """Substitute kDynamic sentinels with values from dynamic_operands.
+
+    static_list    — list of ints, some may be _KDYNAMIC
+    dynamic_operands — SSA names for the dynamic positions, in order
+    Returns a list of resolved ints.
+    """
+    dyn_iter = iter(dynamic_operands)
+    result = []
+    for v in static_list:
+        if v == _KDYNAMIC:
+            name = next(dyn_iter)
+            result.append(int(context.get_value(name)))
+        else:
+            result.append(int(v))
+    return result
+
+
 @register("tensor.extract_slice")
 def tensor__extract_slice(op, context, env):
     """Slice a sub-tensor and reshape to the result type's shape.
 
-    Implements MLIR's tensor.extract_slice: all offsets/sizes/strides are
-    static (dynamic dims are not supported here). The NumPy slice covers the
-    full static extent; the result is then reshaped to the declared result
-    shape (dropping size-1 dims as extract_slice does in MLIR).
+    Supports both fully-static and mixed static/dynamic offsets, sizes, and
+    strides.  Dynamic positions carry the sentinel _KDYNAMIC in the static
+    array; their real values are the trailing SSA operands after the source
+    (offsets first, then sizes, then strides).
     """
     src = context.get_value(op.operands[0])
     if not isinstance(src, Tile):
         raise ValueError(f"tensor.extract_slice: expected Tile source, got {type(src)}")
 
-    offsets = op.attributes["static_offsets"]
-    sizes = op.attributes["static_sizes"]
-    strides = op.attributes["static_strides"]
+    static_offsets = op.attributes["static_offsets"]
+    static_sizes = op.attributes["static_sizes"]
+    static_strides = op.attributes["static_strides"]
     result_shape = tuple(op.attributes["result_shape"])
     dtype_str = op.attributes["dtype"]
 
+    # Dynamic operands follow the source operand, ordered: offsets, sizes, strides.
+    n_dyn_off = sum(1 for v in static_offsets if v == _KDYNAMIC)
+    n_dyn_sz  = sum(1 for v in static_sizes   if v == _KDYNAMIC)
+    n_dyn_st  = sum(1 for v in static_strides  if v == _KDYNAMIC)
+    dyn_ops = op.operands[1:]
+    dyn_off_ops = dyn_ops[:n_dyn_off]
+    dyn_sz_ops  = dyn_ops[n_dyn_off:n_dyn_off + n_dyn_sz]
+    dyn_st_ops  = dyn_ops[n_dyn_off + n_dyn_sz:n_dyn_off + n_dyn_sz + n_dyn_st]
+
+    offsets = _resolve_dynamic(static_offsets, dyn_off_ops, context)
+    sizes   = _resolve_dynamic(static_sizes,   dyn_sz_ops,  context)
+    strides = _resolve_dynamic(static_strides, dyn_st_ops,  context)
+
     idx = tuple(
-        slice(int(off), int(off) + int(sz), int(st))
+        slice(off, off + sz, st)
         for off, sz, st in zip(offsets, sizes, strides)
     )
     sliced = src.data[idx]
@@ -216,9 +250,10 @@ def tensor__extract_slice(op, context, env):
 def tensor__insert_slice(op, context, env):
     """Insert a sub-tensor into a destination tensor and return the result.
 
-    Implements MLIR's tensor.insert_slice: operands[0] is the source (slice),
-    operands[1] is the destination. All offsets/sizes/strides are static.
-    Returns a copy of dest with the source inserted at the given region.
+    Supports both fully-static and mixed static/dynamic offsets, sizes, and
+    strides.  Dynamic positions carry the sentinel _KDYNAMIC in the static
+    array; their real values are the trailing SSA operands after source and
+    dest (offsets first, then sizes, then strides).
     """
     src = context.get_value(op.operands[0])
     dst = context.get_value(op.operands[1])
@@ -228,14 +263,26 @@ def tensor__insert_slice(op, context, env):
     if not isinstance(dst, Tile):
         raise ValueError(f"tensor.insert_slice: expected Tile dest, got {type(dst)}")
 
-    offsets = op.attributes["static_offsets"]
-    sizes = op.attributes["static_sizes"]
-    strides = op.attributes["static_strides"]
+    static_offsets = op.attributes["static_offsets"]
+    static_sizes = op.attributes["static_sizes"]
+    static_strides = op.attributes["static_strides"]
     result_shape = tuple(op.attributes["result_shape"])
     dtype_str = op.attributes["dtype"]
 
+    n_dyn_off = sum(1 for v in static_offsets if v == _KDYNAMIC)
+    n_dyn_sz  = sum(1 for v in static_sizes   if v == _KDYNAMIC)
+    n_dyn_st  = sum(1 for v in static_strides  if v == _KDYNAMIC)
+    dyn_ops = op.operands[2:]
+    dyn_off_ops = dyn_ops[:n_dyn_off]
+    dyn_sz_ops  = dyn_ops[n_dyn_off:n_dyn_off + n_dyn_sz]
+    dyn_st_ops  = dyn_ops[n_dyn_off + n_dyn_sz:n_dyn_off + n_dyn_sz + n_dyn_st]
+
+    offsets = _resolve_dynamic(static_offsets, dyn_off_ops, context)
+    sizes   = _resolve_dynamic(static_sizes,   dyn_sz_ops,  context)
+    strides = _resolve_dynamic(static_strides, dyn_st_ops,  context)
+
     idx = tuple(
-        slice(int(off), int(off) + int(sz), int(st))
+        slice(off, off + sz, st)
         for off, sz, st in zip(offsets, sizes, strides)
     )
     result_data = dst.data.copy()
@@ -591,36 +638,52 @@ def parse_tensor_from_elements(op_text, parse_ctx):
     )
 
 
-def _parse_static_index_lists(op_text):
-    """Parse all [...] bracket groups in op_text as lists of integers.
+def _parse_index_list(content):
+    """Parse a bracket group's content into (static_list, dynamic_names).
 
-    Returns a list-of-lists, one per bracket group found.
+    Each comma-separated entry is either an integer (static) or an SSA name
+    like ``%off`` (dynamic).  Dynamic entries are stored as _KDYNAMIC in the
+    static list; their SSA names are collected in order into dynamic_names.
     """
+    static = []
+    dynamic_names = []
+    for token in content.split(','):
+        token = token.strip()
+        if not token:
+            continue
+        if token.startswith('%'):
+            static.append(_KDYNAMIC)
+            dynamic_names.append(token)
+        else:
+            static.append(int(token))
+    return static, dynamic_names
+
+
+def _parse_index_bracket_groups(op_text):
+    """Return three (static_list, dynamic_names) tuples for [offsets][sizes][strides]."""
     groups = []
     for m in re.finditer(r'\[([^\]]*)\]', op_text):
-        content = m.group(1).strip()
-        groups.append([int(x.strip()) for x in content.split(',') if x.strip()])
-    return groups
+        groups.append(_parse_index_list(m.group(1)))
+    if len(groups) < 3:
+        raise ValueError(f"expected [offsets][sizes][strides] in {op_text!r}")
+    return groups[0], groups[1], groups[2]
 
 
 @register_parser("tensor.extract_slice")
 def parse_tensor_extract_slice(op_text, parse_ctx):
-    """Parse `%r = tensor.extract_slice %src[offsets][sizes][strides] : T to T`."""
+    """Parse `%r = tensor.extract_slice %src[offsets][sizes][strides] : T to T`.
+
+    Supports mixed static/dynamic entries: ``%off`` tokens become _KDYNAMIC
+    in the static array and are appended to operands after the source.
+    """
     from ..parser_utils import parse_tensor_type
-    m = re.match(
-        r'(%\w+)\s*=\s*tensor\.extract_slice\s+(%\w+)', op_text
-    )
+    m = re.match(r'(%\w+)\s*=\s*tensor\.extract_slice\s+(%\w+)', op_text)
     if not m:
         return None
     result_name = m.group(1)
     src_operand = m.group(2)
 
-    groups = _parse_static_index_lists(op_text)
-    if len(groups) < 3:
-        raise ValueError(
-            f"tensor.extract_slice: expected [offsets][sizes][strides], got {op_text!r}"
-        )
-    offsets, sizes, strides = groups[0], groups[1], groups[2]
+    (off_s, off_d), (sz_s, sz_d), (st_s, st_d) = _parse_index_bracket_groups(op_text)
 
     result_type_m = re.search(r'\bto\s+(tensor<[^>]+>)\s*$', op_text)
     if not result_type_m:
@@ -628,18 +691,16 @@ def parse_tensor_extract_slice(op_text, parse_ctx):
     result_type = result_type_m.group(1)
     info = parse_tensor_type(result_type)
     if info is None:
-        raise ValueError(
-            f"tensor.extract_slice: cannot parse result type {result_type!r}"
-        )
+        raise ValueError(f"tensor.extract_slice: cannot parse result type {result_type!r}")
 
     return Operation(
         result=result_name,
         op_type="tensor.extract_slice",
-        operands=[src_operand],
+        operands=[src_operand] + off_d + sz_d + st_d,
         attributes={
-            "static_offsets": offsets,
-            "static_sizes": sizes,
-            "static_strides": strides,
+            "static_offsets": off_s,
+            "static_sizes": sz_s,
+            "static_strides": st_s,
             "result_shape": info["shape"],
             "dtype": info["dtype"],
         },
@@ -649,7 +710,11 @@ def parse_tensor_extract_slice(op_text, parse_ctx):
 
 @register_parser("tensor.insert_slice")
 def parse_tensor_insert_slice(op_text, parse_ctx):
-    """Parse `%r = tensor.insert_slice %src into %dst[offsets][sizes][strides] : T into T`."""
+    """Parse `%r = tensor.insert_slice %src into %dst[offsets][sizes][strides] : T into T`.
+
+    Supports mixed static/dynamic entries: ``%off`` tokens become _KDYNAMIC
+    in the static array and are appended to operands after source and dest.
+    """
     from ..parser_utils import parse_tensor_type
     m = re.match(
         r'(%\w+)\s*=\s*tensor\.insert_slice\s+(%\w+)\s+into\s+(%\w+)', op_text
@@ -660,12 +725,7 @@ def parse_tensor_insert_slice(op_text, parse_ctx):
     src_operand = m.group(2)
     dst_operand = m.group(3)
 
-    groups = _parse_static_index_lists(op_text)
-    if len(groups) < 3:
-        raise ValueError(
-            f"tensor.insert_slice: expected [offsets][sizes][strides], got {op_text!r}"
-        )
-    offsets, sizes, strides = groups[0], groups[1], groups[2]
+    (off_s, off_d), (sz_s, sz_d), (st_s, st_d) = _parse_index_bracket_groups(op_text)
 
     result_type_m = re.search(r'\binto\s+(tensor<[^>]+>)\s*$', op_text)
     if not result_type_m:
@@ -673,18 +733,16 @@ def parse_tensor_insert_slice(op_text, parse_ctx):
     result_type = result_type_m.group(1)
     info = parse_tensor_type(result_type)
     if info is None:
-        raise ValueError(
-            f"tensor.insert_slice: cannot parse result type {result_type!r}"
-        )
+        raise ValueError(f"tensor.insert_slice: cannot parse result type {result_type!r}")
 
     return Operation(
         result=result_name,
         op_type="tensor.insert_slice",
-        operands=[src_operand, dst_operand],
+        operands=[src_operand, dst_operand] + off_d + sz_d + st_d,
         attributes={
-            "static_offsets": offsets,
-            "static_sizes": sizes,
-            "static_strides": strides,
+            "static_offsets": off_s,
+            "static_sizes": sz_s,
+            "static_strides": st_s,
             "result_shape": info["shape"],
             "dtype": info["dtype"],
         },

--- a/ktir_cpu/mlir_frontend/parser.py
+++ b/ktir_cpu/mlir_frontend/parser.py
@@ -638,6 +638,37 @@ def _adapt_tensor_generate(mlir_op, attributes, result_type, operands):
     attributes["dtype"] = info["dtype"]
 
 
+_DYNAMIC_SIZE = -(1 << 63)  # ShapedType::kDynamic in MLIR
+
+
+@MLIRTypeAdapter.install("tensor.extract_slice")
+def _adapt_tensor_extract_slice(mlir_op, attributes, result_type, operands):
+    """Extract static_offsets/sizes/strides and result shape from the op."""
+    from ..parser_utils import parse_tensor_type
+    info = parse_tensor_type(result_type)
+    if info is None:
+        raise ValueError(f"tensor.extract_slice: cannot parse result type {result_type!r}")
+    attributes["result_shape"] = info["shape"]
+    attributes["dtype"] = info["dtype"]
+    attributes["static_offsets"] = list(DenseI64ArrayAttr(mlir_op.attributes["static_offsets"]))
+    attributes["static_sizes"] = list(DenseI64ArrayAttr(mlir_op.attributes["static_sizes"]))
+    attributes["static_strides"] = list(DenseI64ArrayAttr(mlir_op.attributes["static_strides"]))
+
+
+@MLIRTypeAdapter.install("tensor.insert_slice")
+def _adapt_tensor_insert_slice(mlir_op, attributes, result_type, operands):
+    """Extract static_offsets/sizes/strides and result shape from the op."""
+    from ..parser_utils import parse_tensor_type
+    info = parse_tensor_type(result_type)
+    if info is None:
+        raise ValueError(f"tensor.insert_slice: cannot parse result type {result_type!r}")
+    attributes["result_shape"] = info["shape"]
+    attributes["dtype"] = info["dtype"]
+    attributes["static_offsets"] = list(DenseI64ArrayAttr(mlir_op.attributes["static_offsets"]))
+    attributes["static_sizes"] = list(DenseI64ArrayAttr(mlir_op.attributes["static_sizes"]))
+    attributes["static_strides"] = list(DenseI64ArrayAttr(mlir_op.attributes["static_strides"]))
+
+
 # ---------------------------------------------------------------------------
 # Parser
 # ---------------------------------------------------------------------------

--- a/tests/test_dialects_exec.py
+++ b/tests/test_dialects_exec.py
@@ -1156,6 +1156,78 @@ class TestTensor:
         assert result.shape == (1,)
         assert list(result.data) == [128]
 
+    def test_extract_slice(self):
+        # slice rows 2-3, cols 1-3 (offsets=[2,1], sizes=[2,2], strides=[1,1])
+        data = np.arange(16, dtype=np.float16).reshape(4, 4)
+        t = Tile(data, "f16", (4, 4))
+        ctx = _ctx_with(**{"%t": t})
+        result = _call("tensor.extract_slice", ctx, _make_env(),
+                       operands=["%t"],
+                       attributes={
+                           "static_offsets": [2, 1],
+                           "static_sizes": [2, 2],
+                           "static_strides": [1, 1],
+                           "result_shape": (2, 2),
+                           "dtype": "f16",
+                       })
+        assert isinstance(result, Tile)
+        assert result.shape == (2, 2)
+        assert np.array_equal(result.data, data[2:4, 1:3])
+
+    def test_extract_slice_rank_reduce(self):
+        # size-1 leading dim dropped: result_shape (4,) from a (1,4) sub-slice
+        data = np.arange(8, dtype=np.float16).reshape(2, 4)
+        t = Tile(data, "f16", (2, 4))
+        ctx = _ctx_with(**{"%t": t})
+        result = _call("tensor.extract_slice", ctx, _make_env(),
+                       operands=["%t"],
+                       attributes={
+                           "static_offsets": [1, 0],
+                           "static_sizes": [1, 4],
+                           "static_strides": [1, 1],
+                           "result_shape": (4,),
+                           "dtype": "f16",
+                       })
+        assert result.shape == (4,)
+        assert np.array_equal(result.data, data[1, :])
+
+    def test_insert_slice(self):
+        # insert a 2x2 patch at offset [1, 1] into a 4x4 tensor
+        patch = Tile(np.ones((2, 2), dtype=np.float16), "f16", (2, 2))
+        base = Tile(np.zeros((4, 4), dtype=np.float16), "f16", (4, 4))
+        ctx = _ctx_with(**{"%patch": patch, "%base": base})
+        result = _call("tensor.insert_slice", ctx, _make_env(),
+                       operands=["%patch", "%base"],
+                       attributes={
+                           "static_offsets": [1, 1],
+                           "static_sizes": [2, 2],
+                           "static_strides": [1, 1],
+                           "result_shape": (4, 4),
+                           "dtype": "f16",
+                       })
+        assert isinstance(result, Tile)
+        assert result.shape == (4, 4)
+        expected = np.zeros((4, 4), dtype=np.float16)
+        expected[1:3, 1:3] = 1.0
+        assert np.array_equal(result.data, expected)
+
+    def test_insert_slice_no_alias(self):
+        # insert_slice must not mutate the original destination tile
+        patch = Tile(np.ones((2, 2), dtype=np.float16), "f16", (2, 2))
+        base_data = np.zeros((4, 4), dtype=np.float16)
+        base = Tile(base_data.copy(), "f16", (4, 4))
+        ctx = _ctx_with(**{"%patch": patch, "%base": base})
+        _call("tensor.insert_slice", ctx, _make_env(),
+              operands=["%patch", "%base"],
+              attributes={
+                  "static_offsets": [0, 0],
+                  "static_sizes": [2, 2],
+                  "static_strides": [1, 1],
+                  "result_shape": (4, 4),
+                  "dtype": "f16",
+              })
+        assert np.array_equal(base.data, base_data)
+
 
 # ---------------------------------------------------------------------------
 # tensor.generate exec

--- a/tests/test_dialects_exec.py
+++ b/tests/test_dialects_exec.py
@@ -1273,6 +1273,43 @@ class TestTensor:
         expected[64:] = 1.0
         assert np.array_equal(result.data, expected)
 
+    def test_extract_slice_stride_gt1(self):
+        # stride=2: select every other element — requires stop = off + sz * st
+        data = np.arange(10, dtype=np.float32)
+        t = Tile(data, "f32", (10,))
+        ctx = _ctx_with(**{"%t": t})
+        result = _call("tensor.extract_slice", ctx, _make_env(),
+                       operands=["%t"],
+                       attributes={
+                           "static_offsets": [1],
+                           "static_sizes":   [3],
+                           "static_strides": [2],
+                           "result_shape": (3,),
+                           "dtype": "f32",
+                       })
+        assert result.shape == (3,)
+        # off=1, sz=3, st=2 → elements at indices 1, 3, 5
+        assert np.array_equal(result.data, data[1:7:2])
+
+    def test_insert_slice_stride_gt1(self):
+        # stride=2: write to every other element — requires stop = off + sz * st
+        patch = Tile(np.array([10.0, 20.0, 30.0], dtype=np.float32), "f32", (3,))
+        base = Tile(np.zeros((10,), dtype=np.float32), "f32", (10,))
+        ctx = _ctx_with(**{"%patch": patch, "%base": base})
+        result = _call("tensor.insert_slice", ctx, _make_env(),
+                       operands=["%patch", "%base"],
+                       attributes={
+                           "static_offsets": [1],
+                           "static_sizes":   [3],
+                           "static_strides": [2],
+                           "result_shape": (10,),
+                           "dtype": "f32",
+                       })
+        assert result.shape == (10,)
+        expected = np.zeros((10,), dtype=np.float32)
+        expected[1:7:2] = [10.0, 20.0, 30.0]
+        assert np.array_equal(result.data, expected)
+
 
 # ---------------------------------------------------------------------------
 # tensor.generate exec

--- a/tests/test_dialects_exec.py
+++ b/tests/test_dialects_exec.py
@@ -1228,6 +1228,51 @@ class TestTensor:
               })
         assert np.array_equal(base.data, base_data)
 
+    def test_extract_slice_dynamic_offset(self):
+        """Dynamic offset resolved from SSA operand (kDynamic sentinel in static array).
+
+        Mirrors the Spyre matmul lowering pattern:
+            %sl = tensor.extract_slice %b[0, %off, 0][1, 64, 64][1, 1, 1]
+                    : tensor<1x128x64xf32> to tensor<64x64xf32>
+        where %off = k * 64 is a runtime value.
+        """
+        _KDYNAMIC = -(1 << 63)
+        data = np.arange(128 * 64, dtype=np.float32).reshape(1, 128, 64)
+        t = Tile(data, "f32", (1, 128, 64))
+        ctx = _ctx_with(**{"%t": t, "%off": 64})  # second stick: offset=64
+        result = _call("tensor.extract_slice", ctx, _make_env(),
+                       operands=["%t", "%off"],
+                       attributes={
+                           "static_offsets": [0, _KDYNAMIC, 0],
+                           "static_sizes":   [1, 64, 64],
+                           "static_strides": [1, 1, 1],
+                           "result_shape": (64, 64),
+                           "dtype": "f32",
+                       })
+        assert result.shape == (64, 64)
+        assert np.array_equal(result.data, data[0, 64:128, :])
+
+    def test_insert_slice_dynamic_offset(self):
+        """Dynamic offset resolved from SSA operand (kDynamic sentinel in static array)."""
+        _KDYNAMIC = -(1 << 63)
+        patch = Tile(np.ones((64,), dtype=np.float32), "f32", (64,))
+        base_data = np.zeros((128,), dtype=np.float32)
+        base = Tile(base_data.copy(), "f32", (128,))
+        ctx = _ctx_with(**{"%patch": patch, "%base": base, "%off": 64})
+        result = _call("tensor.insert_slice", ctx, _make_env(),
+                       operands=["%patch", "%base", "%off"],
+                       attributes={
+                           "static_offsets": [_KDYNAMIC],
+                           "static_sizes":   [64],
+                           "static_strides": [1],
+                           "result_shape": (128,),
+                           "dtype": "f32",
+                       })
+        assert result.shape == (128,)
+        expected = np.zeros((128,), dtype=np.float32)
+        expected[64:] = 1.0
+        assert np.array_equal(result.data, expected)
+
 
 # ---------------------------------------------------------------------------
 # tensor.generate exec

--- a/tests/test_dialects_parse.py
+++ b/tests/test_dialects_parse.py
@@ -689,6 +689,38 @@ class TestTensorParsers(ParseTestMixin):
         self.assert_attribute(op, "result_shape", (8, 8))
         self.assert_attribute(op, "dtype", "f16")
 
+    def test_extract_slice_dynamic_offset(self):
+        """Dynamic offset %off becomes kDynamic sentinel + extra operand."""
+        _KDYNAMIC = -(1 << 63)
+        op = self._parse(
+            "%sl = tensor.extract_slice %src[0, %off][1, 64][1, 1]"
+            " : tensor<1x128x64xf32> to tensor<64xf32>",
+            args={"%src": "tensor<1x128x64xf32>", "%off": "index"},
+        )
+        self.assert_op_type(op, "tensor.extract_slice")
+        # operands: source + dynamic offset name
+        self.assert_num_operands(op, 2)
+        self.assert_operand_names(op, "%src", "%off")
+        assert op.attributes["static_offsets"] == [0, _KDYNAMIC]
+        self.assert_attribute(op, "static_sizes", [1, 64])
+        self.assert_attribute(op, "static_strides", [1, 1])
+
+    def test_insert_slice_dynamic_offset(self):
+        """Dynamic offset %off becomes kDynamic sentinel + extra operand."""
+        _KDYNAMIC = -(1 << 63)
+        op = self._parse(
+            "%out = tensor.insert_slice %src into %dst[0, %off][1, 64][1, 1]"
+            " : tensor<1x64xf32> into tensor<1x128xf32>",
+            args={"%src": "tensor<1x64xf32>", "%dst": "tensor<1x128xf32>", "%off": "index"},
+        )
+        self.assert_op_type(op, "tensor.insert_slice")
+        # operands: src + dst + dynamic offset name
+        self.assert_num_operands(op, 3)
+        self.assert_operand_names(op, "%src", "%dst", "%off")
+        assert op.attributes["static_offsets"] == [0, _KDYNAMIC]
+        self.assert_attribute(op, "static_sizes", [1, 64])
+        self.assert_attribute(op, "static_strides", [1, 1])
+
 
 # ---------------------------------------------------------------------------
 # ktdp dialect parsers

--- a/tests/test_dialects_parse.py
+++ b/tests/test_dialects_parse.py
@@ -657,6 +657,38 @@ class TestTensorParsers(ParseTestMixin):
         self.assert_operand_names(op, "%a", "%b", "%c")
         self.assert_attribute(op, "shape", (3,))
 
+    def test_extract_slice(self):
+        """tensor.extract_slice parses offsets/sizes/strides and result type."""
+        op = self._parse(
+            "%sl = tensor.extract_slice %src[0, 4][2, 4][1, 1]"
+            " : tensor<8x8xf16> to tensor<2x4xf16>",
+            args={"%src": "tensor<8x8xf16>"},
+        )
+        self.assert_op_type(op, "tensor.extract_slice")
+        self.assert_num_operands(op, 1)
+        self.assert_operand_names(op, "%src")
+        self.assert_attribute(op, "static_offsets", [0, 4])
+        self.assert_attribute(op, "static_sizes", [2, 4])
+        self.assert_attribute(op, "static_strides", [1, 1])
+        self.assert_attribute(op, "result_shape", (2, 4))
+        self.assert_attribute(op, "dtype", "f16")
+
+    def test_insert_slice(self):
+        """tensor.insert_slice parses src, dst, offsets/sizes/strides, and result type."""
+        op = self._parse(
+            "%out = tensor.insert_slice %src into %dst[0, 4][2, 4][1, 1]"
+            " : tensor<2x4xf16> into tensor<8x8xf16>",
+            args={"%src": "tensor<2x4xf16>", "%dst": "tensor<8x8xf16>"},
+        )
+        self.assert_op_type(op, "tensor.insert_slice")
+        self.assert_num_operands(op, 2)
+        self.assert_operand_names(op, "%src", "%dst")
+        self.assert_attribute(op, "static_offsets", [0, 4])
+        self.assert_attribute(op, "static_sizes", [2, 4])
+        self.assert_attribute(op, "static_strides", [1, 1])
+        self.assert_attribute(op, "result_shape", (8, 8))
+        self.assert_attribute(op, "dtype", "f16")
+
 
 # ---------------------------------------------------------------------------
 # ktdp dialect parsers

--- a/tests/test_dialects_parse.py
+++ b/tests/test_dialects_parse.py
@@ -694,8 +694,8 @@ class TestTensorParsers(ParseTestMixin):
         _KDYNAMIC = -(1 << 63)
         op = self._parse(
             "%sl = tensor.extract_slice %src[0, %off][1, 64][1, 1]"
-            " : tensor<1x128x64xf32> to tensor<64xf32>",
-            args={"%src": "tensor<1x128x64xf32>", "%off": "index"},
+            " : tensor<1x128xf32> to tensor<64xf32>",
+            args={"%src": "tensor<1x128xf32>", "%off": "index"},
         )
         self.assert_op_type(op, "tensor.extract_slice")
         # operands: source + dynamic offset name


### PR DESCRIPTION
Adds executor handlers, regex text parsers, and MLIRTypeAdapter handlers for `tensor.extract_slice` and `tensor.insert_slice`, along with parse and exec tests for both ops.

Also fixes the `tensor.extract` dispatch pattern (adds trailing space) to prevent it from shadowing `tensor.extract_slice` in the parser registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)