### PR TITLE
Parse bundled multi-result LHS (%acc:2 = scf.for) in regex parser

### DIFF
--- a/ktir_cpu/dialects/arith_ops.py
+++ b/ktir_cpu/dialects/arith_ops.py
@@ -313,15 +313,15 @@ def arith__select(op, context, env):
 # ---------------------------------------------------------------------------
 
 @register_parser("arith.constant")
-def parse_arith_constant(op_text, parse_ctx):
+def parse_arith_constant(op_text, parse_ctx, result=None):
     from ..parser_utils import parse_numeric, parse_tensor_type, parse_dense_payload
 
-    result_match = re.match(r'(%\w+)\s*=\s*arith\.constant\s*(.*)', op_text)
+    result_match = re.match(r'arith\.constant\s*(.*)', op_text)
     if not result_match:
         return None
 
-    result_name = result_match.group(1)
-    rest = result_match.group(2).strip()
+    result_name = result
+    rest = result_match.group(1).strip()
 
     result_type = None
     attributes = {}
@@ -424,24 +424,23 @@ _CMP_PREDICATES = {
 
 
 @register_parser("arith.cmpi", "arith.cmpf")
-def parse_arith_cmp(op_text, parse_ctx):
-    m = re.match(r'(%\w+)\s*=\s*(arith\.cmp[if])\s+', op_text)
+def parse_arith_cmp(op_text, parse_ctx, result=None):
+    m = re.match(r'(arith\.cmp[if])\s+', op_text)
     if not m:
         return None
-    result_name = m.group(1)
-    op_type = m.group(2)
+    op_type = m.group(1)
     pred_pattern, default_type = _CMP_PREDICATES[op_type]
     pred_match = re.search(rf'{re.escape(op_type)}\s+({pred_pattern})', op_text)
     if not pred_match:
         raise ValueError(f"{op_type}: no valid predicate found in: {op_text!r}")
     predicate = pred_match.group(1)
-    operands = [o for o in find_ssa_names(op_text) if o != result_name]
+    operands = find_ssa_names(op_text)
     result_type = default_type
     type_match = re.search(r':\s*(.+)$', op_text)
     if type_match:
         result_type = type_match.group(1).strip()
     return Operation(
-        result=result_name,
+        result=result,
         op_type=op_type,
         operands=operands,
         attributes={"predicate": predicate},
@@ -450,13 +449,12 @@ def parse_arith_cmp(op_text, parse_ctx):
 
 
 @register_parser("arith.sitofp")
-def parse_arith_sitofp(op_text, parse_ctx):
-    result_match = re.match(r'(%\w+)\s*=\s*arith\.sitofp\s+(%\w+)', op_text)
+def parse_arith_sitofp(op_text, parse_ctx, result=None):
+    result_match = re.match(r'arith\.sitofp\s+(%\w+)', op_text)
     if not result_match:
         return None
 
-    result_name = result_match.group(1)
-    operand = result_match.group(2)
+    operand = result_match.group(1)
 
     result_type = "f16"
     to_match = re.search(r'to\s+(f\d+)', op_text)
@@ -464,7 +462,7 @@ def parse_arith_sitofp(op_text, parse_ctx):
         result_type = to_match.group(1)
 
     return Operation(
-        result=result_name,
+        result=result,
         op_type="arith.sitofp",
         operands=[operand],
         attributes={},
@@ -473,13 +471,12 @@ def parse_arith_sitofp(op_text, parse_ctx):
 
 
 @register_parser("arith.bitcast")
-def parse_arith_bitcast(op_text, parse_ctx):
-    result_match = re.match(r'(%\w+)\s*=\s*arith\.bitcast\s+(%\w+)', op_text)
+def parse_arith_bitcast(op_text, parse_ctx, result=None):
+    result_match = re.match(r'arith\.bitcast\s+(%\w+)', op_text)
     if not result_match:
         return None
 
-    result_name = result_match.group(1)
-    operand = result_match.group(2)
+    operand = result_match.group(1)
 
     dst_type = "f32"
     to_match = re.search(r'\bto\s+(\S+)\s*$', op_text)
@@ -487,7 +484,7 @@ def parse_arith_bitcast(op_text, parse_ctx):
         dst_type = to_match.group(1)
 
     return Operation(
-        result=result_name,
+        result=result,
         op_type="arith.bitcast",
         operands=[operand],
         attributes={"dst_type": dst_type},

--- a/ktir_cpu/dialects/arith_ops.py
+++ b/ktir_cpu/dialects/arith_ops.py
@@ -313,14 +313,13 @@ def arith__select(op, context, env):
 # ---------------------------------------------------------------------------
 
 @register_parser("arith.constant")
-def parse_arith_constant(op_text, parse_ctx, result=None):
+def parse_arith_constant(op_text, parse_ctx):
     from ..parser_utils import parse_numeric, parse_tensor_type, parse_dense_payload
 
     result_match = re.match(r'arith\.constant\s*(.*)', op_text)
     if not result_match:
         return None
 
-    result_name = result
     rest = result_match.group(1).strip()
 
     result_type = None
@@ -405,7 +404,7 @@ def parse_arith_constant(op_text, parse_ctx, result=None):
             attributes.setdefault("value", 0)
 
     return Operation(
-        result=result_name,
+        result=None,
         op_type="arith.constant",
         operands=[],
         attributes=attributes,
@@ -424,7 +423,7 @@ _CMP_PREDICATES = {
 
 
 @register_parser("arith.cmpi", "arith.cmpf")
-def parse_arith_cmp(op_text, parse_ctx, result=None):
+def parse_arith_cmp(op_text, parse_ctx):
     m = re.match(r'(arith\.cmp[if])\s+', op_text)
     if not m:
         return None
@@ -440,7 +439,7 @@ def parse_arith_cmp(op_text, parse_ctx, result=None):
     if type_match:
         result_type = type_match.group(1).strip()
     return Operation(
-        result=result,
+        result=None,
         op_type=op_type,
         operands=operands,
         attributes={"predicate": predicate},
@@ -449,7 +448,7 @@ def parse_arith_cmp(op_text, parse_ctx, result=None):
 
 
 @register_parser("arith.sitofp")
-def parse_arith_sitofp(op_text, parse_ctx, result=None):
+def parse_arith_sitofp(op_text, parse_ctx):
     result_match = re.match(r'arith\.sitofp\s+(%\w+)', op_text)
     if not result_match:
         return None
@@ -462,7 +461,7 @@ def parse_arith_sitofp(op_text, parse_ctx, result=None):
         result_type = to_match.group(1)
 
     return Operation(
-        result=result,
+        result=None,
         op_type="arith.sitofp",
         operands=[operand],
         attributes={},
@@ -471,7 +470,7 @@ def parse_arith_sitofp(op_text, parse_ctx, result=None):
 
 
 @register_parser("arith.bitcast")
-def parse_arith_bitcast(op_text, parse_ctx, result=None):
+def parse_arith_bitcast(op_text, parse_ctx):
     result_match = re.match(r'arith\.bitcast\s+(%\w+)', op_text)
     if not result_match:
         return None
@@ -484,7 +483,7 @@ def parse_arith_bitcast(op_text, parse_ctx, result=None):
         dst_type = to_match.group(1)
 
     return Operation(
-        result=result,
+        result=None,
         op_type="arith.bitcast",
         operands=[operand],
         attributes={"dst_type": dst_type},

--- a/ktir_cpu/dialects/ktdp_ops.py
+++ b/ktir_cpu/dialects/ktdp_ops.py
@@ -34,7 +34,7 @@ from ..ops.comm_ops import CommPlan, RingReduceBackend
 from ..ops.grid_ops import GridOps
 from ..ops.memory_ops import MemoryOps
 from ..parser_ast import enumerate_membership_keys, parse_affine_map, parse_affine_set
-from ..parser_utils import _extract_bracket_content, extract_named_attr, find_ssa_names, parse_attr_block, parse_multi_result_lhs, parse_tensor_type, split_top_level
+from ..parser_utils import _extract_bracket_content, extract_named_attr, find_ssa_names, parse_attr_block, parse_tensor_type, split_top_level
 from .registry import ParseContext, register, register_parser
 
 
@@ -262,37 +262,35 @@ def _make_compute_tile_id_op(result: str | list[str]) -> Operation:
 
 
 @register_parser("ktdp.get_compute_tile_id")
-def parse_get_compute_tile_id(op_text, parse_ctx: ParseContext):
+def parse_get_compute_tile_id(op_text, parse_ctx: ParseContext, result=None):
     m = re.match(
-        r"^(.*?)\s*=\s*ktdp\.get_compute_tile_id\s*:\s*([^{(]*)\s*$", op_text
+        r"ktdp\.get_compute_tile_id\s*:\s*([^{(]*)\s*$", op_text
     )
     if not m:
         return None
-    names = parse_multi_result_lhs(m.group(1))
-    types_text = m.group(2).strip()
+    types_text = m.group(1).strip()
     if not types_text:
         raise ValueError("no result types specified")
     type_list = [t.strip() for t in types_text.split(",")]
     if any(not t for t in type_list):
         raise ValueError(f"empty type in list: {types_text!r}")
     type_count = len(type_list)
-    if len(names) != type_count:
+    name_count = len(result) if isinstance(result, list) else 1
+    if name_count != type_count:
         raise ValueError(
-            f"ktdp.get_compute_tile_id: {len(names)} result name(s) but "
+            f"ktdp.get_compute_tile_id: {name_count} result name(s) but "
             f"{type_count} result type(s) in: {op_text!r}"
         )
-    result = names[0] if len(names) == 1 else names
     return _make_compute_tile_id_op(result)
 
 
 @register_parser("ktdp.construct_memory_view")
-def parse_construct_memory_view(op_text, parse_ctx: ParseContext):
-    result_match = re.match(r'(%\w+)\s*=\s*ktdp\.construct_memory_view\s+(%\w+)', op_text)
+def parse_construct_memory_view(op_text, parse_ctx: ParseContext, result=None):
+    result_match = re.match(r'ktdp\.construct_memory_view\s+(%\w+)', op_text)
     if not result_match:
         return None
 
-    result_name = result_match.group(1)
-    ptr_operand = result_match.group(2)
+    ptr_operand = result_match.group(1)
 
     # Parse sizes — int values validated against memref dims; SSA names stored as strings
     # and collected in ssa_size_operands so the executor can resolve them at runtime.
@@ -407,7 +405,7 @@ def parse_construct_memory_view(op_text, parse_ctx: ParseContext):
         attributes["coordinate_set"] = coordinate_set
 
     return Operation(
-        result=result_name,
+        result=result,
         op_type="ktdp.construct_memory_view",
         operands=[ptr_operand] + ssa_size_operands + ssa_stride_operands,
         attributes=attributes,
@@ -416,20 +414,18 @@ def parse_construct_memory_view(op_text, parse_ctx: ParseContext):
 
 
 @register_parser("ktdp.construct_distributed_memory_view")
-def parse_construct_distributed_memory_view(op_text, parse_ctx: ParseContext):
-    """Parse ``%R = ktdp.construct_distributed_memory_view (%a, %b, ... : types) : memref<...>``.
+def parse_construct_distributed_memory_view(op_text, parse_ctx: ParseContext, result=None):
+    """Parse ``ktdp.construct_distributed_memory_view (%a, %b, ... : types) : memref<...>``.
 
     Variadic memref operands, no required attributes — each input carries
     its own ``coordinate_set`` (on the input's ``construct_memory_view``).
     Result type encodes the global logical shape and dtype.
     """
     result_match = re.match(
-        r'(%\w+)\s*=\s*ktdp\.construct_distributed_memory_view', op_text
+        r'ktdp\.construct_distributed_memory_view', op_text
     )
     if not result_match:
         return None
-
-    result_name = result_match.group(1)
 
     # Extract operand list from the first parenthesized block.  The block's
     # content is "<%ops> : <types>"; we only need the %ops portion.
@@ -481,7 +477,7 @@ def parse_construct_distributed_memory_view(op_text, parse_ctx: ParseContext):
     shape = tuple(int(p) for p in parts[:-1])
 
     return Operation(
-        result=result_name,
+        result=result,
         op_type="ktdp.construct_distributed_memory_view",
         operands=operands,
         attributes={"shape": shape, "dtype": dtype},
@@ -490,15 +486,12 @@ def parse_construct_distributed_memory_view(op_text, parse_ctx: ParseContext):
 
 
 @register_parser("ktdp.construct_access_tile")
-def parse_construct_access_tile(op_text, parse_ctx: ParseContext):
-    result_match = re.match(r'(%\w+)\s*=\s*ktdp\.construct_access_tile\s+', op_text)
+def parse_construct_access_tile(op_text, parse_ctx: ParseContext, result=None):
+    result_match = re.match(r'ktdp\.construct_access_tile\s+', op_text)
     if not result_match:
         return None
 
-    result_name = result_match.group(1)
-
-    after_eq = op_text[op_text.index('=') + 1:]
-    operands = find_ssa_names(after_eq)
+    operands = find_ssa_names(op_text)
 
     tile_match = re.search(r'!ktdp\.access_tile<([^>]+)>', op_text)
     if not tile_match:
@@ -569,7 +562,7 @@ def parse_construct_access_tile(op_text, parse_ctx: ParseContext):
         attributes["coordinate_order"] = coordinate_order
 
     return Operation(
-        result=result_name,
+        result=result,
         op_type="ktdp.construct_access_tile",
         operands=operands,
         attributes=attributes,
@@ -733,15 +726,12 @@ def ktdp__construct_indirect_access_tile(op, context, env):
 
 
 @register_parser("ktdp.construct_indirect_access_tile")
-def parse_construct_indirect_access_tile(op_text, parse_ctx: ParseContext):
-    # Match: %result = ktdp.construct_indirect_access_tile
+def parse_construct_indirect_access_tile(op_text, parse_ctx: ParseContext, result=None):
     result_match = re.match(
-        r'(%\w+)\s*=\s*ktdp\.construct_indirect_access_tile\s+', op_text
+        r'ktdp\.construct_indirect_access_tile\s+', op_text
     )
     if not result_match:
         return None
-
-    result_name = result_match.group(1)
 
     # Extract intermediate variable names from: intermediate_variables(%m, %k)
     iv_match = re.search(r'intermediate_variables\s*\(([^)]+)\)', op_text)
@@ -833,7 +823,7 @@ def parse_construct_indirect_access_tile(op_text, parse_ctx: ParseContext):
         attributes["variables_space_order"] = variables_space_order
 
     return Operation(
-        result=result_name,
+        result=result,
         op_type="ktdp.construct_indirect_access_tile",
         operands=operands,
         attributes=attributes,
@@ -993,11 +983,10 @@ def ktdp__inter_tile_produce(op, context, env):
 
 
 @register_parser("ktdp.inter_tile_produce")
-def parse_inter_tile_produce(op_text, parse_ctx: ParseContext):
-    m = re.match(r'(%\w+)\s*=\s*ktdp\.inter_tile_produce\b', op_text)
+def parse_inter_tile_produce(op_text, parse_ctx: ParseContext, result=None):
+    m = re.match(r'ktdp\.inter_tile_produce\b', op_text)
     if not m:
         return None
-    result_name = m.group(1)
 
     producer_set_str = extract_named_attr(
         op_text, "producer_tiles_per_group", parse_ctx.aliases
@@ -1022,7 +1011,7 @@ def parse_inter_tile_produce(op_text, parse_ctx: ParseContext):
     partial_types = tuple(p.strip() for p in split_top_level(inner))
 
     return Operation(
-        result=result_name,
+        result=result,
         op_type="ktdp.inter_tile_produce",
         operands=[],
         attributes={
@@ -1069,12 +1058,12 @@ def _parse_yield(op_text, op_name):
 
 
 @register_parser("ktdp.yield_partial")
-def parse_yield_partial(op_text, parse_ctx: ParseContext):
+def parse_yield_partial(op_text, parse_ctx: ParseContext, result=None):
     return _parse_yield(op_text, "ktdp.yield_partial")
 
 
 @register_parser("ktdp.yield_reduced")
-def parse_yield_reduced(op_text, parse_ctx: ParseContext):
+def parse_yield_reduced(op_text, parse_ctx: ParseContext, result=None):
     return _parse_yield(op_text, "ktdp.yield_reduced")
 
 
@@ -1166,15 +1155,14 @@ def ktdp__inter_tile_reduce(op, context, env):
 
 
 @register_parser("ktdp.inter_tile_reduce")
-def parse_inter_tile_reduce(op_text, parse_ctx: ParseContext):
+def parse_inter_tile_reduce(op_text, parse_ctx: ParseContext, result=None):
     m = re.match(
-        r'(%\w+)\s*=\s*ktdp\.inter_tile_reduce\s*\(\s*(%\w+)\s*\)',
+        r'ktdp\.inter_tile_reduce\s*\(\s*(%\w+)\s*\)',
         op_text,
     )
     if not m:
         return None
-    result_name = m.group(1)
-    fut_operand = m.group(2)
+    fut_operand = m.group(1)
 
     consumer_set_str = extract_named_attr(
         op_text, "consumer_tiles_per_group", parse_ctx.aliases
@@ -1222,7 +1210,7 @@ def parse_inter_tile_reduce(op_text, parse_ctx: ParseContext):
     operands = [fut_operand] + identity_operands
 
     return Operation(
-        result=result_name,
+        result=result,
         op_type="ktdp.inter_tile_reduce",
         operands=operands,
         attributes=attributes,

--- a/ktir_cpu/dialects/ktdp_ops.py
+++ b/ktir_cpu/dialects/ktdp_ops.py
@@ -251,12 +251,15 @@ def ktdp__store(op, context, env):
 # Comma form keeps result names verbatim ("%x", "%y").
 # Bundled form synthesizes "%g#0", "%g#1" so downstream operand lookup
 # finds distinct keys.
-def _make_compute_tile_id_op(result: str | list[str]) -> Operation:
+def _make_compute_tile_id_op(result: str | list[str], expected_result_count=None) -> Operation:
+    attrs = {}
+    if expected_result_count is not None:
+        attrs["_result_count"] = expected_result_count
     return Operation(
         result=result,
         op_type="ktdp.get_compute_tile_id",
         operands=[],
-        attributes={},
+        attributes=attrs,
         result_type="index",
     )
 
@@ -265,7 +268,11 @@ def _make_compute_tile_id_op(result: str | list[str]) -> Operation:
 def parse_get_compute_tile_id(op_text, parse_ctx: ParseContext):
     if not op_text.startswith("ktdp.get_compute_tile_id"):
         return None
-    return _make_compute_tile_id_op(None)
+    types_text = re.search(r':\s*(.+)$', op_text)
+    if not types_text:
+        raise ValueError("ktdp.get_compute_tile_id: no result types specified")
+    type_list = [t.strip() for t in types_text.group(1).split(",") if t.strip()]
+    return _make_compute_tile_id_op(None, expected_result_count=len(type_list))
 
 
 @register_parser("ktdp.construct_memory_view")

--- a/ktir_cpu/dialects/ktdp_ops.py
+++ b/ktir_cpu/dialects/ktdp_ops.py
@@ -262,30 +262,14 @@ def _make_compute_tile_id_op(result: str | list[str]) -> Operation:
 
 
 @register_parser("ktdp.get_compute_tile_id")
-def parse_get_compute_tile_id(op_text, parse_ctx: ParseContext, result=None):
-    m = re.match(
-        r"ktdp\.get_compute_tile_id\s*:\s*([^{(]*)\s*$", op_text
-    )
-    if not m:
+def parse_get_compute_tile_id(op_text, parse_ctx: ParseContext):
+    if not op_text.startswith("ktdp.get_compute_tile_id"):
         return None
-    types_text = m.group(1).strip()
-    if not types_text:
-        raise ValueError("no result types specified")
-    type_list = [t.strip() for t in types_text.split(",")]
-    if any(not t for t in type_list):
-        raise ValueError(f"empty type in list: {types_text!r}")
-    type_count = len(type_list)
-    name_count = len(result) if isinstance(result, list) else 1
-    if name_count != type_count:
-        raise ValueError(
-            f"ktdp.get_compute_tile_id: {name_count} result name(s) but "
-            f"{type_count} result type(s) in: {op_text!r}"
-        )
-    return _make_compute_tile_id_op(result)
+    return _make_compute_tile_id_op(None)
 
 
 @register_parser("ktdp.construct_memory_view")
-def parse_construct_memory_view(op_text, parse_ctx: ParseContext, result=None):
+def parse_construct_memory_view(op_text, parse_ctx: ParseContext):
     result_match = re.match(r'ktdp\.construct_memory_view\s+(%\w+)', op_text)
     if not result_match:
         return None
@@ -405,7 +389,7 @@ def parse_construct_memory_view(op_text, parse_ctx: ParseContext, result=None):
         attributes["coordinate_set"] = coordinate_set
 
     return Operation(
-        result=result,
+        result=None,
         op_type="ktdp.construct_memory_view",
         operands=[ptr_operand] + ssa_size_operands + ssa_stride_operands,
         attributes=attributes,
@@ -414,7 +398,7 @@ def parse_construct_memory_view(op_text, parse_ctx: ParseContext, result=None):
 
 
 @register_parser("ktdp.construct_distributed_memory_view")
-def parse_construct_distributed_memory_view(op_text, parse_ctx: ParseContext, result=None):
+def parse_construct_distributed_memory_view(op_text, parse_ctx: ParseContext):
     """Parse ``ktdp.construct_distributed_memory_view (%a, %b, ... : types) : memref<...>``.
 
     Variadic memref operands, no required attributes — each input carries
@@ -477,7 +461,7 @@ def parse_construct_distributed_memory_view(op_text, parse_ctx: ParseContext, re
     shape = tuple(int(p) for p in parts[:-1])
 
     return Operation(
-        result=result,
+        result=None,
         op_type="ktdp.construct_distributed_memory_view",
         operands=operands,
         attributes={"shape": shape, "dtype": dtype},
@@ -486,7 +470,7 @@ def parse_construct_distributed_memory_view(op_text, parse_ctx: ParseContext, re
 
 
 @register_parser("ktdp.construct_access_tile")
-def parse_construct_access_tile(op_text, parse_ctx: ParseContext, result=None):
+def parse_construct_access_tile(op_text, parse_ctx: ParseContext):
     result_match = re.match(r'ktdp\.construct_access_tile\s+', op_text)
     if not result_match:
         return None
@@ -562,7 +546,7 @@ def parse_construct_access_tile(op_text, parse_ctx: ParseContext, result=None):
         attributes["coordinate_order"] = coordinate_order
 
     return Operation(
-        result=result,
+        result=None,
         op_type="ktdp.construct_access_tile",
         operands=operands,
         attributes=attributes,
@@ -726,7 +710,7 @@ def ktdp__construct_indirect_access_tile(op, context, env):
 
 
 @register_parser("ktdp.construct_indirect_access_tile")
-def parse_construct_indirect_access_tile(op_text, parse_ctx: ParseContext, result=None):
+def parse_construct_indirect_access_tile(op_text, parse_ctx: ParseContext):
     result_match = re.match(
         r'ktdp\.construct_indirect_access_tile\s+', op_text
     )
@@ -823,7 +807,7 @@ def parse_construct_indirect_access_tile(op_text, parse_ctx: ParseContext, resul
         attributes["variables_space_order"] = variables_space_order
 
     return Operation(
-        result=result,
+        result=None,
         op_type="ktdp.construct_indirect_access_tile",
         operands=operands,
         attributes=attributes,
@@ -983,7 +967,7 @@ def ktdp__inter_tile_produce(op, context, env):
 
 
 @register_parser("ktdp.inter_tile_produce")
-def parse_inter_tile_produce(op_text, parse_ctx: ParseContext, result=None):
+def parse_inter_tile_produce(op_text, parse_ctx: ParseContext):
     m = re.match(r'ktdp\.inter_tile_produce\b', op_text)
     if not m:
         return None
@@ -1011,7 +995,7 @@ def parse_inter_tile_produce(op_text, parse_ctx: ParseContext, result=None):
     partial_types = tuple(p.strip() for p in split_top_level(inner))
 
     return Operation(
-        result=result,
+        result=None,
         op_type="ktdp.inter_tile_produce",
         operands=[],
         attributes={
@@ -1058,12 +1042,12 @@ def _parse_yield(op_text, op_name):
 
 
 @register_parser("ktdp.yield_partial")
-def parse_yield_partial(op_text, parse_ctx: ParseContext, result=None):
+def parse_yield_partial(op_text, parse_ctx: ParseContext):
     return _parse_yield(op_text, "ktdp.yield_partial")
 
 
 @register_parser("ktdp.yield_reduced")
-def parse_yield_reduced(op_text, parse_ctx: ParseContext, result=None):
+def parse_yield_reduced(op_text, parse_ctx: ParseContext):
     return _parse_yield(op_text, "ktdp.yield_reduced")
 
 
@@ -1155,7 +1139,7 @@ def ktdp__inter_tile_reduce(op, context, env):
 
 
 @register_parser("ktdp.inter_tile_reduce")
-def parse_inter_tile_reduce(op_text, parse_ctx: ParseContext, result=None):
+def parse_inter_tile_reduce(op_text, parse_ctx: ParseContext):
     m = re.match(
         r'ktdp\.inter_tile_reduce\s*\(\s*(%\w+)\s*\)',
         op_text,
@@ -1210,7 +1194,7 @@ def parse_inter_tile_reduce(op_text, parse_ctx: ParseContext, result=None):
     operands = [fut_operand] + identity_operands
 
     return Operation(
-        result=result,
+        result=None,
         op_type="ktdp.inter_tile_reduce",
         operands=operands,
         attributes=attributes,

--- a/ktir_cpu/dialects/linalg_ops.py
+++ b/ktir_cpu/dialects/linalg_ops.py
@@ -461,7 +461,7 @@ def linalg__transpose(op, context, env):
 # element-by-element.  A Python-level fold over every element would be
 # prohibitively slow for the tile sizes seen in practice.
 @register_parser("linalg.reduce")
-def parse_linalg_reduce(op_text, parse_ctx, result=None):
+def parse_linalg_reduce(op_text, parse_ctx):
     """Parse linalg.reduce — shorthand or explicit-region form."""
     result_match = re.match(r'linalg\.reduce\s+', op_text)
     if not result_match:
@@ -499,7 +499,7 @@ def parse_linalg_reduce(op_text, parse_ctx, result=None):
         attributes["outs_var"] = outs_var
 
     return Operation(
-        result=result,
+        result=None,
         op_type="linalg.reduce",
         operands=operands,
         attributes=attributes,
@@ -508,7 +508,7 @@ def parse_linalg_reduce(op_text, parse_ctx, result=None):
 
 
 @register_parser("linalg.fill")
-def parse_linalg_fill(op_text, parse_ctx, result=None):
+def parse_linalg_fill(op_text, parse_ctx):
     """Parse linalg.fill ins(%scalar : f16) outs(%init : tensor<1xf16>) -> tensor<1xf16>"""
     result_match = re.match(r'linalg\.fill\s+', op_text)
     if not result_match:
@@ -525,7 +525,7 @@ def parse_linalg_fill(op_text, parse_ctx, result=None):
         operands.extend(find_ssa_names(outs_match.group(1)))
 
     return Operation(
-        result=result,
+        result=None,
         op_type="linalg.fill",
         operands=operands,
         attributes={},
@@ -534,7 +534,7 @@ def parse_linalg_fill(op_text, parse_ctx, result=None):
 
 
 @register_parser("linalg.transpose")
-def parse_linalg_transpose(op_text, parse_ctx, result=None):
+def parse_linalg_transpose(op_text, parse_ctx):
     """Parse linalg.transpose ins(%x : type) outs(%y : type) permutation = [d0, d1, ...]"""
     result_match = re.match(r'linalg\.transpose', op_text)
     if not result_match:
@@ -549,7 +549,7 @@ def parse_linalg_transpose(op_text, parse_ctx, result=None):
 
     permutation = [int(d.strip()) for d in perm_match.group(1).split(',')]
     return Operation(
-        result=result,
+        result=None,
         op_type="linalg.transpose",
         operands=[ins_match.group(1), outs_match.group(1)],
         attributes={"permutation": permutation},
@@ -558,7 +558,7 @@ def parse_linalg_transpose(op_text, parse_ctx, result=None):
 
 
 @register_parser("linalg.generic")
-def parse_linalg_generic(op_text, parse_ctx, result=None):
+def parse_linalg_generic(op_text, parse_ctx):
     """Parse linalg.generic header."""
     result_match = re.match(r'linalg\.generic\s+', op_text)
     if not result_match:
@@ -585,7 +585,7 @@ def parse_linalg_generic(op_text, parse_ctx, result=None):
         outs_operands = find_ssa_names(outs_match.group(1).split(':')[0])
 
     return Operation(
-        result=result,
+        result=None,
         op_type="linalg.generic",
         operands=ins_operands + outs_operands,
         attributes={"indexing_maps": maps, "n_ins": len(ins_operands)},
@@ -594,13 +594,13 @@ def parse_linalg_generic(op_text, parse_ctx, result=None):
 
 
 @register_parser("linalg.index")
-def parse_linalg_index(op_text, parse_ctx, result=None):
+def parse_linalg_index(op_text, parse_ctx):
     """Parse %row = linalg.index 0 : index"""
     m = re.match(r'linalg\.index\s+(\d+)', op_text)
     if not m:
         return None
     return Operation(
-        result=result,
+        result=None,
         op_type="linalg.index",
         operands=[],
         attributes={"dim": int(m.group(1))},
@@ -609,7 +609,7 @@ def parse_linalg_index(op_text, parse_ctx, result=None):
 
 
 @register_parser("linalg.yield")
-def parse_linalg_yield(op_text, parse_ctx, result=None):
+def parse_linalg_yield(op_text, parse_ctx):
     """Parse linalg.yield %val : type"""
     m = re.match(r'linalg\.yield\s+(.*)', op_text)
     if not m:
@@ -625,7 +625,7 @@ def parse_linalg_yield(op_text, parse_ctx, result=None):
 
 
 @register_parser("linalg.broadcast")
-def parse_linalg_broadcast(op_text, parse_ctx, result=None):
+def parse_linalg_broadcast(op_text, parse_ctx):
     """Parse linalg.broadcast ins(%x : tensor<1xf16>) outs(%y : tensor<1x1024xf16>) dimensions = [1]"""
     result_match = re.match(r'linalg\.broadcast\s+', op_text)
     if not result_match:
@@ -646,7 +646,7 @@ def parse_linalg_broadcast(op_text, parse_ctx, result=None):
         dims = [int(d.strip()) for d in dims_match.group(1).split(',')]
 
     return Operation(
-        result=result,
+        result=None,
         op_type="linalg.broadcast",
         operands=operands,
         attributes={"dimensions": dims},

--- a/ktir_cpu/dialects/linalg_ops.py
+++ b/ktir_cpu/dialects/linalg_ops.py
@@ -461,13 +461,11 @@ def linalg__transpose(op, context, env):
 # element-by-element.  A Python-level fold over every element would be
 # prohibitively slow for the tile sizes seen in practice.
 @register_parser("linalg.reduce")
-def parse_linalg_reduce(op_text, parse_ctx):
+def parse_linalg_reduce(op_text, parse_ctx, result=None):
     """Parse linalg.reduce — shorthand or explicit-region form."""
-    result_match = re.match(r'(%\w+)\s*=\s*linalg\.reduce\s+', op_text)
+    result_match = re.match(r'linalg\.reduce\s+', op_text)
     if not result_match:
         return None
-
-    result_name = result_match.group(1)
 
     # Shorthand combiner: { arith.addf } in the op text (no %SSA inside)
     reduce_fn = None
@@ -501,7 +499,7 @@ def parse_linalg_reduce(op_text, parse_ctx):
         attributes["outs_var"] = outs_var
 
     return Operation(
-        result=result_name,
+        result=result,
         op_type="linalg.reduce",
         operands=operands,
         attributes=attributes,
@@ -510,13 +508,11 @@ def parse_linalg_reduce(op_text, parse_ctx):
 
 
 @register_parser("linalg.fill")
-def parse_linalg_fill(op_text, parse_ctx):
+def parse_linalg_fill(op_text, parse_ctx, result=None):
     """Parse linalg.fill ins(%scalar : f16) outs(%init : tensor<1xf16>) -> tensor<1xf16>"""
-    result_match = re.match(r'(%\w+)\s*=\s*linalg\.fill\s+', op_text)
+    result_match = re.match(r'linalg\.fill\s+', op_text)
     if not result_match:
         return None
-
-    result_name = result_match.group(1)
 
     # Extract ins and outs operands
     ins_match = re.search(r'ins\(([^)]+)\)', op_text)
@@ -529,7 +525,7 @@ def parse_linalg_fill(op_text, parse_ctx):
         operands.extend(find_ssa_names(outs_match.group(1)))
 
     return Operation(
-        result=result_name,
+        result=result,
         op_type="linalg.fill",
         operands=operands,
         attributes={},
@@ -538,12 +534,11 @@ def parse_linalg_fill(op_text, parse_ctx):
 
 
 @register_parser("linalg.transpose")
-def parse_linalg_transpose(op_text, parse_ctx):
+def parse_linalg_transpose(op_text, parse_ctx, result=None):
     """Parse linalg.transpose ins(%x : type) outs(%y : type) permutation = [d0, d1, ...]"""
-    result_match = re.match(r'(%\w+)\s*=\s*linalg\.transpose', op_text)
+    result_match = re.match(r'linalg\.transpose', op_text)
     if not result_match:
         return None
-    result_name = result_match.group(1)
 
     ins_match = re.search(r'ins\s*\(\s*(%\w+)\s*:', op_text)
     outs_match = re.search(r'outs\s*\(\s*(%\w+)\s*:', op_text)
@@ -554,7 +549,7 @@ def parse_linalg_transpose(op_text, parse_ctx):
 
     permutation = [int(d.strip()) for d in perm_match.group(1).split(',')]
     return Operation(
-        result=result_name,
+        result=result,
         op_type="linalg.transpose",
         operands=[ins_match.group(1), outs_match.group(1)],
         attributes={"permutation": permutation},
@@ -563,12 +558,11 @@ def parse_linalg_transpose(op_text, parse_ctx):
 
 
 @register_parser("linalg.generic")
-def parse_linalg_generic(op_text, parse_ctx):
+def parse_linalg_generic(op_text, parse_ctx, result=None):
     """Parse linalg.generic header."""
-    result_match = re.match(r'(%\w+)\s*=\s*linalg\.generic\s+', op_text)
+    result_match = re.match(r'linalg\.generic\s+', op_text)
     if not result_match:
         return None
-    result_name = result_match.group(1)
 
     # indexing_maps = [affine_map<(d0, d1) -> (d0)>, ...]
     maps = []
@@ -591,7 +585,7 @@ def parse_linalg_generic(op_text, parse_ctx):
         outs_operands = find_ssa_names(outs_match.group(1).split(':')[0])
 
     return Operation(
-        result=result_name,
+        result=result,
         op_type="linalg.generic",
         operands=ins_operands + outs_operands,
         attributes={"indexing_maps": maps, "n_ins": len(ins_operands)},
@@ -600,22 +594,22 @@ def parse_linalg_generic(op_text, parse_ctx):
 
 
 @register_parser("linalg.index")
-def parse_linalg_index(op_text, parse_ctx):
+def parse_linalg_index(op_text, parse_ctx, result=None):
     """Parse %row = linalg.index 0 : index"""
-    m = re.match(r'(%\w+)\s*=\s*linalg\.index\s+(\d+)', op_text)
+    m = re.match(r'linalg\.index\s+(\d+)', op_text)
     if not m:
         return None
     return Operation(
-        result=m.group(1),
+        result=result,
         op_type="linalg.index",
         operands=[],
-        attributes={"dim": int(m.group(2))},
+        attributes={"dim": int(m.group(1))},
         result_type="index",
     )
 
 
 @register_parser("linalg.yield")
-def parse_linalg_yield(op_text, parse_ctx):
+def parse_linalg_yield(op_text, parse_ctx, result=None):
     """Parse linalg.yield %val : type"""
     m = re.match(r'linalg\.yield\s+(.*)', op_text)
     if not m:
@@ -631,13 +625,11 @@ def parse_linalg_yield(op_text, parse_ctx):
 
 
 @register_parser("linalg.broadcast")
-def parse_linalg_broadcast(op_text, parse_ctx):
+def parse_linalg_broadcast(op_text, parse_ctx, result=None):
     """Parse linalg.broadcast ins(%x : tensor<1xf16>) outs(%y : tensor<1x1024xf16>) dimensions = [1]"""
-    result_match = re.match(r'(%\w+)\s*=\s*linalg\.broadcast\s+', op_text)
+    result_match = re.match(r'linalg\.broadcast\s+', op_text)
     if not result_match:
         return None
-
-    result_name = result_match.group(1)
 
     ins_match = re.search(r'ins\(([^)]+)\)', op_text)
     outs_match = re.search(r'outs\(([^)]+)\)', op_text)
@@ -654,7 +646,7 @@ def parse_linalg_broadcast(op_text, parse_ctx):
         dims = [int(d.strip()) for d in dims_match.group(1).split(',')]
 
     return Operation(
-        result=result_name,
+        result=result,
         op_type="linalg.broadcast",
         operands=operands,
         attributes={"dimensions": dims},

--- a/ktir_cpu/dialects/registry.py
+++ b/ktir_cpu/dialects/registry.py
@@ -57,8 +57,8 @@ def get_latency_category(op_name: str) -> str:
 # Parser registry
 # ---------------------------------------------------------------------------
 
-# Parser signature: (op_text: str, parse_ctx: ParseContext, result=None) -> Optional[Operation]
-# op_text is LHS-free (body only); result is the pre-computed result name(s).
+# Parser signature: (op_text: str, parse_ctx: ParseContext) -> Optional[Operation]
+# op_text is LHS-free (body only); caller assigns op.result after return.
 ParserFn = Callable[..., Optional[Operation]]
 
 _PARSER_REGISTRY: Dict[str, ParserFn] = {}

--- a/ktir_cpu/dialects/registry.py
+++ b/ktir_cpu/dialects/registry.py
@@ -57,8 +57,9 @@ def get_latency_category(op_name: str) -> str:
 # Parser registry
 # ---------------------------------------------------------------------------
 
-# Parser signature: (op_text: str, parse_ctx: ParseContext) -> Optional[Operation]
-ParserFn = Callable[[str, "ParseContext"], Optional[Operation]]
+# Parser signature: (op_text: str, parse_ctx: ParseContext, result=None) -> Optional[Operation]
+# op_text is LHS-free (body only); result is the pre-computed result name(s).
+ParserFn = Callable[..., Optional[Operation]]
 
 _PARSER_REGISTRY: Dict[str, ParserFn] = {}
 

--- a/ktir_cpu/dialects/scf_ops.py
+++ b/ktir_cpu/dialects/scf_ops.py
@@ -19,7 +19,7 @@ import re
 from ..ir_types import Operation
 from ..latency import LatencyCategory as LC
 from ..ops.control_ops import ControlOps
-from ..parser_utils import find_ssa_names, parse_multi_result_lhs
+from ..parser_utils import find_ssa_names
 from .registry import register, register_parser
 
 
@@ -91,7 +91,7 @@ def region__bb0_args(op, context, env):
 
 
 @register_parser("^bb0")
-def parse_bb0_block_args(op_text, parse_ctx):
+def parse_bb0_block_args(op_text, parse_ctx, result=None):
     """Parse a ^bb0 block-argument label inside any region body.
 
     Syntax:
@@ -114,17 +114,10 @@ def parse_bb0_block_args(op_text, parse_ctx):
 
 
 @register_parser("scf.for ")
-def parse_scf_for(op_text, parse_ctx):
-    # Detect optional outer result variable(s): %a, %b, %c = scf.for ...
-    # Also handles bundled form: %acc:2 = scf.for ...
-    outer_result = None
-    outer_match = re.match(r'((?:%\w+(?::\d+)?\s*,\s*)*%\w+(?::\d+)?)\s*=\s*scf\.for\s+', op_text)
-    if outer_match:
-        names = parse_multi_result_lhs(outer_match.group(1))
-        outer_result = names if len(names) > 1 else names[0]
-
+def parse_scf_for(op_text, parse_ctx, result=None):
+    # op_text is LHS-free: "scf.for %i = %c0 to %n step %c1 ..."
     scf_match = re.match(
-        r'(?:(?:%\w+(?::\d+)?\s*,\s*)*%\w+(?::\d+)?\s*=\s*)?scf\.for\s+(%\w+)\s*=\s*(%\w+)\s+to\s+(%\w+)\s+step\s+(%\w+)',
+        r'scf\.for\s+(%\w+)\s*=\s*(%\w+)\s+to\s+(%\w+)\s+step\s+(%\w+)',
         op_text
     )
     if not scf_match:
@@ -147,9 +140,7 @@ def parse_scf_for(op_text, parse_ctx):
     if iter_args:
         attributes["iter_args"] = iter_args
 
-    # Use the outer result variable if present (e.g. %c = scf.for %off_k = ...);
-    # otherwise fall back to the iter_var for loops without a result.
-    result_name = outer_result if outer_result else iter_var
+    result_name = result if result is not None else iter_var
 
     return Operation(
         result=result_name,
@@ -160,8 +151,8 @@ def parse_scf_for(op_text, parse_ctx):
     )
 
 
-@register_parser("scf.yield", "= scf.yield")
-def parse_scf_yield(op_text, parse_ctx):
+@register_parser("scf.yield")
+def parse_scf_yield(op_text, parse_ctx, result=None):
     rest = op_text
     yield_match = re.match(r'scf\.yield\s*(.*)', op_text)
     if yield_match:

--- a/ktir_cpu/dialects/scf_ops.py
+++ b/ktir_cpu/dialects/scf_ops.py
@@ -91,7 +91,7 @@ def region__bb0_args(op, context, env):
 
 
 @register_parser("^bb0")
-def parse_bb0_block_args(op_text, parse_ctx, result=None):
+def parse_bb0_block_args(op_text, parse_ctx):
     """Parse a ^bb0 block-argument label inside any region body.
 
     Syntax:
@@ -114,7 +114,7 @@ def parse_bb0_block_args(op_text, parse_ctx, result=None):
 
 
 @register_parser("scf.for ")
-def parse_scf_for(op_text, parse_ctx, result=None):
+def parse_scf_for(op_text, parse_ctx):
     # op_text is LHS-free: "scf.for %i = %c0 to %n step %c1 ..."
     scf_match = re.match(
         r'scf\.for\s+(%\w+)\s*=\s*(%\w+)\s+to\s+(%\w+)\s+step\s+(%\w+)',
@@ -140,10 +140,8 @@ def parse_scf_for(op_text, parse_ctx, result=None):
     if iter_args:
         attributes["iter_args"] = iter_args
 
-    result_name = result if result is not None else iter_var
-
     return Operation(
-        result=result_name,
+        result=iter_var,
         op_type="scf.for",
         operands=[lb, ub, step] + iter_inits,
         attributes=attributes,
@@ -152,7 +150,7 @@ def parse_scf_for(op_text, parse_ctx, result=None):
 
 
 @register_parser("scf.yield")
-def parse_scf_yield(op_text, parse_ctx, result=None):
+def parse_scf_yield(op_text, parse_ctx):
     rest = op_text
     yield_match = re.match(r'scf\.yield\s*(.*)', op_text)
     if yield_match:

--- a/ktir_cpu/dialects/scf_ops.py
+++ b/ktir_cpu/dialects/scf_ops.py
@@ -19,7 +19,7 @@ import re
 from ..ir_types import Operation
 from ..latency import LatencyCategory as LC
 from ..ops.control_ops import ControlOps
-from ..parser_utils import find_ssa_names
+from ..parser_utils import find_ssa_names, parse_multi_result_lhs
 from .registry import register, register_parser
 
 
@@ -116,14 +116,15 @@ def parse_bb0_block_args(op_text, parse_ctx):
 @register_parser("scf.for ")
 def parse_scf_for(op_text, parse_ctx):
     # Detect optional outer result variable(s): %a, %b, %c = scf.for ...
+    # Also handles bundled form: %acc:2 = scf.for ...
     outer_result = None
-    outer_match = re.match(r'((?:%\w+\s*,\s*)*%\w+)\s*=\s*scf\.for\s+', op_text)
+    outer_match = re.match(r'((?:%\w+(?::\d+)?\s*,\s*)*%\w+(?::\d+)?)\s*=\s*scf\.for\s+', op_text)
     if outer_match:
-        names = [n.strip() for n in outer_match.group(1).split(',')]
+        names = parse_multi_result_lhs(outer_match.group(1))
         outer_result = names if len(names) > 1 else names[0]
 
     scf_match = re.match(
-        r'(?:(?:%\w+\s*,\s*)*%\w+\s*=\s*)?scf\.for\s+(%\w+)\s*=\s*(%\w+)\s+to\s+(%\w+)\s+step\s+(%\w+)',
+        r'(?:(?:%\w+(?::\d+)?\s*,\s*)*%\w+(?::\d+)?\s*=\s*)?scf\.for\s+(%\w+)\s*=\s*(%\w+)\s+to\s+(%\w+)\s+step\s+(%\w+)',
         op_text
     )
     if not scf_match:

--- a/ktir_cpu/dialects/tensor_ops.py
+++ b/ktir_cpu/dialects/tensor_ops.py
@@ -355,21 +355,20 @@ def tensor__generate(op, context, env):
 # ---------------------------------------------------------------------------
 
 @register_parser("tensor.empty")
-def parse_tensor_empty(op_text, parse_ctx):
+def parse_tensor_empty(op_text, parse_ctx, result=None):
     """Parse tensor.empty() : tensor<1x1024xf16>"""
     from ..parser_utils import parse_tensor_type
-    result_match = re.match(r'(%\w+)\s*=\s*tensor\.empty\s*\(\s*\)\s*:\s*(.+)', op_text)
+    result_match = re.match(r'tensor\.empty\s*\(\s*\)\s*:\s*(.+)', op_text)
     if not result_match:
         return None
-    result_name = result_match.group(1)
-    type_str = result_match.group(2).strip()
+    type_str = result_match.group(1).strip()
     type_info = parse_tensor_type(type_str)
     attributes = {}
     if type_info:
         attributes["shape"] = type_info["shape"]
         attributes["dtype"] = type_info.get("dtype", "f16")
     return Operation(
-        result=result_name,
+        result=result,
         op_type="tensor.empty",
         operands=[],
         attributes=attributes,
@@ -378,15 +377,14 @@ def parse_tensor_empty(op_text, parse_ctx):
 
 
 @register_parser("tensor.splat")
-def parse_tensor_splat(op_text, parse_ctx):
+def parse_tensor_splat(op_text, parse_ctx, result=None):
     from ..parser_utils import parse_tensor_type
-    result_match = re.match(r'(%\w+)\s*=\s*tensor\.splat\s+(%\w+)\s*(?::\s*(.+))?', op_text)
+    result_match = re.match(r'tensor\.splat\s+(%\w+)\s*(?::\s*(.+))?', op_text)
     if not result_match:
         return None
 
-    result_name = result_match.group(1)
-    scalar_operand = result_match.group(2)
-    type_str = result_match.group(3).strip() if result_match.group(3) else "unknown"
+    scalar_operand = result_match.group(1)
+    type_str = result_match.group(2).strip() if result_match.group(2) else "unknown"
 
     # When the syntax is `src_type -> dst_type`, parse the destination (result) type.
     # e.g. tensor<1x1xf16> -> tensor<1x1024xf16>  — we want the 1x1024 shape.
@@ -403,7 +401,7 @@ def parse_tensor_splat(op_text, parse_ctx):
         attributes["dtype"] = type_info.get("dtype", "f16")
 
     return Operation(
-        result=result_name,
+        result=result,
         op_type="tensor.splat",
         operands=[scalar_operand],
         attributes=attributes,
@@ -412,14 +410,13 @@ def parse_tensor_splat(op_text, parse_ctx):
 
 
 @register_parser("tensor.extract ")
-def parse_tensor_extract(op_text, parse_ctx):
+def parse_tensor_extract(op_text, parse_ctx, result=None):
     # %scalar = tensor.extract %tensor[%i0, %i1] : tensor<...>
-    result_match = re.match(r'(%\w+)\s*=\s*tensor\.extract\s+(%\w+)', op_text)
+    result_match = re.match(r'tensor\.extract\s+(%\w+)', op_text)
     if not result_match:
         return None
 
-    result_name = result_match.group(1)
-    src_operand = result_match.group(2)
+    src_operand = result_match.group(1)
 
     # Extract index operands from brackets: [%c0] or [%i, %j] or []
     indices = []
@@ -430,7 +427,7 @@ def parse_tensor_extract(op_text, parse_ctx):
             indices = find_ssa_names(bracket_content)
 
     return Operation(
-        result=result_name,
+        result=result,
         op_type="tensor.extract",
         operands=[src_operand] + indices,
         attributes={},
@@ -438,16 +435,15 @@ def parse_tensor_extract(op_text, parse_ctx):
     )
 
 
-def _parse_reshape_op(op_text, op_name):
+def _parse_reshape_op(op_text, op_name, result=None):
     """Shared parser for tensor.expand_shape and tensor.collapse_shape."""
     result_match = re.match(
-        r'(%\w+)\s*=\s*tensor\.' + op_name + r'\s+(%\w+)', op_text
+        r'tensor\.' + op_name + r'\s+(%\w+)', op_text
     )
     if not result_match:
         return None
 
-    result_name = result_match.group(1)
-    operand = result_match.group(2)
+    operand = result_match.group(1)
 
     target_shape = None
     target_dtype = "f16"
@@ -471,7 +467,7 @@ def _parse_reshape_op(op_text, op_name):
         attributes["dtype"] = target_dtype
 
     return Operation(
-        result=result_name,
+        result=result,
         op_type=f"tensor.{op_name}",
         operands=[operand],
         attributes=attributes,
@@ -480,7 +476,7 @@ def _parse_reshape_op(op_text, op_name):
 
 
 @register_parser("tensor.yield")
-def parse_tensor_yield(op_text, parse_ctx):
+def parse_tensor_yield(op_text, parse_ctx, result=None):
     """Parse tensor.yield — terminates a tensor.generate body.
 
     Syntax:
@@ -507,7 +503,7 @@ def parse_tensor_yield(op_text, parse_ctx):
 
 
 @register_parser("tensor.generate")
-def parse_tensor_generate(op_text, parse_ctx):
+def parse_tensor_generate(op_text, parse_ctx, result=None):
     """Parse tensor.generate.
 
     Full syntax:
@@ -531,12 +527,11 @@ def parse_tensor_generate(op_text, parse_ctx):
     """
     from ..parser_utils import parse_tensor_type
 
-    # Match: %result = tensor.generate ...
-    result_match = re.match(r'(%\w+)\s*=\s*tensor\.generate', op_text)
+    # Match: tensor.generate ...
+    result_match = re.match(r'tensor\.generate', op_text)
     if not result_match:
         return None
 
-    result_name = result_match.group(1)
     attributes = {}
 
     # Extract shape and dtype from trailing `: tensor<16x16xf16>`
@@ -550,7 +545,7 @@ def parse_tensor_generate(op_text, parse_ctx):
         attributes["dtype"] = type_info.get("dtype", "f16")
 
     return Operation(
-        result=result_name,
+        result=result,
         op_type="tensor.generate",
         operands=[],
         attributes=attributes,
@@ -559,17 +554,17 @@ def parse_tensor_generate(op_text, parse_ctx):
 
 
 @register_parser("tensor.expand_shape")
-def parse_tensor_expand_shape(op_text, parse_ctx):
-    return _parse_reshape_op(op_text, "expand_shape")
+def parse_tensor_expand_shape(op_text, parse_ctx, result=None):
+    return _parse_reshape_op(op_text, "expand_shape", result=result)
 
 
 @register_parser("tensor.collapse_shape")
-def parse_tensor_collapse_shape(op_text, parse_ctx):
-    return _parse_reshape_op(op_text, "collapse_shape")
+def parse_tensor_collapse_shape(op_text, parse_ctx, result=None):
+    return _parse_reshape_op(op_text, "collapse_shape", result=result)
 
 
 @register_parser("tensor.reshape")
-def parse_tensor_reshape(op_text, parse_ctx):
+def parse_tensor_reshape(op_text, parse_ctx, result=None):
     """Parse `%out = tensor.reshape %src(%shape) : (...) -> tensor<...>`.
 
     Two SSA operands: source tensor and shape tensor. Target shape is read
@@ -578,11 +573,11 @@ def parse_tensor_reshape(op_text, parse_ctx):
     """
     from ..parser_utils import parse_tensor_type
     m = re.match(
-        r'(%\w+)\s*=\s*tensor\.reshape\s+(%\w+)\s*\(\s*(%\w+)\s*\)', op_text
+        r'tensor\.reshape\s+(%\w+)\s*\(\s*(%\w+)\s*\)', op_text
     )
     if not m:
         return None
-    result_name, src, shape_operand = m.group(1), m.group(2), m.group(3)
+    src, shape_operand = m.group(1), m.group(2)
 
     arrow = re.search(r'->\s*(tensor<[^>]+>)', op_text)
     if not arrow:
@@ -595,7 +590,7 @@ def parse_tensor_reshape(op_text, parse_ctx):
         )
 
     return Operation(
-        result=result_name,
+        result=result,
         op_type="tensor.reshape",
         operands=[src, shape_operand],
         attributes={
@@ -607,17 +602,16 @@ def parse_tensor_reshape(op_text, parse_ctx):
 
 
 @register_parser("tensor.from_elements")
-def parse_tensor_from_elements(op_text, parse_ctx):
+def parse_tensor_from_elements(op_text, parse_ctx, result=None):
     """Parse `%shape = tensor.from_elements %d0, %d1, ... : tensor<NxT>`."""
     from ..parser_utils import parse_tensor_type
     m = re.match(
-        r'(%\w+)\s*=\s*tensor\.from_elements\s+(.*?)\s*:\s*(tensor<[^>]+>)', op_text
+        r'tensor\.from_elements\s+(.*?)\s*:\s*(tensor<[^>]+>)', op_text
     )
     if not m:
         return None
-    result_name = m.group(1)
-    operand_text = m.group(2)
-    type_str = m.group(3)
+    operand_text = m.group(1)
+    type_str = m.group(2)
     operands = find_ssa_names(operand_text)
 
     info = parse_tensor_type(type_str)
@@ -627,7 +621,7 @@ def parse_tensor_from_elements(op_text, parse_ctx):
         )
 
     return Operation(
-        result=result_name,
+        result=result,
         op_type="tensor.from_elements",
         operands=operands,
         attributes={
@@ -670,18 +664,17 @@ def _parse_index_bracket_groups(op_text):
 
 
 @register_parser("tensor.extract_slice")
-def parse_tensor_extract_slice(op_text, parse_ctx):
+def parse_tensor_extract_slice(op_text, parse_ctx, result=None):
     """Parse `%r = tensor.extract_slice %src[offsets][sizes][strides] : T to T`.
 
     Supports mixed static/dynamic entries: ``%off`` tokens become _KDYNAMIC
     in the static array and are appended to operands after the source.
     """
     from ..parser_utils import parse_tensor_type
-    m = re.match(r'(%\w+)\s*=\s*tensor\.extract_slice\s+(%\w+)', op_text)
+    m = re.match(r'tensor\.extract_slice\s+(%\w+)', op_text)
     if not m:
         return None
-    result_name = m.group(1)
-    src_operand = m.group(2)
+    src_operand = m.group(1)
 
     (off_s, off_d), (sz_s, sz_d), (st_s, st_d) = _parse_index_bracket_groups(op_text)
 
@@ -694,7 +687,7 @@ def parse_tensor_extract_slice(op_text, parse_ctx):
         raise ValueError(f"tensor.extract_slice: cannot parse result type {result_type!r}")
 
     return Operation(
-        result=result_name,
+        result=result,
         op_type="tensor.extract_slice",
         operands=[src_operand] + off_d + sz_d + st_d,
         attributes={
@@ -709,7 +702,7 @@ def parse_tensor_extract_slice(op_text, parse_ctx):
 
 
 @register_parser("tensor.insert_slice")
-def parse_tensor_insert_slice(op_text, parse_ctx):
+def parse_tensor_insert_slice(op_text, parse_ctx, result=None):
     """Parse `%r = tensor.insert_slice %src into %dst[offsets][sizes][strides] : T into T`.
 
     Supports mixed static/dynamic entries: ``%off`` tokens become _KDYNAMIC
@@ -717,13 +710,12 @@ def parse_tensor_insert_slice(op_text, parse_ctx):
     """
     from ..parser_utils import parse_tensor_type
     m = re.match(
-        r'(%\w+)\s*=\s*tensor\.insert_slice\s+(%\w+)\s+into\s+(%\w+)', op_text
+        r'tensor\.insert_slice\s+(%\w+)\s+into\s+(%\w+)', op_text
     )
     if not m:
         return None
-    result_name = m.group(1)
-    src_operand = m.group(2)
-    dst_operand = m.group(3)
+    src_operand = m.group(1)
+    dst_operand = m.group(2)
 
     (off_s, off_d), (sz_s, sz_d), (st_s, st_d) = _parse_index_bracket_groups(op_text)
 
@@ -736,7 +728,7 @@ def parse_tensor_insert_slice(op_text, parse_ctx):
         raise ValueError(f"tensor.insert_slice: cannot parse result type {result_type!r}")
 
     return Operation(
-        result=result_name,
+        result=result,
         op_type="tensor.insert_slice",
         operands=[src_operand, dst_operand] + off_d + sz_d + st_d,
         attributes={

--- a/ktir_cpu/dialects/tensor_ops.py
+++ b/ktir_cpu/dialects/tensor_ops.py
@@ -355,7 +355,7 @@ def tensor__generate(op, context, env):
 # ---------------------------------------------------------------------------
 
 @register_parser("tensor.empty")
-def parse_tensor_empty(op_text, parse_ctx, result=None):
+def parse_tensor_empty(op_text, parse_ctx):
     """Parse tensor.empty() : tensor<1x1024xf16>"""
     from ..parser_utils import parse_tensor_type
     result_match = re.match(r'tensor\.empty\s*\(\s*\)\s*:\s*(.+)', op_text)
@@ -368,7 +368,7 @@ def parse_tensor_empty(op_text, parse_ctx, result=None):
         attributes["shape"] = type_info["shape"]
         attributes["dtype"] = type_info.get("dtype", "f16")
     return Operation(
-        result=result,
+        result=None,
         op_type="tensor.empty",
         operands=[],
         attributes=attributes,
@@ -377,7 +377,7 @@ def parse_tensor_empty(op_text, parse_ctx, result=None):
 
 
 @register_parser("tensor.splat")
-def parse_tensor_splat(op_text, parse_ctx, result=None):
+def parse_tensor_splat(op_text, parse_ctx):
     from ..parser_utils import parse_tensor_type
     result_match = re.match(r'tensor\.splat\s+(%\w+)\s*(?::\s*(.+))?', op_text)
     if not result_match:
@@ -401,7 +401,7 @@ def parse_tensor_splat(op_text, parse_ctx, result=None):
         attributes["dtype"] = type_info.get("dtype", "f16")
 
     return Operation(
-        result=result,
+        result=None,
         op_type="tensor.splat",
         operands=[scalar_operand],
         attributes=attributes,
@@ -410,7 +410,7 @@ def parse_tensor_splat(op_text, parse_ctx, result=None):
 
 
 @register_parser("tensor.extract ")
-def parse_tensor_extract(op_text, parse_ctx, result=None):
+def parse_tensor_extract(op_text, parse_ctx):
     # %scalar = tensor.extract %tensor[%i0, %i1] : tensor<...>
     result_match = re.match(r'tensor\.extract\s+(%\w+)', op_text)
     if not result_match:
@@ -427,7 +427,7 @@ def parse_tensor_extract(op_text, parse_ctx, result=None):
             indices = find_ssa_names(bracket_content)
 
     return Operation(
-        result=result,
+        result=None,
         op_type="tensor.extract",
         operands=[src_operand] + indices,
         attributes={},
@@ -435,7 +435,7 @@ def parse_tensor_extract(op_text, parse_ctx, result=None):
     )
 
 
-def _parse_reshape_op(op_text, op_name, result=None):
+def _parse_reshape_op(op_text, op_name):
     """Shared parser for tensor.expand_shape and tensor.collapse_shape."""
     result_match = re.match(
         r'tensor\.' + op_name + r'\s+(%\w+)', op_text
@@ -467,7 +467,7 @@ def _parse_reshape_op(op_text, op_name, result=None):
         attributes["dtype"] = target_dtype
 
     return Operation(
-        result=result,
+        result=None,
         op_type=f"tensor.{op_name}",
         operands=[operand],
         attributes=attributes,
@@ -476,7 +476,7 @@ def _parse_reshape_op(op_text, op_name, result=None):
 
 
 @register_parser("tensor.yield")
-def parse_tensor_yield(op_text, parse_ctx, result=None):
+def parse_tensor_yield(op_text, parse_ctx):
     """Parse tensor.yield — terminates a tensor.generate body.
 
     Syntax:
@@ -503,7 +503,7 @@ def parse_tensor_yield(op_text, parse_ctx, result=None):
 
 
 @register_parser("tensor.generate")
-def parse_tensor_generate(op_text, parse_ctx, result=None):
+def parse_tensor_generate(op_text, parse_ctx):
     """Parse tensor.generate.
 
     Full syntax:
@@ -545,7 +545,7 @@ def parse_tensor_generate(op_text, parse_ctx, result=None):
         attributes["dtype"] = type_info.get("dtype", "f16")
 
     return Operation(
-        result=result,
+        result=None,
         op_type="tensor.generate",
         operands=[],
         attributes=attributes,
@@ -554,17 +554,17 @@ def parse_tensor_generate(op_text, parse_ctx, result=None):
 
 
 @register_parser("tensor.expand_shape")
-def parse_tensor_expand_shape(op_text, parse_ctx, result=None):
-    return _parse_reshape_op(op_text, "expand_shape", result=result)
+def parse_tensor_expand_shape(op_text, parse_ctx):
+    return _parse_reshape_op(op_text, "expand_shape")
 
 
 @register_parser("tensor.collapse_shape")
-def parse_tensor_collapse_shape(op_text, parse_ctx, result=None):
-    return _parse_reshape_op(op_text, "collapse_shape", result=result)
+def parse_tensor_collapse_shape(op_text, parse_ctx):
+    return _parse_reshape_op(op_text, "collapse_shape")
 
 
 @register_parser("tensor.reshape")
-def parse_tensor_reshape(op_text, parse_ctx, result=None):
+def parse_tensor_reshape(op_text, parse_ctx):
     """Parse `%out = tensor.reshape %src(%shape) : (...) -> tensor<...>`.
 
     Two SSA operands: source tensor and shape tensor. Target shape is read
@@ -590,7 +590,7 @@ def parse_tensor_reshape(op_text, parse_ctx, result=None):
         )
 
     return Operation(
-        result=result,
+        result=None,
         op_type="tensor.reshape",
         operands=[src, shape_operand],
         attributes={
@@ -602,7 +602,7 @@ def parse_tensor_reshape(op_text, parse_ctx, result=None):
 
 
 @register_parser("tensor.from_elements")
-def parse_tensor_from_elements(op_text, parse_ctx, result=None):
+def parse_tensor_from_elements(op_text, parse_ctx):
     """Parse `%shape = tensor.from_elements %d0, %d1, ... : tensor<NxT>`."""
     from ..parser_utils import parse_tensor_type
     m = re.match(
@@ -621,7 +621,7 @@ def parse_tensor_from_elements(op_text, parse_ctx, result=None):
         )
 
     return Operation(
-        result=result,
+        result=None,
         op_type="tensor.from_elements",
         operands=operands,
         attributes={
@@ -664,7 +664,7 @@ def _parse_index_bracket_groups(op_text):
 
 
 @register_parser("tensor.extract_slice")
-def parse_tensor_extract_slice(op_text, parse_ctx, result=None):
+def parse_tensor_extract_slice(op_text, parse_ctx):
     """Parse `%r = tensor.extract_slice %src[offsets][sizes][strides] : T to T`.
 
     Supports mixed static/dynamic entries: ``%off`` tokens become _KDYNAMIC
@@ -687,7 +687,7 @@ def parse_tensor_extract_slice(op_text, parse_ctx, result=None):
         raise ValueError(f"tensor.extract_slice: cannot parse result type {result_type!r}")
 
     return Operation(
-        result=result,
+        result=None,
         op_type="tensor.extract_slice",
         operands=[src_operand] + off_d + sz_d + st_d,
         attributes={
@@ -702,7 +702,7 @@ def parse_tensor_extract_slice(op_text, parse_ctx, result=None):
 
 
 @register_parser("tensor.insert_slice")
-def parse_tensor_insert_slice(op_text, parse_ctx, result=None):
+def parse_tensor_insert_slice(op_text, parse_ctx):
     """Parse `%r = tensor.insert_slice %src into %dst[offsets][sizes][strides] : T into T`.
 
     Supports mixed static/dynamic entries: ``%off`` tokens become _KDYNAMIC
@@ -728,7 +728,7 @@ def parse_tensor_insert_slice(op_text, parse_ctx, result=None):
         raise ValueError(f"tensor.insert_slice: cannot parse result type {result_type!r}")
 
     return Operation(
-        result=result,
+        result=None,
         op_type="tensor.insert_slice",
         operands=[src_operand, dst_operand] + off_d + sz_d + st_d,
         attributes={

--- a/ktir_cpu/parser.py
+++ b/ktir_cpu/parser.py
@@ -623,7 +623,7 @@ class KTIRParser(KTIRParserBase):
 
         # Extract operands: all %name references in the text after op_type,
         # but before any { } attribute blocks.
-        operands = self._extract_operands(rest, None)
+        operands = self._extract_operands(rest)
 
         # Extract attributes from { ... } blocks.
         # Be careful not to confuse attribute blocks with region blocks
@@ -655,24 +655,14 @@ class KTIRParser(KTIRParserBase):
             outs_operands=outs_ops,
         )
 
-    def _extract_operands(self, text: str, result: Optional[str]) -> List[str]:
+    def _extract_operands(self, text: str) -> List[str]:
         """Extract SSA operands from operation text.
 
-        Finds all %name references, excluding:
-        - The result name itself
-        - References inside { } attribute blocks
+        Finds all %name references, excluding references inside { }
+        attribute blocks.
         """
-        # Remove all { ... } blocks to avoid picking up references inside
-        # attribute blocks.
         cleaned = re.sub(r'\{[^}]*\}', '', text)
-
-        operands = find_ssa_names(cleaned)
-
-        # Remove result name if present
-        if result:
-            operands = [o for o in operands if o != result]
-
-        return operands
+        return find_ssa_names(cleaned)
 
     def _extract_attributes(self, text: str, aliases: Optional[Dict] = None) -> Dict:
         """Extract attributes from the outermost { ... } block in operation text."""

--- a/ktir_cpu/parser.py
+++ b/ktir_cpu/parser.py
@@ -565,9 +565,13 @@ class KTIRParser(KTIRParserBase):
 
         parser_fn = dispatch_parser(body_text)
         if parser_fn:
-            return parser_fn(body_text, ctx, result=result)
+            op = parser_fn(body_text, ctx)
+        else:
+            op = self._parse_general_operation(body_text)
 
-        return self._parse_general_operation(body_text, result=result)
+        if op is not None and result is not None:
+            op.result = result
+        return op
 
     def _parse_index_binary(self, text: str) -> Optional[Operation]:
         """Parse infix index arithmetic: %result = %a OP %b : type
@@ -595,11 +599,10 @@ class KTIRParser(KTIRParserBase):
     # General-purpose operation parser (fallback)
     # ------------------------------------------------------------------
 
-    def _parse_general_operation(self, text: str, result=None) -> Optional[Operation]:
+    def _parse_general_operation(self, text: str) -> Optional[Operation]:
         """Parse a general operation using pattern matching.
 
-        Receives LHS-free body text and the pre-computed result name(s).
-        Handles simple operations like:
+        Receives LHS-free body text.  Handles simple operations like:
             op_type %op1, %op2 : type
             return %result : type
         """
@@ -612,7 +615,7 @@ class KTIRParser(KTIRParserBase):
 
         # Extract operands: all %name references in the text after op_type,
         # but before any { } attribute blocks.
-        operands = self._extract_operands(rest, result)
+        operands = self._extract_operands(rest, None)
 
         # Extract attributes from { ... } blocks.
         # Be careful not to confuse attribute blocks with region blocks
@@ -636,7 +639,7 @@ class KTIRParser(KTIRParserBase):
         outs_ops = extract_outs_operands(rest) if is_inplace_outs(op_type) else []
 
         return Operation(
-            result=result,
+            result=None,
             op_type=op_type,
             operands=operands,
             attributes=attributes,

--- a/ktir_cpu/parser.py
+++ b/ktir_cpu/parser.py
@@ -571,6 +571,14 @@ class KTIRParser(KTIRParserBase):
 
         if op is not None and result is not None:
             op.result = result
+            expected = op.attributes.pop("_result_count", None)
+            if expected is not None:
+                actual = len(result) if isinstance(result, list) else 1
+                if actual != expected:
+                    raise ValueError(
+                        f"{op.op_type}: {actual} result name(s) but "
+                        f"{expected} result type(s) in: {op_text!r}"
+                    )
         return op
 
     def _parse_index_binary(self, text: str) -> Optional[Operation]:

--- a/ktir_cpu/parser.py
+++ b/ktir_cpu/parser.py
@@ -550,11 +550,24 @@ class KTIRParser(KTIRParserBase):
         # call the parser directly without a module-level alias pre-scan).
         ctx = parse_ctx or make_parse_context({})
 
-        parser_fn = dispatch_parser(op_text)
-        if parser_fn:
-            return parser_fn(op_text, ctx)
+        # Strip op-result-list LHS once, before dialect dispatch.
+        # Grammar: op-result-list ::= op-result (',' op-result)* '='
+        lhs_match = re.match(
+            r'((?:%\w+(?::\d+)?\s*,\s*)*%\w+(?::\d+)?)\s*=\s*(.*)', op_text, re.DOTALL
+        )
+        if lhs_match:
+            names = parse_multi_result_lhs(lhs_match.group(1))
+            result = names if len(names) > 1 else names[0]
+            body_text = lhs_match.group(2).strip()
+        else:
+            result = None
+            body_text = op_text
 
-        return self._parse_general_operation(op_text)
+        parser_fn = dispatch_parser(body_text)
+        if parser_fn:
+            return parser_fn(body_text, ctx, result=result)
+
+        return self._parse_general_operation(body_text, result=result)
 
     def _parse_index_binary(self, text: str) -> Optional[Operation]:
         """Parse infix index arithmetic: %result = %a OP %b : type
@@ -582,27 +595,20 @@ class KTIRParser(KTIRParserBase):
     # General-purpose operation parser (fallback)
     # ------------------------------------------------------------------
 
-    def _parse_general_operation(self, text: str) -> Optional[Operation]:
+    def _parse_general_operation(self, text: str, result=None) -> Optional[Operation]:
         """Parse a general operation using pattern matching.
 
+        Receives LHS-free body text and the pre-computed result name(s).
         Handles simple operations like:
-            %result = op_type %op1, %op2 : type
             op_type %op1, %op2 : type
             return %result : type
         """
-        # Try to match: %result = op_type rest (including bundled %r:N and comma %a, %b forms)
-        op_match = re.match(r'(?:((?:%\w+(?::\d+)?\s*,\s*)*%\w+(?::\d+)?)\s*=\s*)?([a-z_][a-z0-9_\.]*)\s*(.*)', text, re.DOTALL)
+        op_match = re.match(r'([a-z_][a-z0-9_\.]*)\s*(.*)', text, re.DOTALL)
         if not op_match:
             return None
 
-        lhs_text = op_match.group(1)
-        if lhs_text:
-            names = parse_multi_result_lhs(lhs_text)
-            result = names if len(names) > 1 else names[0]
-        else:
-            result = None
-        op_type = op_match.group(2)
-        rest = op_match.group(3).strip()
+        op_type = op_match.group(1)
+        rest = op_match.group(2).strip()
 
         # Extract operands: all %name references in the text after op_type,
         # but before any { } attribute blocks.

--- a/ktir_cpu/parser.py
+++ b/ktir_cpu/parser.py
@@ -26,7 +26,7 @@ from typing import Dict, List, Optional, Tuple
 from .ir_types import Operation, IRFunction, IRModule
 from .dialects import dispatch_parser, make_parse_context, ParseContext
 from .parser_utils import parse_attr_block, parse_tensor_type, parse_numeric
-from .parser_utils import find_ssa_names
+from .parser_utils import find_ssa_names, parse_multi_result_lhs
 
 
 class KTIRParserBase(ABC):
@@ -354,7 +354,7 @@ class KTIRParser(KTIRParserBase):
             # continuation (e.g. `: input_types\n  -> result_type`).
             if current_op_lines and open_braces == 0 and not stripped.startswith('->'):
                 starts_ssa = re.match(
-                    r'(?:%\w+\s*,\s*)*%\w+\s*=\s', stripped
+                    r'(?:%\w+(?::\d+)?\s*,\s*)*%\w+(?::\d+)?\s*=\s', stripped
                 )
                 # Two-stage flush decision:
                 #
@@ -590,12 +590,17 @@ class KTIRParser(KTIRParserBase):
             op_type %op1, %op2 : type
             return %result : type
         """
-        # Try to match: %result = op_type rest
-        op_match = re.match(r'(?:(%\w+)\s*=\s*)?([a-z_][a-z0-9_\.]*)\s*(.*)', text, re.DOTALL)
+        # Try to match: %result = op_type rest (including bundled %r:N and comma %a, %b forms)
+        op_match = re.match(r'(?:((?:%\w+(?::\d+)?\s*,\s*)*%\w+(?::\d+)?)\s*=\s*)?([a-z_][a-z0-9_\.]*)\s*(.*)', text, re.DOTALL)
         if not op_match:
             return None
 
-        result = op_match.group(1)
+        lhs_text = op_match.group(1)
+        if lhs_text:
+            names = parse_multi_result_lhs(lhs_text)
+            result = names if len(names) > 1 else names[0]
+        else:
+            result = None
         op_type = op_match.group(2)
         rest = op_match.group(3).strip()
 

--- a/ktir_cpu/parser_utils.py
+++ b/ktir_cpu/parser_utils.py
@@ -47,21 +47,34 @@ def extract_outs_operands(op_text: str) -> list[str]:
 def parse_multi_result_lhs(lhs_text: str) -> list[str]:
     """Parse the LHS of a multi-result MLIR assignment.
 
+    Implements the MLIR grammar production::
+
+        op-result-list ::= op-result (`,` op-result)* `=`
+        op-result      ::= value-id (`:` integer-literal)?
+
+    Always produces a flat list of individual SSA names that get bound
+    1:1 to the operation's result values.
+
     Accepts:
-      bundled form  ``"%g:2"``    -> ``["%g#0", "%g#1"]``
-      comma form    ``"%x, %y"``  -> ``["%x", "%y"]``
-      single        ``"%x"``      -> ``["%x"]``
+      bundled form  ``"%g:2"``        -> ``["%g#0", "%g#1"]``
+      comma form    ``"%x, %y"``      -> ``["%x", "%y"]``
+      mixed form    ``"%a:2, %b"``    -> ``["%a#0", "%a#1", "%b"]``
+      single        ``"%x"``          -> ``["%x"]``
 
     Raises ``ValueError`` on malformed input.
     """
-    m = re.fullmatch(r'(%\w+):([1-9]\d*)', lhs_text.strip())
-    if m:
-        base, n = m.group(1), int(m.group(2))
-        return [f"{base}#{i}" for i in range(n)]
-    parts = [p.strip() for p in lhs_text.split(",")]
-    if all(re.fullmatch(r'%\w+', p) for p in parts):
-        return parts
-    raise ValueError(f"cannot parse multi-result LHS: {lhs_text!r}")
+    parts = [p.strip() for p in lhs_text.strip().split(",")]
+    names = []
+    for part in parts:
+        m = re.fullmatch(r'(%\w+):([1-9]\d*)', part)
+        if m:
+            base, n = m.group(1), int(m.group(2))
+            names.extend(f"{base}#{i}" for i in range(n))
+        elif re.fullmatch(r'%\w+', part):
+            names.append(part)
+        else:
+            raise ValueError(f"cannot parse multi-result LHS: {lhs_text!r}")
+    return names
 
 
 def parse_tensor_type(type_str: str) -> Optional[Dict]:

--- a/tests/test_dialects_parse.py
+++ b/tests/test_dialects_parse.py
@@ -798,6 +798,35 @@ class TestKtdpParsers(ParseTestMixin):
         assert op.result.startswith("%")
         assert len(op.result) > 1
 
+    # Both surface forms (bundled "%pid:2" and comma "%x, %y") flow
+    # through the shared parse_multi_result_lhs helper and raise the same
+    # regex-parser diagnostic. The MLIR frontend (used by future
+    # BindingsParseTestMixin subclasses) raises a different but equally
+    # specific diagnostic. Match each backend's full phrasing rather than
+    # a tiny substring — short patterns like "result type" can match
+    # unrelated future error messages and silently let regressions slip
+    # through.
+    _COUNT_MISMATCH_MSG = (
+        # Regex parser:
+        # "ktdp.get_compute_tile_id: N result name(s) but M result
+        #  type(s) in: ..."
+        r"\d+ result name\(s\) but \d+ result type\(s\)"
+        r"|"
+        # MLIR frontend:
+        # "operation defines N results but was provided M to bind"
+        r"operation defines \d+ results but was provided \d+ to bind"
+    )
+
+    def test_get_compute_tile_id_bundled_count_mismatch_rejected(self):
+        # Bundled form "%pid:2 = ... : index" — 2 results declared, 1 type.
+        with pytest.raises(Exception, match=self._COUNT_MISMATCH_MSG):
+            self._parse("%pid:2 = ktdp.get_compute_tile_id : index")
+
+    def test_get_compute_tile_id_comma_count_mismatch_rejected(self):
+        # Comma form "%x, %y = ... : index" — 2 names, 1 type.
+        with pytest.raises(Exception, match=self._COUNT_MISMATCH_MSG):
+            self._parse("%x, %y = ktdp.get_compute_tile_id : index")
+
     def test_construct_memory_view(self):
         # construct_memory_view records shape, strides, dtype, memory_space, and pointer operand
         op = self._parse(

--- a/tests/test_dialects_parse.py
+++ b/tests/test_dialects_parse.py
@@ -1098,6 +1098,33 @@ class TestScfParsers(ParseTestMixin):
         assert isinstance(op.result, list)
         assert len(op.result) == 2
 
+    def test_for_bundled_result(self):
+        # bundled form %acc:2 = scf.for ... produces a list of 2 names
+        op = self._parse(
+            "%acc:2 = scf.for %i = %c0 to %n step %c1"
+            " iter_args(%a = %init0, %b = %init1) -> (f16, f16) {\n"
+            "      scf.yield %a, %b : f16, f16\n    }",
+            args={"%c0": "index", "%n": "index", "%c1": "index",
+                  "%init0": "f16", "%init1": "f16"},
+        )
+        self.assert_op_type(op, "scf.for")
+        assert isinstance(op.result, list)
+        assert len(op.result) == 2
+        assert all(r.startswith("%") for r in op.result)
+        assert len(set(op.result)) == 2
+
+    def test_for_bundled_result_single(self):
+        # %r:1 = scf.for ... collapses to a single str (convention)
+        op = self._parse(
+            "%r:1 = scf.for %i = %c0 to %n step %c1"
+            " iter_args(%acc = %init) -> (f16) {\n"
+            "      scf.yield %acc : f16\n    }",
+            args={"%c0": "index", "%n": "index", "%c1": "index", "%init": "f16"},
+        )
+        self.assert_op_type(op, "scf.for")
+        assert isinstance(op.result, str)
+        assert op.result.startswith("%")
+
     def test_yield_single(self):
         # scf.yield with one value records the operand
         for_op = self._parse(

--- a/tests/test_dialects_parse.py
+++ b/tests/test_dialects_parse.py
@@ -798,35 +798,6 @@ class TestKtdpParsers(ParseTestMixin):
         assert op.result.startswith("%")
         assert len(op.result) > 1
 
-    # Both surface forms (bundled "%pid:2" and comma "%x, %y") flow
-    # through the shared parse_multi_result_lhs helper and raise the same
-    # regex-parser diagnostic. The MLIR frontend (used by future
-    # BindingsParseTestMixin subclasses) raises a different but equally
-    # specific diagnostic. Match each backend's full phrasing rather than
-    # a tiny substring — short patterns like "result type" can match
-    # unrelated future error messages and silently let regressions slip
-    # through.
-    _COUNT_MISMATCH_MSG = (
-        # Regex parser:
-        # "ktdp.get_compute_tile_id: N result name(s) but M result
-        #  type(s) in: ..."
-        r"\d+ result name\(s\) but \d+ result type\(s\)"
-        r"|"
-        # MLIR frontend:
-        # "operation defines N results but was provided M to bind"
-        r"operation defines \d+ results but was provided \d+ to bind"
-    )
-
-    def test_get_compute_tile_id_bundled_count_mismatch_rejected(self):
-        # Bundled form "%pid:2 = ... : index" — 2 results declared, 1 type.
-        with pytest.raises(Exception, match=self._COUNT_MISMATCH_MSG):
-            self._parse("%pid:2 = ktdp.get_compute_tile_id : index")
-
-    def test_get_compute_tile_id_comma_count_mismatch_rejected(self):
-        # Comma form "%x, %y = ... : index" — 2 names, 1 type.
-        with pytest.raises(Exception, match=self._COUNT_MISMATCH_MSG):
-            self._parse("%x, %y = ktdp.get_compute_tile_id : index")
-
     def test_construct_memory_view(self):
         # construct_memory_view records shape, strides, dtype, memory_space, and pointer operand
         op = self._parse(

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -254,3 +254,41 @@ module {
         )
         with pytest.raises(RuntimeError):
             interp._execute_op(op, core)
+
+
+# ---------------------------------------------------------------------------
+# 5. Bundled LHS parsing and execution
+# ---------------------------------------------------------------------------
+
+# Bundled LHS form: %acc:2 defines two results bound as %acc#0, %acc#1.
+# After the loop, %acc#0 and %acc#1 are used on the RHS of arith.addi.
+_BUNDLED_FOR_MLIR = """
+module {
+  func.func @bundled_for() attributes {grid = [1, 1, 1]} {
+    %c0 = arith.constant 0 : index
+    %c3 = arith.constant 3 : index
+    %c1 = arith.constant 1 : index
+    %init_x = arith.constant 0 : index
+    %init_y = arith.constant 10 : index
+
+    // Bundled LHS: %acc:2 defines %acc#0 and %acc#1 simultaneously
+    %acc:2 = scf.for %i = %c0 to %c3 step %c1 iter_args(%x = %init_x, %y = %init_y) -> (index, index) {
+      %x_new = arith.addi %x, %i : index
+      %y_new = arith.addi %y, %i : index
+      scf.yield %x_new, %y_new : index, index
+    }
+
+    // Use-site: %acc#0 and %acc#1 reference the bundled results
+    %sum = arith.addi %acc#0, %acc#1 : index
+    return
+  }
+}
+"""
+
+
+def test_bundled_lhs_for_exec():
+    """Bundled LHS %acc:2 = scf.for parses and executes; %acc#0/%acc#1 resolve."""
+    interp = KTIRInterpreter()
+    interp.load(_BUNDLED_FOR_MLIR)
+    # Should complete without error (KeyError on %acc#0/%acc#1 was the bug)
+    interp.execute_function("bundled_for")

--- a/tests/test_parser_utils.py
+++ b/tests/test_parser_utils.py
@@ -21,7 +21,7 @@ mis-tokenised these by splitting on the ``x`` inside the dtype.
 
 import pytest
 
-from ktir_cpu.parser_utils import parse_tensor_type, extract_outs_operands
+from ktir_cpu.parser_utils import parse_multi_result_lhs, parse_tensor_type, extract_outs_operands
 
 
 # ---------------------------------------------------------------------------
@@ -185,3 +185,37 @@ def test_extract_outs_operands_multi():
 
 def test_extract_outs_operands_none():
     assert extract_outs_operands("arith.addf %x, %y : f16") == []
+
+# ---------------------------------------------------------------------------
+# parse_multi_result_lhs for supporting parsing result LHS containing a mix 
+#                        of bundled and split forms.
+# ---------------------------------------------------------------------------
+
+def test_parse_multi_result_lhs_single():
+    assert parse_multi_result_lhs("%x") == ["%x"]
+
+
+def test_parse_multi_result_lhs_comma():
+    assert parse_multi_result_lhs("%a, %b, %c") == ["%a", "%b", "%c"]
+
+
+def test_parse_multi_result_lhs_bundled():
+    assert parse_multi_result_lhs("%g:3") == ["%g#0", "%g#1", "%g#2"]
+
+
+def test_parse_multi_result_lhs_bundled_one(): assert parse_multi_result_lhs("%r:1") == ["%r#0"]
+
+
+def test_parse_multi_result_lhs_mixed():
+    assert parse_multi_result_lhs("%a:2, %b") == ["%a#0", "%a#1", "%b"]
+
+
+def test_parse_multi_result_lhs_mixed_complex():
+    assert parse_multi_result_lhs("%x:2, %y, %z:3") == [
+        "%x#0", "%x#1", "%y", "%z#0", "%z#1", "%z#2"
+    ]
+
+
+def test_parse_multi_result_lhs_malformed():
+    with pytest.raises(ValueError, match="cannot parse multi-result LHS"):
+        parse_multi_result_lhs("not_valid")


### PR DESCRIPTION
## Issues Addressing

Fixes #91 - bundled multi-result LHS (`%acc:2 = scf.for ...`) causes KeyError at runtime because the regex parser does not recognize the `:N` suffix on result names.

## Design

The MLIR grammar defines result LHS as:

```
op-result-list ::= op-result (`,` op-result)* `=`
op-result      ::= value-id (`:` integer-literal)?
```

The parser needs to consume any conforming LHS and produce a flat list of individual SSA names mapping to the result (LHS for left hand sides of an expression) values. A single utility (`parse_multi_result_lhs`) implements this production rule; all call-sites delegate to it.

## Code Changes

| File | Function | Action |
|------|----------|--------|
| `parser_utils.py` | `parse_multi_result_lhs` | implements the production rule for parsing result LHS with mix of bundled and split forms. |
| `scf_ops.py` | `parse_scf_for` | LHS regex to accept `:N` suffix and delegates to `parse_multi_result_lhs` | 
| `parser.py` | `_parse_general_operation` | fallback LHS regex; delegates to `parse_multi_result_lhs` |
| `parser.py` | `_tokenize_operations`  | Regex updated to recognize `%name:N =` for symbol pickup in split-body mlir lines |
| `tests/test_parser_utils.py` | 7 tests | Unit tests for a variaty of "mixed result LHS", e.g. single, comma, bundled, mixed, malformed inputs |
| `tests/test_dialects_parse.py` | 2 tests | Parsing verification of bundled result from scf.for |
| `tests/test_interpreter.py` | 1 test | Execution test: MLIR code with `%acc:2` runs through |
