### PR TITLE
Fix redundant matmul computation in linalg.batch_matmul handler

### DIFF
--- a/ktir_cpu/dialects/linalg_ops.py
+++ b/ktir_cpu/dialects/linalg_ops.py
@@ -310,7 +310,8 @@ def linalg__batch_matmul(op, context, env):
     """
     tile_a = context.get_value(op.operands[0])  # ins[0] = A  (B×M×K)
     tile_b = context.get_value(op.operands[1])  # ins[1] = B  (B×K×N)
-    result = Tile(tile_a.data @ tile_b.data, tile_a.dtype, (tile_a.data @ tile_b.data).shape)
+    product = tile_a.data @ tile_b.data
+    result = Tile(product, tile_a.dtype, product.shape)
     if len(op.operands) > 2:
         acc = context.get_value(op.operands[2])
         if isinstance(acc, Tile):


### PR DESCRIPTION
## Summary

Fixes https://github.com/torch-spyre/ktir-cpu/issues/113

The `linalg.batch_matmul` handler computed `tile_a.data @ tile_b.data` twice — once for the data and once solely to derive `.shape`. This is wasteful since batched matmul is O(B·M·K·N). The fix stores the result once and reuses it.

## Changes

- `ktir_cpu/dialects/linalg_ops.py`: compute the matmul product into a local variable and reuse it for both the `Tile` data and shape arguments.
