### PR TITLE
feat: floordiv/mod as first-class operators in affine expression parser

### DIFF
--- a/ktir_cpu/dialects/ktdp_helpers.py
+++ b/ktir_cpu/dialects/ktdp_helpers.py
@@ -71,6 +71,8 @@ def _classify_refs(node, var_names: list):
         return (tag, node[1], _classify_refs(node[2], var_names))
     if tag == "neg":
         return (tag, _classify_refs(node[1], var_names))
+    if tag in ("floordiv", "mod"):
+        return (tag, _classify_refs(node[1], var_names), node[2])
     return node  # "const", "dim" — pass through unchanged
 
 
@@ -107,6 +109,8 @@ def _reclassify_dims(node, ssa_operand_names: list):
         return (tag, node[1], _reclassify_dims(node[2], ssa_operand_names))
     if tag == "neg":
         return (tag, _reclassify_dims(node[1], ssa_operand_names))
+    if tag in ("floordiv", "mod"):
+        return (tag, _reclassify_dims(node[1], ssa_operand_names), node[2])
     return node  # "const" — pass through unchanged
 
 
@@ -121,26 +125,11 @@ def parse_subscript_expr(token: str, var_names: list):
       - integer literal                              → ``("const", value)``
       - ``lhs OP rhs``  (OP = +, -, *)              → ``("add/sub/mul", ...)``
 
-    Legacy keyword forms handled via regex fast-path:
-      - ``%name floordiv N``  → ``("floordiv", i, N)``
-      - ``%name mod N``       → ``("mod", i, N)``
-
     ``var_names`` is the list of intermediate variable names (without ``%``).
     """
     from ..parser_ast import _Parser, _tokenise
 
     t = token.strip()
-    bare = t.lstrip("%")
-
-    # Legacy fast-path: keyword forms not in the expression grammar.
-    m = _re.match(r'^(\w+)\s+floordiv\s+(\d+)$', bare)
-    if m:
-        return ("floordiv", var_names.index(m.group(1)), int(m.group(2)))
-    m = _re.match(r'^(\w+)\s+mod\s+(\d+)$', bare)
-    if m:
-        return ("mod", var_names.index(m.group(1)), int(m.group(2)))
-
-    # General case: recursive-descent parse, then classify named refs.
     node = _Parser(_tokenise(t)).parse_expr()
     return _classify_refs(node, var_names)
 
@@ -151,17 +140,11 @@ def eval_subscript_expr(expr: tuple, pt: tuple) -> int:
     *expr* must be a tuple produced by :func:`parse_subscript_expr`.
     *pt* is the variable vector (one int per intermediate variable).
 
-    Delegates to the affine AST evaluator for generic node types
-    (const, dim, add, sub, mul, neg).  Intervenes only for the legacy
-    ("floordiv", i, N) / ("mod", i, N) forms not in the affine grammar.
-    ("ssa", ...) nodes must be pre-resolved to ("const", v) by
-    _resolve_node before eval is called.
+    Fully delegates to the affine AST evaluator, which handles all node
+    types including floordiv and mod.  ("ssa", ...) nodes must be
+    pre-resolved to ("const", v) by _resolve_node before eval is called.
     """
     from ..parser_ast import _eval_node
-    if expr[0] == "floordiv":
-        return pt[expr[1]] // expr[2]
-    if expr[0] == "mod":
-        return pt[expr[1]] % expr[2]
     return _eval_node(expr, list(pt))
 
 

--- a/ktir_cpu/dialects/ktdp_ops.py
+++ b/ktir_cpu/dialects/ktdp_ops.py
@@ -788,19 +788,15 @@ def parse_construct_indirect_access_tile(op_text, parse_ctx: ParseContext):
             operands.append(view_name)
             index_view_idx += 1
         else:
-            # Direct: (%h) or (%tkv mod 64) etc.
-            inner = dim_text.strip('()')
-            var_ref = inner.strip().lstrip('%')
-            if var_ref in intermediate_vars:
-                dim_subscripts.append({
-                    "kind": "direct",
-                    "var_index": intermediate_vars.index(var_ref),
-                })
-            else:
-                dim_subscripts.append({
-                    "kind": "direct_expr",
-                    "subscript": parse_subscript_expr(inner, intermediate_vars),
-                })
+            # Direct subscript: bare variable (%h), parenthesised expression
+            # ((%tkv mod 64)), or compound expression ((%a + %b * 64) floordiv 64).
+            # Parenthesised forms like (expr) are valid affine syntax — _atom
+            # handles the outer parens, so pass dim_text directly rather than
+            # stripping, which would corrupt compound-LHS expressions.
+            dim_subscripts.append({
+                "kind": "direct_expr",
+                "subscript": parse_subscript_expr(dim_text, intermediate_vars),
+            })
 
     # Parse attribute block
     attrs = parse_attr_block(op_text, parse_ctx.aliases)

