### PR TITLE
Fix: roofline dominant unit by cycles + per-unit arithmetic intensity

### DIFF
--- a/ktir_cpu/latency.py
+++ b/ktir_cpu/latency.py
@@ -461,8 +461,8 @@ class LatencyReport:
         """Compute per-unit roofline metrics for the critical-path core.
 
         Two compute units are modelled (systolic for matmul, SIMD for everything
-        else).  The dominant unit — whichever accumulated the most FLOPs — sets
-        the compute ceiling.  The chart shows one roof::
+        else).  The dominant unit — whichever consumed the most compute cycles —
+        sets the headline.  The chart shows one roof::
 
             GFLOP/s
               ^
@@ -485,9 +485,11 @@ class LatencyReport:
         - **simd**: all other compute ops (float, transcendental, int),
           peak = ``simd_elements_per_cycle × clock``
 
-        The **dominant unit** is whichever accumulated the most FLOPs in the
-        kernel trace — it reflects which unit did the real work.  The summary
-        ``efficiency`` is reported for the dominant unit.
+        The **dominant unit** is whichever consumed the most compute cycles in
+        the kernel trace — the real bottleneck.  FLOPs are not comparable across
+        units (matmul ``2*M*N*K`` vs SIMD per-element), so cycles, not FLOPs,
+        identify the busy unit.  The summary ``arithmetic_intensity`` and
+        ``efficiency`` are reported for the dominant unit.
 
         For each unit, ``achieved_gflops`` is ``unit_flops / total_wall_time``
         (not unit_flops / unit_cycles) so the achieved rate reflects true
@@ -497,9 +499,10 @@ class LatencyReport:
            Communication cycles (ring allgather/reduce) are not modelled.
 
         Returns a dict with:
-            arithmetic_intensity: total FLOPs / total bytes (FLOP/B).
+            arithmetic_intensity: the dominant unit's per-unit AI
+                (``dominant_unit FLOPs / total bytes``, FLOP/B).
             peak_bw_gb_s: Per-core HBM bandwidth in GB/s.
-            dominant_unit: ``"systolic"`` or ``"simd"`` (most FLOPs).
+            dominant_unit: ``"systolic"`` or ``"simd"`` (most compute cycles).
             efficiency: achieved / ceiling for the dominant unit (0..1).
             cores_active: number of cores that consumed any cycle (nonzero
                 total_cycles). A core left idle by an oversized grid produces a
@@ -515,6 +518,7 @@ class LatencyReport:
                 chip_throughput / efficiency to read actual utilization.
             units: per-unit dict, each with:
                 achieved_gflops, ceiling_gflops, ridge_point, efficiency,
+                arithmetic_intensity (this unit's own FLOPs / total bytes),
                 peak_gflops, chip_peak_gflops, chip_throughput.
 
         Per-unit chip-level fields (peak-based, Nsight SOL analogue):
@@ -546,9 +550,6 @@ class LatencyReport:
         elapsed_s = critical.total_cycles / clock
         peak_bw = self.config.hbm_bytes_per_cycle_per_core * clock
 
-        ai = (critical.total_flops / critical.total_bytes
-              if critical.total_bytes > 0 else float('inf'))
-
         # Count cores that consumed any cycle, not every grid core that produced
         # a counter entry: an oversized grid leaves some cores with zero loop
         # iterations (0 cycles), and those must not inflate utilization. Use
@@ -577,8 +578,15 @@ class LatencyReport:
             cats = unit_categories[unit_name]
             flops = sum(critical.flops_by_category.get(c, 0.0) for c in cats)
             achieved = flops / elapsed_s if elapsed_s > 0 else 0.0
-            # Roofline ceiling at this kernel's AI for this unit.
-            ceiling = min(peak, peak_bw * ai)
+            # Per-unit arithmetic intensity: this unit's own FLOPs over the
+            # kernel's total bytes (NCU convention — numerator split per
+            # pipeline, denominator the shared byte traffic). Each unit gets its
+            # own ceiling instead of sharing one mixed AI, so the other unit's
+            # FLOPs no longer inflate this unit's ceiling.
+            unit_ai = (flops / critical.total_bytes
+                       if critical.total_bytes > 0 else float('inf'))
+            # Roofline ceiling at this unit's own AI.
+            ceiling = min(peak, peak_bw * unit_ai)
             # Cores are homogeneous: every core shares the same clock and
             # compute rates from HardwareConfig, so the chip peak is
             # peak * num_cores, which equals summing identical per-core peaks.
@@ -603,22 +611,28 @@ class LatencyReport:
                 "ceiling_gflops": ceiling / 1e9,
                 "ridge_point": peak / peak_bw,
                 "efficiency": achieved / ceiling if ceiling > 0 else 0.0,
+                "arithmetic_intensity": unit_ai,
                 "peak_gflops": peak / 1e9,
                 "chip_peak_gflops": chip_peak / 1e9,
                 "chip_throughput": chip_throughput,
             }
 
-        # Dominant unit = most FLOPs. Fall back to "simd" when no compute.
+        # Dominant unit = the unit that consumed the most compute cycles — the
+        # real bottleneck. Per-category cycles are already attributed to each
+        # unit upstream (LatencyTracker._estimate); read that conclusion rather
+        # than re-deriving from FLOPs, which are not comparable across units
+        # (matmul 2*M*N*K vs SIMD per-element). Fall back to "simd" when no
+        # compute ran at all (every category zero → both flops and cycles zero).
         dominant = max(
             unit_ceilings,
-            key=lambda u: sum(critical.flops_by_category.get(c, 0.0)
+            key=lambda u: sum(critical.cycles_by_category.get(c, 0.0)
                               for c in unit_categories[u]),
         )
         if all(units[u]["achieved_gflops"] == 0.0 for u in units):
             dominant = "simd"
 
         return {
-            "arithmetic_intensity": ai,
+            "arithmetic_intensity": units[dominant]["arithmetic_intensity"],
             "peak_bw_gb_s": peak_bw / 1e9,
             "dominant_unit": dominant,
             "efficiency": units[dominant]["efficiency"],

--- a/tests/test_latency.py
+++ b/tests/test_latency.py
@@ -396,6 +396,41 @@ class TestRoofline:
         assert unit["chip_throughput"] < extrapolation
         assert extrapolation == pytest.approx(1.5 * unit["chip_throughput"])
 
+    def test_dominant_by_cycles_and_per_unit_ai(self):
+        """Dominant unit is the cycle bottleneck, not the FLOP-heaviest, and each
+        unit gets its own arithmetic intensity (its FLOPs / total bytes).
+
+        Mirrors the paged_attention shape on default HW: the systolic matmul has
+        far more FLOPs (524288) but runs in a single cycle, while the SIMD path
+        has fewer FLOPs (28480) yet spends 496 cycles — it is the real
+        bottleneck. Selecting by FLOPs would wrongly pick systolic; selecting by
+        cycles (reading the per-category cycle tally produced upstream) picks
+        simd. No existing roofline test asserts which unit is dominant, so this
+        pins the cycle-based selection against silent regression.
+        """
+        from ktir_cpu.latency import CoreLatencyCounters
+
+        total_bytes = 71680
+        c = CoreLatencyCounters()
+        c.record("compute_matmul", cycles=1.0, flops=524288.0)
+        c.record("compute_float", cycles=496.0, flops=28480.0, nbytes=total_bytes)
+
+        rf = LatencyReport(config=HardwareConfig(), counters={0: c}).roofline()
+
+        # FLOP-heaviest is systolic; cycle-heaviest (the bottleneck) is simd.
+        assert rf["dominant_unit"] == "simd"
+
+        # Each unit's AI is its own FLOPs over the shared total bytes — distinct,
+        # not one mixed value shared by both.
+        ai_sys = rf["units"]["systolic"]["arithmetic_intensity"]
+        ai_simd = rf["units"]["simd"]["arithmetic_intensity"]
+        assert ai_sys == pytest.approx(524288.0 / total_bytes)
+        assert ai_simd == pytest.approx(28480.0 / total_bytes)
+        assert ai_sys != ai_simd
+
+        # The top-level AI is sourced from the dominant (simd) unit, not a mix.
+        assert rf["arithmetic_intensity"] == pytest.approx(ai_simd)
+
     @pytest.mark.parametrize("path,func_name,entry", get_test_params("add_kernel"))
     def test_vector_add_is_memory_bound(self, path, func_name, entry):
         """vector_add has low arithmetic intensity → memory-bound on roofline."""


### PR DESCRIPTION
Fix `roofline()`'s summary stage, which picked the dominant compute unit by accumulated FLOPs and fed both units one mixed arithmetic intensity. Step 1 of #122 — correctness only; the `efficiency` formula/denominator is unchanged.

| | before | after |
|---|---|---|
| dominant unit | most **FLOPs** | most **compute cycles** |
| arithmetic intensity | one mixed AI shared by both units | **per-unit** (`unit_flops / total_bytes`) |

- **Before**: dominant = `argmax(flops_by_category)`; ceiling = `min(peak, peak_bw × mixed_AI)`, shared by both units.
- **Why not enough**: matmul FLOPs (`2·M·N·K`) and SIMD per-element FLOPs aren't comparable, so a FLOP-heavy but near-idle unit was reported as dominant, and each unit's ceiling was inflated by the other unit's FLOPs.
- **What changed**: dominant is read from the per-category compute cycles already attributed upstream; each unit gets its own AI and ceiling; top-level AI/efficiency are sourced from the dominant unit.
- **How it solves it**: cycles identify the real bottleneck; per-unit AI gives each unit a correct ceiling. `efficiency` (`achieved/ceiling`) is untouched — it just receives the correct per-unit ceiling, so the reported value moves because the old one was computed from the wrong (mixed) ceiling.

Measured on default `HardwareConfig()`: dominant `systolic → simd`, top-level AI `7.71 → 0.40`, efficiency `0.78 → 0.82`. Adds a regression test pinning cycle-based dominant selection (previously unguarded).

Related to #120.