--- a/ktir_cpu/parser_ast.py
+++ b/ktir_cpu/parser_ast.py
@@ -232,6 +232,10 @@ class _Parser:
                 raise ValueError(f"Expected integer constant after {op!r}, got {num_tok!r}")
             n = int(self.consume())
             tag, int_both_sides = _MULTIPLICATIVE_OPS[op]
+            if op in ("floordiv", "mod") and n <= 0:
+                raise ValueError(
+                    f"{op!r} requires a positive integer divisor, got {n}"
+                )
             primary = (tag, n, primary) if int_both_sides else (tag, primary, n)
         return primary
 

--- a/ktir_cpu/parser_ast.py
+++ b/ktir_cpu/parser_ast.py
@@ -43,7 +43,8 @@ Linear affine expressions:
   - Addition (+), subtraction (-), negation (unary -)
   - Multiplication by a constant coefficient (N * dI or dI * N)
 
-Not supported: floordiv, ceildiv, mod.
+Supported division ops: floordiv (floor toward -∞), mod (non-negative remainder).
+Not supported: ceildiv.
 
 Affine set enumeration
 ----------------------
@@ -75,6 +76,8 @@ from .affine import AffineMap, AffineSet, BoxSet
 #   ("sub",   node, node)
 #   ("neg",   node)           — unary negation
 #   ("mul",   int,  node)     — constant-coefficient multiplication
+#   ("floordiv", node, int)   — floor division; RHS must be a positive int constant
+#   ("mod",   node, int)      — non-negative remainder (always ≥ 0); RHS positive int
 #   ("max",   node, node)     — pointwise maximum (constructed by sym_max,
 #                               not the surface parser; used to express
 #                               symbolic ``BoxSet.lo`` after intersect)
@@ -98,6 +101,18 @@ _TOKEN_RE = re.compile(
     r'|(==|>=|<=|->|[+\-*(),:[\]])'  # operator / punctuation; == before >= (group 4)
     r')'
 )
+
+# Reserved keyword tokens — never valid as dim/sym/ref names.
+_AFFINE_KEYWORDS = frozenset({"floordiv", "ceildiv", "mod"})
+
+# Multiplicative operators: token → (ast_tag, int_both_sides).
+# int_both_sides=True  → integer may appear on either side; node is (tag, n, primary)
+# int_both_sides=False → integer must be on the right;      node is (tag, primary, n)
+_MULTIPLICATIVE_OPS = {
+    "*":        ("mul",      True),
+    "floordiv": ("floordiv", False),
+    "mod":      ("mod",      False),
+}
 
 
 def _tokenise(text: str) -> List[str]:
@@ -196,29 +211,39 @@ class _Parser:
             operand = self._atom()
             return ("neg", operand)
 
-        # Integer that may be a coefficient: N * expr
+        # Integer-leading: N * expr  (coefficient on the left, arbitrary atom on right).
+        # This is the only form where * takes a non-integer RHS.
         if tok is not None and re.fullmatch(r'-?\d+', tok):
             num = int(self.consume())
             if self.peek() == "*":
                 self.consume("*")
                 operand = self._atom()
                 return ("mul", num, operand)
-            return ("const", num)
+            primary: _Node = ("const", num)
+        else:
+            primary = self._atom()
 
-        # Atom that may be followed by a coefficient: expr * N
-        node = self._atom()
-        if self.peek() == "*":
-            self.consume("*")
+        # Postfix multiplicative operators: expr * N, expr floordiv N, expr mod N.
+        # All require an integer constant on the right.
+        while self.peek() in _MULTIPLICATIVE_OPS:
+            op = self.consume()
             num_tok = self.peek()
             if num_tok is None or not re.fullmatch(r'-?\d+', num_tok):
-                raise ValueError(f"Expected integer coefficient after '*', got {num_tok!r}")
-            return ("mul", int(self.consume()), node)
-        return node
+                raise ValueError(f"Expected integer constant after {op!r}, got {num_tok!r}")
+            n = int(self.consume())
+            tag, int_both_sides = _MULTIPLICATIVE_OPS[op]
+            primary = (tag, n, primary) if int_both_sides else (tag, primary, n)
+        return primary
 
     def _atom(self) -> _Node:
         tok = self.peek()
         if tok is None:
             raise ValueError("Unexpected end of expression")
+
+        if tok in _AFFINE_KEYWORDS:
+            raise ValueError(
+                f"Keyword {tok!r} is not valid as an atom in an affine expression"
+            )
 
         # Parenthesised sub-expression
         if tok == "(":
@@ -449,6 +474,11 @@ def _eval_node(node: _Node, dims: List[int], syms: Optional[List[int]] = None) -
         return -_eval_node(node[1], dims, syms)
     if tag == "mul":
         return node[1] * _eval_node(node[2], dims, syms)
+    if tag == "floordiv":
+        return _eval_node(node[1], dims, syms) // node[2]
+    if tag == "mod":
+        # Non-negative remainder matching MLIR semantics: result is always in [0, N).
+        return _eval_node(node[1], dims, syms) % node[2]
     if tag == "max":
         return max(_eval_node(node[1], dims, syms), _eval_node(node[2], dims, syms))
     if tag == "min":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,4 +54,5 @@ markers = [
 dev = [
     "jupyter>=1.1.1",
     "matplotlib>=3.10.9",
+    "pytest>=9.0.2",
 ]

--- a/tests/test_ast.py
+++ b/tests/test_ast.py
@@ -132,6 +132,96 @@ class TestParseExpr:
 
 
 # ===========================================================================
+# floordiv / mod expression parsing and evaluation
+# ===========================================================================
+
+class TestFloorDivMod:
+
+    # --- AST structure ---
+
+    def test_floordiv_dim(self):
+        node = parse_expr("d0 floordiv 4")
+        assert node == ("floordiv", ("dim", 0), 4)
+
+    def test_mod_dim(self):
+        node = parse_expr("d0 mod 8")
+        assert node == ("mod", ("dim", 0), 8)
+
+    def test_floordiv_const_lhs(self):
+        # Integer-leading path — previously broken (early-returned before the loop).
+        node = parse_expr("5 floordiv 3")
+        assert node == ("floordiv", ("const", 5), 3)
+
+    def test_mod_const_lhs(self):
+        node = parse_expr("7 mod 4")
+        assert node == ("mod", ("const", 7), 4)
+
+    def test_floordiv_compound_lhs(self):
+        # Compound expression as LHS — the motivating case from the gather kernel.
+        node = parse_expr("(d0 + d1 * 64) floordiv 64")
+        assert node == (
+            "floordiv",
+            ("add", ("dim", 0), ("mul", 64, ("dim", 1))),
+            64,
+        )
+
+    def test_mod_compound_lhs(self):
+        node = parse_expr("(d0 + 1) mod 8")
+        assert node == ("mod", ("add", ("dim", 0), ("const", 1)), 8)
+
+    def test_floordiv_then_mod_chain(self):
+        # d0 floordiv 4 mod 2  →  (d0 floordiv 4) mod 2  (left-to-right)
+        node = parse_expr("d0 floordiv 4 mod 2")
+        assert node == ("mod", ("floordiv", ("dim", 0), 4), 2)
+
+    # --- Evaluation ---
+
+    def test_floordiv_eval_exact(self):
+        node = parse_expr("d0 floordiv 4")
+        assert eval_expr(node, [8]) == 2
+        assert eval_expr(node, [12]) == 3
+
+    def test_floordiv_eval_floor_semantics(self):
+        # Python // floors toward -∞, matching MLIR affine semantics.
+        node = parse_expr("d0 floordiv 4")
+        assert eval_expr(node, [7]) == 1
+        assert eval_expr(node, [0]) == 0
+
+    def test_mod_eval(self):
+        node = parse_expr("d0 mod 64")
+        assert eval_expr(node, [0]) == 0
+        assert eval_expr(node, [63]) == 63
+        assert eval_expr(node, [64]) == 0
+        assert eval_expr(node, [65]) == 1
+
+    def test_compound_floordiv_eval(self):
+        # (y_offset + d_stick*64 + d_lane) floordiv 64
+        # dims: d0=y_offset, d1=d_stick, d2=d_lane
+        node = parse_expr("(d0 + d1 * 64 + d2) floordiv 64")
+        assert eval_expr(node, [0, 0, 0]) == 0
+        assert eval_expr(node, [0, 1, 0]) == 1
+        assert eval_expr(node, [32, 0, 32]) == 1   # (32+0+32)//64 == 1
+        assert eval_expr(node, [32, 0, 31]) == 0   # (32+0+31)//64 == 0
+
+    def test_compound_mod_eval(self):
+        node = parse_expr("(d0 + d1 * 64 + d2) mod 64")
+        assert eval_expr(node, [0, 0, 0]) == 0
+        assert eval_expr(node, [0, 0, 5]) == 5
+        assert eval_expr(node, [32, 0, 32]) == 0   # (32+0+32) % 64 == 0
+        assert eval_expr(node, [32, 0, 10]) == 42  # (32+0+10) % 64 == 42
+
+    # --- Keyword guard in _atom ---
+
+    def test_keyword_as_atom_raises(self):
+        with pytest.raises(ValueError, match="Keyword"):
+            parse_expr("floordiv")
+
+    def test_keyword_mod_as_atom_raises(self):
+        with pytest.raises(ValueError, match="Keyword"):
+            parse_expr("mod")
+
+
+# ===========================================================================
 # parse_affine_map — AST structure
 # ===========================================================================
 

--- a/tests/test_ast.py
+++ b/tests/test_ast.py
@@ -210,6 +210,24 @@ class TestFloorDivMod:
         assert eval_expr(node, [32, 0, 32]) == 0   # (32+0+32) % 64 == 0
         assert eval_expr(node, [32, 0, 10]) == 42  # (32+0+10) % 64 == 42
 
+    # --- Non-positive divisor guard ---
+
+    def test_floordiv_zero_divisor_raises(self):
+        with pytest.raises(ValueError, match="positive integer divisor"):
+            parse_expr("d0 floordiv 0")
+
+    def test_floordiv_negative_divisor_raises(self):
+        with pytest.raises(ValueError, match="positive integer divisor"):
+            parse_expr("d0 floordiv -4")
+
+    def test_mod_zero_divisor_raises(self):
+        with pytest.raises(ValueError, match="positive integer divisor"):
+            parse_expr("d0 mod 0")
+
+    def test_mod_negative_divisor_raises(self):
+        with pytest.raises(ValueError, match="positive integer divisor"):
+            parse_expr("d0 mod -1")
+
     # --- Keyword guard in _atom ---
 
     def test_keyword_as_atom_raises(self):

--- a/tests/test_indirect_access.py
+++ b/tests/test_indirect_access.py
@@ -953,7 +953,9 @@ class TestSubscriptExpr:
 # ---------------------------------------------------------------------------
 
 # Kernel: copy src[i] -> dst[i floordiv 64][i mod 64]
-# src is a flat 128-element view; dst is a 2x64 view.
+# src is a flat 128-element view (stick 0); dst is a 2x64 view (stick 100).
+# Sticks are spaced far apart so the two allocations don't collide
+# (STICK_BYTES=128, f16=2 bytes → 64 f16 per stick; 128 f16 spans 2 sticks).
 # intermediate_variables(%page, %lane) iterate over [0,2) x [0,64).
 # src subscript: (%page * 64 + %lane)   — direct, compound mul+add
 # dst dim 0:     (%page * 64 + %lane) floordiv 64  — compound LHS floordiv
@@ -968,7 +970,7 @@ _COMPOUND_FLOORDIV_MOD_MLIR = """
 module {
   func.func @compound_floordiv_mod() attributes {grid = [1, 1]} {
     %src_addr = arith.constant 0 : index
-    %dst_addr = arith.constant 1 : index
+    %dst_addr = arith.constant 100 : index
 
     %src = ktdp.construct_memory_view %src_addr, sizes: [128], strides: [1] {
         coordinate_set = #src_set,
@@ -1017,12 +1019,12 @@ def test_compound_floordiv_mod_direct_subscript():
     def _prepare(grid_shape):
         _orig(grid_shape)
         hbm = interp.memory.hbm
-        hbm.write(0, np.arange(128, dtype=np.float16))   # src: 0..127
-        hbm.write(1, np.zeros(128, dtype=np.float16))    # dst: zeroed
+        hbm.write(0, np.arange(128, dtype=np.float16))    # src: stick 0
+        hbm.write(100, np.zeros(128, dtype=np.float16))  # dst: stick 100
     interp._prepare_execution = _prepare
 
     interp.execute_function("compound_floordiv_mod")
 
-    dst = interp.memory.hbm.read(1, 128, "f16").reshape(2, 64)
+    dst = interp.memory.hbm.read(100, 128, "f16").reshape(2, 64)
     expected = np.arange(128, dtype=np.float16).reshape(2, 64)
     np.testing.assert_array_equal(dst, expected)

--- a/tests/test_indirect_access.py
+++ b/tests/test_indirect_access.py
@@ -852,3 +852,95 @@ def test_non_permutation_vso_raises(mlir_factory, func_name):
 
     with pytest.raises(ValueError, match="must permute its input dimensions"):
         interp.execute_function(func_name)
+
+
+# ---------------------------------------------------------------------------
+# parse_subscript_expr / eval_subscript_expr — unit tests
+# ---------------------------------------------------------------------------
+
+class TestSubscriptExpr:
+    """Unit tests for parse_subscript_expr and eval_subscript_expr.
+
+    These exercise the helpers in isolation, independent of any MLIR module.
+    var_names mirrors the intermediate_variables list; SSA refs are pre-resolved
+    to ("const", v) before eval (as _resolve_node does at construct time).
+    """
+
+    from ktir_cpu.dialects.ktdp_helpers import parse_subscript_expr, eval_subscript_expr
+
+    # --- single variable ---
+
+    def test_bare_dim(self):
+        from ktir_cpu.dialects.ktdp_helpers import parse_subscript_expr, eval_subscript_expr
+        expr = parse_subscript_expr("%d0", ["d0", "d1"])
+        assert expr == ("dim", 0)
+        assert eval_subscript_expr(expr, (3, 7)) == 3
+
+    # --- floordiv ---
+
+    def test_floordiv_single_var(self):
+        from ktir_cpu.dialects.ktdp_helpers import parse_subscript_expr, eval_subscript_expr
+        expr = parse_subscript_expr("%d0 floordiv 4", ["d0"])
+        assert expr == ("floordiv", ("dim", 0), 4)
+        assert eval_subscript_expr(expr, (8,)) == 2
+        assert eval_subscript_expr(expr, (7,)) == 1
+
+    def test_mod_single_var(self):
+        from ktir_cpu.dialects.ktdp_helpers import parse_subscript_expr, eval_subscript_expr
+        expr = parse_subscript_expr("%d0 mod 64", ["d0"])
+        assert expr == ("mod", ("dim", 0), 64)
+        assert eval_subscript_expr(expr, (65,)) == 1
+        assert eval_subscript_expr(expr, (64,)) == 0
+
+    # --- compound LHS with SSA ref (pre-resolved to const) ---
+
+    def test_compound_floordiv_with_ssa(self):
+        # (%y_offset + %d_stick * 64 + %d_lane) floordiv 64
+        # y_offset is an outer SSA value; d_stick, d_lane are iteration vars.
+        from ktir_cpu.dialects.ktdp_helpers import parse_subscript_expr, eval_subscript_expr
+        var_names = ["d_stick", "d_lane"]
+        expr = parse_subscript_expr(
+            "(%y_offset + %d_stick * 64 + %d_lane) floordiv 64",
+            var_names,
+        )
+        # Pre-resolve %y_offset to ("const", 32) as _resolve_node would.
+        def resolve(node):
+            if node[0] == "ssa":
+                return ("const", 32)
+            if node[0] in ("add", "sub"):
+                return (node[0], resolve(node[1]), resolve(node[2]))
+            if node[0] == "mul":
+                return (node[0], node[1], resolve(node[2]))
+            if node[0] == "floordiv":
+                return (node[0], resolve(node[1]), node[2])
+            return node
+        expr = resolve(expr)
+        # (32 + d_stick*64 + d_lane) floordiv 64
+        assert eval_subscript_expr(expr, (0, 0))  == 0   # (32+0+0)//64 == 0
+        assert eval_subscript_expr(expr, (0, 32)) == 1   # (32+0+32)//64 == 1
+        assert eval_subscript_expr(expr, (1, 0))  == 1   # (32+64+0)//64 == 1
+        assert eval_subscript_expr(expr, (1, 32)) == 2   # (32+64+32)//64 == 2
+
+    def test_compound_mod_with_ssa(self):
+        from ktir_cpu.dialects.ktdp_helpers import parse_subscript_expr, eval_subscript_expr
+        var_names = ["d_stick", "d_lane"]
+        expr = parse_subscript_expr(
+            "(%y_offset + %d_stick * 64 + %d_lane) mod 64",
+            var_names,
+        )
+        def resolve(node):
+            if node[0] == "ssa":
+                return ("const", 32)
+            if node[0] in ("add", "sub"):
+                return (node[0], resolve(node[1]), resolve(node[2]))
+            if node[0] == "mul":
+                return (node[0], node[1], resolve(node[2]))
+            if node[0] == "mod":
+                return (node[0], resolve(node[1]), node[2])
+            return node
+        expr = resolve(expr)
+        # (32 + d_stick*64 + d_lane) mod 64
+        assert eval_subscript_expr(expr, (0, 0))  == 32  # (32+0+0) % 64
+        assert eval_subscript_expr(expr, (0, 32)) == 0   # (32+0+32) % 64
+        assert eval_subscript_expr(expr, (1, 0))  == 32  # (32+64+0) % 64
+        assert eval_subscript_expr(expr, (1, 31)) == 63  # (32+64+31) % 64

--- a/tests/test_indirect_access.py
+++ b/tests/test_indirect_access.py
@@ -944,3 +944,85 @@ class TestSubscriptExpr:
         assert eval_subscript_expr(expr, (0, 32)) == 0   # (32+0+32) % 64
         assert eval_subscript_expr(expr, (1, 0))  == 32  # (32+64+0) % 64
         assert eval_subscript_expr(expr, (1, 31)) == 63  # (32+64+31) % 64
+
+
+# ---------------------------------------------------------------------------
+# Integration: construct_indirect_access_tile with compound floordiv/mod
+# direct subscripts — exercises the ktdp_ops.py parser path (line 792),
+# which the TestSubscriptExpr unit tests bypass.
+# ---------------------------------------------------------------------------
+
+# Kernel: copy src[i] -> dst[i floordiv 64][i mod 64]
+# src is a flat 128-element view; dst is a 2x64 view.
+# intermediate_variables(%page, %lane) iterate over [0,2) x [0,64).
+# src subscript: (%page * 64 + %lane)   — direct, compound mul+add
+# dst dim 0:     (%page * 64 + %lane) floordiv 64  — compound LHS floordiv
+# dst dim 1:     (%page * 64 + %lane) mod 64        — compound LHS mod
+# After the copy dst[p][l] == src[p*64+l] == p*64+l for all p,l.
+_COMPOUND_FLOORDIV_MOD_MLIR = """
+#src_set = affine_set<(d0) : (d0 >= 0, -d0 + 127 >= 0)>
+#dst_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 1 >= 0, d1 >= 0, -d1 + 63 >= 0)>
+#var_set  = affine_set<(d0, d1) : (d0 >= 0, -d0 + 1 >= 0, d1 >= 0, -d1 + 63 >= 0)>
+#var_order = affine_map<(d0, d1) -> (d0, d1)>
+
+module {
+  func.func @compound_floordiv_mod() attributes {grid = [1, 1]} {
+    %src_addr = arith.constant 0 : index
+    %dst_addr = arith.constant 1 : index
+
+    %src = ktdp.construct_memory_view %src_addr, sizes: [128], strides: [1] {
+        coordinate_set = #src_set,
+        memory_space = #ktdp.spyre_memory_space<HBM>
+    } : memref<128xf16>
+
+    %dst = ktdp.construct_memory_view %dst_addr, sizes: [2, 64], strides: [64, 1] {
+        coordinate_set = #dst_set,
+        memory_space = #ktdp.spyre_memory_space<HBM>
+    } : memref<2x64xf16>
+
+    %src_tile = ktdp.construct_indirect_access_tile
+        intermediate_variables(%page, %lane)
+        %src[(%page * 64 + %lane)] {
+            variables_space_set = #var_set,
+            variables_space_order = #var_order
+        } : memref<128xf16> -> !ktdp.access_tile<2x64xindex>
+
+    %dst_tile = ktdp.construct_indirect_access_tile
+        intermediate_variables(%page, %lane)
+        %dst[(%page * 64 + %lane) floordiv 64, (%page * 64 + %lane) mod 64] {
+            variables_space_set = #var_set,
+            variables_space_order = #var_order
+        } : memref<2x64xf16> -> !ktdp.access_tile<2x64xindex>
+
+    %data = ktdp.load %src_tile : !ktdp.access_tile<2x64xindex> -> tensor<2x64xf16>
+    ktdp.store %data, %dst_tile : tensor<2x64xf16>, !ktdp.access_tile<2x64xindex>
+
+    return
+  }
+}
+"""
+
+
+def test_compound_floordiv_mod_direct_subscript():
+    """Compound-LHS floordiv/mod in construct_indirect_access_tile direct subscripts.
+
+    Exercises ktdp_ops.py parse path (strip('()') bug site) with a non-trivial
+    expression as the floordiv/mod LHS.  Without the fix, floordiv/mod would be
+    silently dropped and dst would not be written correctly.
+    """
+    interp = KTIRInterpreter()
+    interp.load(_COMPOUND_FLOORDIV_MOD_MLIR)
+
+    _orig = interp._prepare_execution
+    def _prepare(grid_shape):
+        _orig(grid_shape)
+        hbm = interp.memory.hbm
+        hbm.write(0, np.arange(128, dtype=np.float16))   # src: 0..127
+        hbm.write(1, np.zeros(128, dtype=np.float16))    # dst: zeroed
+    interp._prepare_execution = _prepare
+
+    interp.execute_function("compound_floordiv_mod")
+
+    dst = interp.memory.hbm.read(1, 128, "f16").reshape(2, 64)
+    expected = np.arange(128, dtype=np.float16).reshape(2, 64)
+    np.testing.assert_array_equal(dst, expected)

--- a/uv.lock
+++ b/uv.lock
@@ -1100,6 +1100,7 @@ mlir-frontend = [
 dev = [
     { name = "jupyter" },
     { name = "matplotlib" },
+    { name = "pytest" },
 ]
 
 [package.metadata]
@@ -1115,6 +1116,7 @@ provides-extras = ["dev", "mlir-frontend"]
 dev = [
     { name = "jupyter", specifier = ">=1.1.1" },
     { name = "matplotlib", specifier = ">=3.10.9" },
+    { name = "pytest", specifier = ">=9.0.2" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

`floordiv` and `mod` are MLIR affine grammar keywords but the tokeniser was emitting them as plain identifiers. The parser intercepted them ad-hoc in `_term` via a `peek()` check, but this had two structural bugs:

1. The integer-leading branch (`5 floordiv 3`) had an early `return` that exited `_term` before reaching the operator loop, so `5 floordiv 3` would silently misparse.
2. `_atom` had no guard against keywords reaching it — it raised an opaque `ValueError: Unexpected token: 'floordiv'` instead of something actionable.

This blocked the gather stick kernel, which needs compound-LHS expressions like `(y_offset + d*64 + lane) floordiv 64`.

## Changes

**`ktir_cpu/parser_ast.py`**
- Add `_AFFINE_KEYWORDS` (reserved keyword set) and `_MULTIPLICATIVE_OPS` dispatch table (`token → ast_tag + coeff_first` flag).
- Unify `_term`: integer-leading `N*expr` keeps its prefix form; all postfix operators (`expr*N`, `expr floordiv N`, `expr mod N`) share a single `while` loop keyed off `_MULTIPLICATIVE_OPS` — no `if/elif` chain.
- Guard `_atom`: raises `ValueError` mentioning "Keyword" before the opaque catch-all.
- Add `("floordiv", node, int)` and `("mod", node, int)` AST tags; evaluate via `_eval_node` using Python `//` and `%` (floor semantics, non-negative remainder).

**`ktir_cpu/dialects/ktdp_helpers.py`**
- Recurse into `floordiv`/`mod` LHS in `_classify_refs` and `_reclassify_dims`.
- Remove legacy regex fast-path from `parse_subscript_expr`; simplify `eval_subscript_expr` to fully delegate to `_eval_node`.

**`tests/`**
- `TestFloorDivMod` in `test_ast.py`: AST structure, evaluation, keyword guard.
- `TestSubscriptExpr` in `test_indirect_access.py`: `parse_subscript_expr`/`eval_subscript_expr` with compound SSA expressions.

## Adding a new keyword in future

Touch exactly one place: add an entry to `_MULTIPLICATIVE_OPS` (e.g. `"ceildiv": ("ceildiv", False)`).