### PR TITLE
fix: consume single-use tiles at last-use to reduce peak LX (#130)

### DIFF
--- a/docs/lx_tracking.md
+++ b/docs/lx_tracking.md
@@ -1,0 +1,137 @@
+# LX Tracking
+
+## High-level overview
+
+Each core has a fixed-capacity LX scratchpad (`lx.capacity`). The interpreter
+tracks live usage in `lx.used` and raises `MemoryError` when an allocation
+would exceed capacity.
+
+Allocation follows MLIR's SSA scoping rules: each region (function body,
+`scf.for` body, `scf.if` branch) gets its own scope on a stack.
+`set_value` writes into the topmost scope and is the **single charge point**
+for `lx.used` — only `Tile` values (tensor data backed by NumPy arrays) occupy
+LX; metadata types (`TileRef`, `AccessTile`, scalars) do not.
+
+At scope exit (`pop_scope`), all tiles in the popped scope are freed and
+`lx.next_ptr` is rewound to the watermark saved at scope entry (`push_scope`).
+This keeps the bump pointer in sync with `lx.used`.
+
+
+## Complication 1: aliased tiles
+
+A single tile (one Python object, one allocation) can be bound to multiple SSA
+names simultaneously. The canonical case is `linalg.reduce`, which binds its
+result to both the op's SSA result name and the `outs` buffer name:
+
+```
+%result = linalg.reduce(%input, %init) outs(%accum)
+# %result and %accum now refer to the same Python Tile object
+```
+
+Charging `lx.used` once per `set_value` call would double-count the same
+allocation.
+
+**Solution: `_tile_refcount` keyed by `id(Tile)`.**
+
+```
+_tile_refcount: Dict[int, int]   # id(Tile) → reference count
+```
+
+- **First binding** (`_tile_refcount.get(id(tile), 0) == 0`): charge
+  `lx.used += tile.size_bytes()`, set refcount to 1.
+- **Subsequent bindings** (same `id()`): increment refcount only — no
+  additional charge.
+- **Overwrite** (`set_value` replacing an existing name): decrement old tile's
+  refcount; free if it reaches 0.
+- **Scope exit** (`pop_scope`): decrement refcount for every tile in the popped
+  scope; free if it reaches 0.
+
+This ensures each physical allocation is charged exactly once regardless of how
+many SSA names point to it.
+
+
+## Complication 2: single-use tiles
+
+Scope-exit deallocation is correct but conservative. Within a loop body, tiles
+that are produced and immediately consumed (used exactly once) stay live in the
+scope until the body scope is popped at the end of the iteration. In a
+reduction loop this inflates peak LX needlessly:
+
+```
+// %accum_zero is used exactly once — to initialize the loop's iter_arg.
+// With scope-exit-only deallocation it occupies LX for the entire loop.
+%accum_zero = ktdp.load(%c_view, %c_tile) : tensor<1x128xf16>
+%accum_itr = scf.for ... iter_args(%accum_itr = %accum_zero) {
+    %accum_next = arith.addf %accum_itr, %partial : tensor<1x128xf16>
+    scf.yield %accum_next
+}
+```
+
+**Solution: consume-on-last-use in `get_value`.**
+
+At parse time, a single pass over all ops and nested regions counts how many
+times each SSA name appears as an operand:
+
+```python
+_use_counts: Dict[str, int]   # SSA name → total operand occurrences
+```
+
+SSA names are unique across the function, so a flat global map suffices — no
+per-region threading required.
+
+In `get_value`, when a name is fetched for its last use, it is consumed
+(removed from scope and freed) before the consuming op runs:
+
+```python
+if (isinstance(value, Tile)
+        and self._use_counts.get(name, 0) == 1   # last use
+        and scope is self._scope_stack[-1]):       # topmost-scope guard (see below)
+    del scope[name]
+    self._tile_refcount[id(value)] -= 1
+    if self._tile_refcount[id(value)] == 0:
+        del self._tile_refcount[id(value)]
+        self.lx.used -= value.size_bytes()
+return value   # caller still receives the tile data
+```
+
+The result is that the new tile produced by the consuming op can occupy the
+freed slot at no net increase in `lx.used`.
+
+**Topmost-scope guard.** Without the `scope is self._scope_stack[-1]` check,
+an outer-scope name with `use_count == 1` — e.g. a constant loaded before a
+loop and referenced once per iteration inside it — would be consumed on the
+first iteration fetch and raise `KeyError` on subsequent iterations. The guard
+restricts early-freeing to names that live in the currently-active scope,
+where "currently-active" means the scope that would normally own the value's
+lifetime anyway.
+
+
+## Limitation: simultaneous window for iter-arg tiles
+
+The consume-on-last-use mechanism cannot eliminate the peak-LX cost of loop
+carry variables. Consider:
+
+```
+// Parent scope holds %accum_itr.
+// Inside the body scope, arith.addf produces %accum_next (new Tile, new id()).
+// At the moment %accum_next is charged, %accum_itr is still live in the parent
+// scope — both tiles occupy LX simultaneously.
+%accum_next = arith.addf %accum_itr, %partial : tensor<1x128xf16>
+scf.yield %accum_next
+// After body scope pops, the for-op rebinds %accum_itr := %accum_next in the
+// parent scope via set_value, which frees the old %accum_itr tile.
+// But the peak has already been reached.
+```
+
+`%accum_itr` lives in the parent scope, not the topmost (body) scope, so the
+topmost-scope guard correctly blocks early consumption — `%accum_itr` is
+fetched on every iteration, not just once.
+
+The `set_value` rebind does reclaim the old carry tile promptly after each
+iteration (refcount drops to 0 when the parent-scope name is overwritten), but
+it cannot act before `%accum_next` is charged. One iteration's worth of both
+the old and new carry tile must be simultaneously live.
+
+Eliminating this window would require either explicit last-use annotations in
+the IR or a liveness analysis pass that is currently out of scope.
+

--- a/docs/lx_tracking.md
+++ b/docs/lx_tracking.md
@@ -135,3 +135,29 @@ the old and new carry tile must be simultaneously live.
 Eliminating this window would require either explicit last-use annotations in
 the IR or a liveness analysis pass that is currently out of scope.
 
+
+## Feature flags: LXOptions
+
+Both mechanisms above are controlled by `LXOptions`, a dataclass passed to
+`CoreContext` alongside `LXScratchpad`:
+
+```python
+@dataclass
+class LXOptions:
+    alias_dedup: bool = True       # Complication 1: refcount by id(Tile)
+    consume_last_use: bool = True  # Complication 2: free at last fetch
+```
+
+Both default to `True` so production behavior is unchanged. Tests use explicit
+presets to isolate each feature and measure its effect on `lx.used`:
+
+```python
+_LX_BASELINE = LXOptions(alias_dedup=False, consume_last_use=False)
+_LX_DEDUP    = LXOptions(alias_dedup=True,  consume_last_use=False)
+_LX_FULL     = LXOptions(alias_dedup=True,  consume_last_use=True)
+```
+
+`consume_last_use` requires `alias_dedup` to be correct — the refcount must
+reach 0 at the right moment for the free in `get_value` to fire. Running
+`consume_last_use=True` with `alias_dedup=False` is unsupported.
+

--- a/ktir_cpu/grid.py
+++ b/ktir_cpu/grid.py
@@ -23,7 +23,7 @@ from collections import deque
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Callable, Dict, Generator, List, Optional, Set, Tuple, Any
 from .ir_types import Tile
-from .memory import LXScratchpad, SpyreMemoryHierarchy, HBMSimulator
+from .memory import LXOptions, LXScratchpad, SpyreMemoryHierarchy, HBMSimulator
 
 if TYPE_CHECKING:
     from .ops.comm_ops import TransferBackend
@@ -84,11 +84,12 @@ class CoreContext:
         # set_value("%m_acc", %m_new) in parent scope: refcount tracks automatically.
     """
 
-    def __init__(self, core_id: int, grid_pos: Tuple[int, int, int], lx: LXScratchpad, hbm: HBMSimulator):
+    def __init__(self, core_id: int, grid_pos: Tuple[int, int, int], lx: LXScratchpad, hbm: HBMSimulator, lx_options: LXOptions = None):
         self.core_id = core_id
         self.grid_pos = grid_pos  # (x, y, z) position in grid
         self.lx = lx              # Core-local LX scratchpad
         self.hbm = hbm            # Shared HBM
+        self.lx_options = lx_options if lx_options is not None else LXOptions()
         self._scope_stack: List[Dict[str, Any]] = [{}]  # bottom = function body
         self._tile_refcount: Dict[int, int] = {}  # id(Tile) -> refcount
         self._lx_next_ptr_stack: List[int] = []  # watermarks for lx.next_ptr rewind on pop_scope
@@ -224,9 +225,12 @@ class CoreContext:
         scope = self._scope_stack.pop()
         for value in scope.values():
             if isinstance(value, Tile):
-                self._tile_refcount[id(value)] -= 1
-                if self._tile_refcount[id(value)] == 0:
-                    del self._tile_refcount[id(value)]
+                if self.lx_options.alias_dedup:
+                    self._tile_refcount[id(value)] -= 1
+                    if self._tile_refcount[id(value)] == 0:
+                        del self._tile_refcount[id(value)]
+                        self.lx.used -= value.size_bytes()
+                else:
                     self.lx.used -= value.size_bytes()
         self.lx.next_ptr = self._lx_next_ptr_stack.pop()
         assert len(self._lx_next_ptr_stack) == len(self._scope_stack) - 1
@@ -264,13 +268,27 @@ class CoreContext:
         """
         old = self._scope_stack[-1].get(name)
         if isinstance(old, Tile):
-            self._tile_refcount[id(old)] -= 1
-            if self._tile_refcount[id(old)] == 0:
-                del self._tile_refcount[id(old)]
+            if self.lx_options.alias_dedup:
+                self._tile_refcount[id(old)] -= 1
+                if self._tile_refcount[id(old)] == 0:
+                    del self._tile_refcount[id(old)]
+                    self.lx.used -= old.size_bytes()
+            else:
                 self.lx.used -= old.size_bytes()
         self._scope_stack[-1][name] = value
         if isinstance(value, Tile):
-            if self._tile_refcount.get(id(value), 0) == 0:
+            if self.lx_options.alias_dedup:
+                if self._tile_refcount.get(id(value), 0) == 0:
+                    if self.lx.used + value.size_bytes() > self.lx.capacity:
+                        raise MemoryError(
+                            f"LX scratchpad overflow on core {self.core_id}: "
+                            f"requested {value.size_bytes()} bytes, "
+                            f"available {self.lx.capacity - self.lx.used} bytes "
+                            f"(capacity {self.lx.capacity} bytes)"
+                        )
+                    self.lx.used += value.size_bytes()
+                self._tile_refcount[id(value)] = self._tile_refcount.get(id(value), 0) + 1
+            else:
                 if self.lx.used + value.size_bytes() > self.lx.capacity:
                     raise MemoryError(
                         f"LX scratchpad overflow on core {self.core_id}: "
@@ -279,7 +297,6 @@ class CoreContext:
                         f"(capacity {self.lx.capacity} bytes)"
                     )
                 self.lx.used += value.size_bytes()
-            self._tile_refcount[id(value)] = self._tile_refcount.get(id(value), 0) + 1
 
     def get_value(self, name: str) -> Any:
         """Get SSA value, searching top-to-bottom.
@@ -299,13 +316,17 @@ class CoreContext:
         for scope in reversed(self._scope_stack):
             if name in scope:
                 value = scope[name]
-                if (isinstance(value, Tile)
+                if (self.lx_options.consume_last_use
+                        and isinstance(value, Tile)
                         and self._use_counts.get(name, 0) == 1
                         and scope is self._scope_stack[-1]):
                     del scope[name]
-                    self._tile_refcount[id(value)] -= 1
-                    if self._tile_refcount[id(value)] == 0:
-                        del self._tile_refcount[id(value)]
+                    if self.lx_options.alias_dedup:
+                        self._tile_refcount[id(value)] -= 1
+                        if self._tile_refcount[id(value)] == 0:
+                            del self._tile_refcount[id(value)]
+                            self.lx.used -= value.size_bytes()
+                    else:
                         self.lx.used -= value.size_bytes()
                 return value
         raise KeyError(f"Value '{name}' not found in core {self.core_id}")

--- a/ktir_cpu/grid.py
+++ b/ktir_cpu/grid.py
@@ -298,11 +298,15 @@ class CoreContext:
                     )
                 self.lx.used += value.size_bytes()
 
-    def get_value(self, name: str) -> Any:
+    def get_value(self, name: str, *, peek: bool = False) -> Any:
         """Get SSA value, searching top-to-bottom.
 
         On last use (use_count == 1), pops the value from scope and frees LX
         immediately so the caller can reuse or replace the buffer at no net cost.
+
+        Args:
+            peek: If True, suppress consume-on-last-use (used by latency
+                pre-resolution, which reads operand values without consuming them).
 
         Args:
             name: SSA value name (e.g., "%x_tile")
@@ -316,7 +320,8 @@ class CoreContext:
         for scope in reversed(self._scope_stack):
             if name in scope:
                 value = scope[name]
-                if (self.lx_options.consume_last_use
+                if (not peek
+                        and self.lx_options.consume_last_use
                         and isinstance(value, Tile)
                         and self._use_counts.get(name, 0) == 1
                         and scope is self._scope_stack[-1]):

--- a/ktir_cpu/grid.py
+++ b/ktir_cpu/grid.py
@@ -92,6 +92,7 @@ class CoreContext:
         self._scope_stack: List[Dict[str, Any]] = [{}]  # bottom = function body
         self._tile_refcount: Dict[int, int] = {}  # id(Tile) -> refcount
         self._lx_next_ptr_stack: List[int] = []  # watermarks for lx.next_ptr rewind on pop_scope
+        self._use_counts: Dict[str, int] = {}  # SSA name -> use count for current region
         # Scheduler-managed cross-core access — both functions are set by
         # GridExecutor.execute_with_communication via attach_scheduler() and
         # cleared via detach_scheduler() at the end of the run.
@@ -283,6 +284,9 @@ class CoreContext:
     def get_value(self, name: str) -> Any:
         """Get SSA value, searching top-to-bottom.
 
+        On last use (use_count == 1), pops the value from scope and frees LX
+        immediately so the caller can reuse or replace the buffer at no net cost.
+
         Args:
             name: SSA value name (e.g., "%x_tile")
 
@@ -294,7 +298,16 @@ class CoreContext:
         """
         for scope in reversed(self._scope_stack):
             if name in scope:
-                return scope[name]
+                value = scope[name]
+                if (isinstance(value, Tile)
+                        and self._use_counts.get(name, 0) == 1
+                        and scope is self._scope_stack[-1]):
+                    del scope[name]
+                    self._tile_refcount[id(value)] -= 1
+                    if self._tile_refcount[id(value)] == 0:
+                        del self._tile_refcount[id(value)]
+                        self.lx.used -= value.size_bytes()
+                return value
         raise KeyError(f"Value '{name}' not found in core {self.core_id}")
 
     def has_value(self, name: str) -> bool:

--- a/ktir_cpu/grid.py
+++ b/ktir_cpu/grid.py
@@ -305,11 +305,9 @@ class CoreContext:
         immediately so the caller can reuse or replace the buffer at no net cost.
 
         Args:
+            name: SSA value name (e.g., "%x_tile")
             peek: If True, suppress consume-on-last-use (used by latency
                 pre-resolution, which reads operand values without consuming them).
-
-        Args:
-            name: SSA value name (e.g., "%x_tile")
 
         Returns:
             The value

--- a/ktir_cpu/interpreter.py
+++ b/ktir_cpu/interpreter.py
@@ -207,7 +207,7 @@ class KTIRInterpreter:
             resolved_operands = []
             for name in op.operands:
                 try:
-                    resolved_operands.append(context.get_value(name))
+                    resolved_operands.append(context.get_value(name, peek=True))
                 except KeyError:
                     resolved_operands.append(None)
 

--- a/ktir_cpu/interpreter.py
+++ b/ktir_cpu/interpreter.py
@@ -167,6 +167,9 @@ class KTIRInterpreter:
                 # Scalar argument (like n)
                 input_ptrs[arg_name] = tensor
 
+        for core in self.grid_executor.cores:
+            core._use_counts = func.use_counts
+
         self.grid_executor.execute_with_communication(
             func.operations, input_ptrs, self._execute_op,
             transfer_backend=self.ring_backend,

--- a/ktir_cpu/ir_types.py
+++ b/ktir_cpu/ir_types.py
@@ -402,6 +402,7 @@ class IRFunction:
     arguments: List[Tuple[str, str]]  # [(name, type), ...]
     operations: List[Operation]
     grid: Tuple[int, int, int]  # Grid shape from function attributes
+    use_counts: Dict[str, int] = field(default_factory=dict)  # SSA name -> use count for function body
     return_type: Optional[str] = None
     tensor_sizes: Dict[str, Dict[str, Any]] = field(default_factory=dict, init=False, repr=False)
 

--- a/ktir_cpu/memory.py
+++ b/ktir_cpu/memory.py
@@ -96,6 +96,47 @@ import numpy as np
 # ---------------------------------------------------------------------------
 
 from .dtypes import to_np_dtype, bytes_per_elem
+from dataclasses import dataclass as _dataclass
+
+
+@_dataclass
+class LXOptions:
+    """Feature flags for CoreContext LX tracking.
+
+    Both flags default to True (full tracking enabled).  Pass a custom
+    instance to CoreContext to isolate or disable individual features —
+    useful in tests to measure the effect of each mechanism in isolation.
+
+    alias_dedup
+    -----------
+    Tracks each Tile allocation by id(Tile) via a refcount dict.  Prevents
+    double-charging when multiple SSA names point to the same Python object:
+
+        tile = Tile(...)
+        set_value("%a", tile)  # refcount 0→1, lx.used += N
+        set_value("%b", tile)  # same id(), refcount 1→2, lx.used unchanged
+        pop_scope()            # refcount 2→1 for %b, 1→0 for %a → lx.used -= N
+
+    Without this flag, each set_value charges independently and pop_scope
+    frees independently — aliases inflate lx.used by a factor of N aliases.
+
+    consume_last_use
+    ----------------
+    Frees a Tile at its last fetch (use_count == 1 in the global use-count
+    map) instead of waiting for scope exit.  Requires alias_dedup to be
+    correct (refcount must reach 0 at the right moment).
+
+    Only applies to names in the topmost scope — outer-scope names used
+    inside a loop have use_count == 1 globally but are fetched per iteration;
+    the topmost-scope guard (scope is _scope_stack[-1]) blocks early-free.
+
+    Preset combinations used in tests:
+        _LX_BASELINE = LXOptions(alias_dedup=False, consume_last_use=False)
+        _LX_DEDUP    = LXOptions(alias_dedup=True,  consume_last_use=False)
+        _LX_FULL     = LXOptions(alias_dedup=True,  consume_last_use=True)
+    """
+    alias_dedup: bool = True
+    consume_last_use: bool = True
 
 
 class _AllocStore(dict):

--- a/ktir_cpu/parser.py
+++ b/ktir_cpu/parser.py
@@ -132,12 +132,14 @@ class KTIRParser(KTIRParserBase):
 
             # Parse operations from function body
             operations = self._parse_operations(func_body, parse_ctx)
+            use_counts = self._build_use_counts(operations)
 
             func = IRFunction(
                 name=func_name,
                 arguments=args,
                 operations=operations,
-                grid=grid
+                grid=grid,
+                use_counts=use_counts,
             )
 
             module.add_function(func)
@@ -269,6 +271,18 @@ class KTIRParser(KTIRParserBase):
                 operations.append(op)
 
         return operations
+
+    @staticmethod
+    def _build_use_counts(ops) -> Dict[str, int]:
+        """Count operand uses recursively across all ops and nested regions."""
+        counts: Dict[str, int] = {}
+        for op in ops:
+            for name in op.operands:
+                counts[name] = counts.get(name, 0) + 1
+            for region in op.regions:
+                for name, n in KTIRParser._build_use_counts(region).items():
+                    counts[name] = counts.get(name, 0) + n
+        return counts
 
     @staticmethod
     def _preprocess_text(text: str) -> str:

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -255,30 +255,6 @@ class TestSoftmaxExecution(InterpreterTestMixin):
 
         np.testing.assert_allclose(result, expected, rtol=1e-2, atol=1e-2)
 
-    @pytest.mark.parametrize("path,func_name,entry", get_test_params(
-        "softmax_kernel", filter="ktir/softmax_wide"))
-    def test_softmax_lx_overflow(self, path, func_name, entry):
-        """Softmax with a row too wide for LX should raise MemoryError.
-
-        A naive rowwise softmax loads the full row (1×C) and produces several
-        intermediate Tiles of the same shape (splat, subf, exp, divf).
-        With C=262144 the peak live set is ~3MB, exceeding the 2MB LX.
-        This is exactly the scenario that online_rowchunk solves by
-        chunking the column dimension.
-        """
-        interp = self._make_interp()
-        interp.load(path)
-
-        output_ptr, input_ptr, *_ = interp.arg_names(func_name)
-        sizes = interp.tensor_input_output_sizes(func_name)
-        n_rows_val, n_cols = sizes[input_ptr]["shape"]
-        rng = np.random.default_rng(42)
-        inp = rng.standard_normal((n_rows_val, n_cols)).astype(np.float16)
-        out = np.zeros((n_rows_val, n_cols), dtype=np.float16)
-
-        kwargs = self._build_kwargs(entry, {output_ptr: out, input_ptr: inp})
-        with pytest.raises(MemoryError, match=entry["exception_msg"]):
-            interp.execute_function(func_name, **kwargs)
 
 
 class TestLayerNormExecution(InterpreterTestMixin):

--- a/tests/test_lx_scoping.py
+++ b/tests/test_lx_scoping.py
@@ -22,16 +22,148 @@ import numpy as np
 import pytest
 
 from ktir_cpu.grid import CoreContext
-from ktir_cpu.memory import LXScratchpad, HBMSimulator
+from ktir_cpu.memory import LXOptions, LXScratchpad, HBMSimulator
 from ktir_cpu.ir_types import Tile
 from ktir_cpu.ops.memory_ops import MemoryOps
 
+# ---------------------------------------------------------------------------
+# LXOptions presets used throughout
+# ---------------------------------------------------------------------------
 
-def _make_context(lx_size_mb: int = 2) -> CoreContext:
+_LX_BASELINE = LXOptions(alias_dedup=False, consume_last_use=False)
+_LX_DEDUP    = LXOptions(alias_dedup=True,  consume_last_use=False)
+_LX_FULL     = LXOptions(alias_dedup=True,  consume_last_use=True)
+
+# ---------------------------------------------------------------------------
+# MLIR kernels used by parse-level and end-to-end tests
+# ---------------------------------------------------------------------------
+
+# Small 8×8 matmul — used by TestUseCountsParsed to verify _build_use_counts.
+MATMUL_UC_MLIR = """
+module {
+  func.func @matmul_uc_test(
+      %a_ptr: index, %b_ptr: index, %c_ptr: index, %K: index,
+      %BM: index, %BN: index, %BK: index
+  ) attributes {grid = [1]} {
+    %pid_m, %pid_n = ktdp.get_compute_tile_id : index, index
+    %a_view = ktdp.construct_memory_view %a_ptr, sizes: [8, 8], strides: [8, 1] {
+      coordinate_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 7 >= 0, d1 >= 0, -d1 + 7 >= 0)>,
+      memory_space = #ktdp.spyre_memory_space<HBM>
+    } : memref<8x8xf16>
+    %b_view = ktdp.construct_memory_view %b_ptr, sizes: [8, 8], strides: [8, 1] {
+      coordinate_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 7 >= 0, d1 >= 0, -d1 + 7 >= 0)>,
+      memory_space = #ktdp.spyre_memory_space<HBM>
+    } : memref<8x8xf16>
+    %c_view = ktdp.construct_memory_view %c_ptr, sizes: [8, 8], strides: [8, 1] {
+      coordinate_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 7 >= 0, d1 >= 0, -d1 + 7 >= 0)>,
+      memory_space = #ktdp.spyre_memory_space<HBM>
+    } : memref<8x8xf16>
+    %c0 = arith.constant 0 : index
+    %accum_zero = arith.constant dense<0.0> : tensor<8x8xf16>
+    %c = scf.for %off_k = %c0 to %K step %BK iter_args(%accum_itr = %accum_zero) -> (tensor<8x8xf16>) {
+      %a_acc = ktdp.construct_access_tile %a_view[%pid_m, %off_k] {
+        access_tile_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 7 >= 0, d1 >= 0, -d1 + 7 >= 0)>,
+        access_tile_order = affine_map<(d0, d1) -> (d0, d1)>
+      } : memref<8x8xf16> -> !ktdp.access_tile<8x8xindex>
+      %b_acc = ktdp.construct_access_tile %b_view[%off_k, %pid_n] {
+        access_tile_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 7 >= 0, d1 >= 0, -d1 + 7 >= 0)>,
+        access_tile_order = affine_map<(d0, d1) -> (d0, d1)>
+      } : memref<8x8xf16> -> !ktdp.access_tile<8x8xindex>
+      %a = ktdp.load %a_acc : !ktdp.access_tile<8x8xindex> -> tensor<8x8xf16>
+      %b = ktdp.load %b_acc : !ktdp.access_tile<8x8xindex> -> tensor<8x8xf16>
+      %c_init = tensor.empty() : tensor<8x8xf16>
+      %a_dot_b = linalg.matmul ins(%a, %b : tensor<8x8xf16>, tensor<8x8xf16>)
+                               outs(%c_init : tensor<8x8xf16>) -> tensor<8x8xf16>
+      %accum_next = arith.addf %accum_itr, %a_dot_b : tensor<8x8xf16>
+      scf.yield %accum_next : tensor<8x8xf16>
+    }
+    %c_acc = ktdp.construct_access_tile %c_view[%pid_m, %pid_n] {
+        access_tile_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 7 >= 0, d1 >= 0, -d1 + 7 >= 0)>,
+        access_tile_order = affine_map<(d0, d1) -> (d0, d1)>
+      } : memref<8x8xf16> -> !ktdp.access_tile<8x8xindex>
+    ktdp.store %c, %c_acc : tensor<8x8xf16>, !ktdp.access_tile<8x8xindex>
+    return
+  }
+}
+"""
+
+# Large-tile matmul — used by TestLastUseMatmulKernel end-to-end test.
+# BM=512, BN=256, BK=64: accumulator tile = 512*256*2 = 262144 bytes (256 KB).
+# Peak live set with _LX_BASELINE exceeds 1 MB; with _LX_FULL it fits.
+MATMUL_LX_MLIR = """
+module {
+  func.func @matmul_lx_test(
+      %a_ptr: index,
+      %b_ptr: index,
+      %c_ptr: index,
+      %K: index,
+      %BM: index,
+      %BN: index,
+      %BK: index
+  ) attributes {grid = [1]} {
+    %pid_m, %pid_n = ktdp.get_compute_tile_id : index, index
+
+    %a_view = ktdp.construct_memory_view %a_ptr, sizes: [512, 256], strides: [256, 1] {
+      coordinate_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 511 >= 0, d1 >= 0, -d1 + 255 >= 0)>,
+      memory_space = #ktdp.spyre_memory_space<HBM>
+    } : memref<512x256xf16>
+
+    %b_view = ktdp.construct_memory_view %b_ptr, sizes: [256, 256], strides: [256, 1] {
+      coordinate_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 255 >= 0, d1 >= 0, -d1 + 255 >= 0)>,
+      memory_space = #ktdp.spyre_memory_space<HBM>
+    } : memref<256x256xf16>
+
+    %c_view = ktdp.construct_memory_view %c_ptr, sizes: [512, 256], strides: [256, 1] {
+      coordinate_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 511 >= 0, d1 >= 0, -d1 + 255 >= 0)>,
+      memory_space = #ktdp.spyre_memory_space<HBM>
+    } : memref<512x256xf16>
+
+    %c0 = arith.constant 0 : index
+    %accum_zero = arith.constant dense<0.0> : tensor<512x256xf16>
+
+    %c = scf.for %off_k = %c0 to %K step %BK iter_args(%accum_itr = %accum_zero) -> (tensor<512x256xf16>) {
+
+      %a_acc = ktdp.construct_access_tile %a_view[%pid_m, %off_k] {
+        access_tile_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 511 >= 0, d1 >= 0, -d1 + 63 >= 0)>,
+        access_tile_order = affine_map<(d0, d1) -> (d0, d1)>
+      } : memref<512x256xf16> -> !ktdp.access_tile<512x64xindex>
+
+      %b_acc = ktdp.construct_access_tile %b_view[%off_k, %pid_n] {
+        access_tile_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 63 >= 0, d1 >= 0, -d1 + 255 >= 0)>,
+        access_tile_order = affine_map<(d0, d1) -> (d0, d1)>
+      } : memref<256x256xf16> -> !ktdp.access_tile<64x256xindex>
+
+      %a = ktdp.load %a_acc : !ktdp.access_tile<512x64xindex> -> tensor<512x64xf16>
+      %b = ktdp.load %b_acc : !ktdp.access_tile<64x256xindex> -> tensor<64x256xf16>
+
+      %c_init = tensor.empty() : tensor<512x256xf16>
+      %a_dot_b = linalg.matmul ins(%a, %b : tensor<512x64xf16>, tensor<64x256xf16>)
+                               outs(%c_init : tensor<512x256xf16>) -> tensor<512x256xf16>
+
+      %accum_next = arith.addf %accum_itr, %a_dot_b : tensor<512x256xf16>
+
+      scf.yield %accum_next : tensor<512x256xf16>
+    }
+
+    %c_acc = ktdp.construct_access_tile %c_view[%pid_m, %pid_n] {
+        access_tile_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 511 >= 0, d1 >= 0, -d1 + 255 >= 0)>,
+        access_tile_order = affine_map<(d0, d1) -> (d0, d1)>
+      } : memref<512x256xf16> -> !ktdp.access_tile<512x256xindex>
+
+    ktdp.store %c, %c_acc : tensor<512x256xf16>, !ktdp.access_tile<512x256xindex>
+
+    return
+  }
+}
+"""
+
+
+def _make_context(lx_size_mb: int = 2, lx_options: LXOptions = None) -> CoreContext:
     """Create a CoreContext with a fresh LX scratchpad and HBM."""
     lx = LXScratchpad(size_mb=lx_size_mb, core_id=0)
     hbm = HBMSimulator()
-    return CoreContext(core_id=0, grid_pos=(0, 0, 0), lx=lx, hbm=hbm)
+    return CoreContext(core_id=0, grid_pos=(0, 0, 0), lx=lx, hbm=hbm,
+                       lx_options=lx_options if lx_options is not None else _LX_FULL)
 
 
 def _make_tile(shape: tuple, dtype: str = "f16") -> Tile:
@@ -127,13 +259,21 @@ class TestLXTracking:
         ctx.set_value("%tile", 0)  # overwrite with a non-Tile — refcount drops to 0
         assert ctx.lx.used == 0
 
-    def test_alias_does_not_double_count(self):
-        """Two names bound to the same Tile object charge LX only once."""
-        ctx = _make_context()
-        tile = _make_tile((32, 1024))
+    def test_alias_charges_once_with_dedup(self):
+        """With alias_dedup, two names for the same Tile charge LX once (N)."""
+        ctx = _make_context(lx_options=_LX_DEDUP)
+        tile = _make_tile((32, 1024))  # 65536 bytes
         ctx.set_value("%a", tile)
-        ctx.set_value("%b", tile)  # alias — same id(tile)
+        ctx.set_value("%b", tile)  # same id(tile)
         assert ctx.lx.used == 65536
+
+    def test_alias_double_charges_without_dedup(self):
+        """Without alias_dedup, two names for the same Tile charge LX twice (2N)."""
+        ctx = _make_context(lx_options=_LX_BASELINE)
+        tile = _make_tile((32, 1024))  # 65536 bytes
+        ctx.set_value("%a", tile)
+        ctx.set_value("%b", tile)
+        assert ctx.lx.used == 65536 * 2
 
     def test_pop_scope_frees_lx(self):
         """Popping a scope frees LX for all Tiles defined in that scope."""
@@ -743,3 +883,189 @@ class TestNextPtrRewind:
         assert ctx._lx_next_ptr_stack == []
         assert ctx.lx.next_ptr == 0
         assert ctx.lx.used == 0
+
+
+# ---------------------------------------------------------------------------
+# Consume-on-last-use
+# ---------------------------------------------------------------------------
+
+class TestConsumeOnLastUse:
+    """Tests for the consume_last_use feature (issue #130).
+
+    Each test pairs _LX_DEDUP (consume off) and _LX_FULL (consume on)
+    to show the expected lx.used in each configuration.
+    """
+
+    def test_single_use_tile_lx_used(self):
+        """Single-use tile: with consume on, LX is freed at fetch; with consume off, it stays."""
+        tile = _make_tile((32, 64))  # 4096 bytes
+
+        ctx_off = _make_context(lx_options=_LX_DEDUP)
+        ctx_off.set_value("%a", tile)
+        ctx_off._use_counts = {"%a": 1}
+        ctx_off.get_value("%a")
+        assert ctx_off.lx.used == 4096  # still held — consume off
+        assert ctx_off.has_value("%a")
+
+        ctx_on = _make_context(lx_options=_LX_FULL)
+        ctx_on.set_value("%a", tile)
+        ctx_on._use_counts = {"%a": 1}
+        ctx_on.get_value("%a")
+        assert ctx_on.lx.used == 0     # freed at fetch — consume on
+        assert not ctx_on.has_value("%a")
+
+    def test_multi_use_tile_not_consumed(self):
+        """Multi-use tile (count > 1) is never consumed regardless of consume_last_use."""
+        tile = _make_tile((32, 64))  # 4096 bytes
+
+        for opts in (_LX_DEDUP, _LX_FULL):
+            ctx = _make_context(lx_options=opts)
+            ctx.set_value("%a", tile)
+            ctx._use_counts = {"%a": 2}
+            ctx.get_value("%a")
+            assert ctx.lx.used == 4096
+            assert ctx.has_value("%a")
+
+    def test_non_tile_not_consumed(self):
+        """Scalars are never consumed regardless of use_count."""
+        for opts in (_LX_DEDUP, _LX_FULL):
+            ctx = _make_context(lx_options=opts)
+            ctx.set_value("%s", 42)
+            ctx._use_counts = {"%s": 1}
+            assert ctx.get_value("%s") == 42
+            assert ctx.has_value("%s")
+
+    def test_net_zero_with_consume_on(self):
+        """With consume on: fetch two single-use tiles (lx → 0), register result (lx = N)."""
+        ctx = _make_context(lx_options=_LX_FULL)
+        tile_a = _make_tile((16, 16))  # 512 bytes
+        tile_b = _make_tile((16, 16))
+        ctx.set_value("%a", tile_a)
+        ctx.set_value("%b", tile_b)
+        ctx._use_counts = {"%a": 1, "%b": 1}
+
+        assert ctx.lx.used == 1024
+        ctx.get_value("%a")
+        assert ctx.lx.used == 512
+        ctx.get_value("%b")
+        assert ctx.lx.used == 0
+        ctx.set_value("%r", _make_tile((16, 16)))
+        assert ctx.lx.used == 512
+
+    def test_net_accumulation_with_consume_off(self):
+        """With consume off: fetching does not free — lx stays at 1024 after both fetches."""
+        ctx = _make_context(lx_options=_LX_DEDUP)
+        tile_a = _make_tile((16, 16))  # 512 bytes
+        tile_b = _make_tile((16, 16))
+        ctx.set_value("%a", tile_a)
+        ctx.set_value("%b", tile_b)
+        ctx._use_counts = {"%a": 1, "%b": 1}
+
+        ctx.get_value("%a")
+        ctx.get_value("%b")
+        assert ctx.lx.used == 1024  # both still live
+
+
+class TestUseCountsParsed:
+    """Verify _build_use_counts identifies the three single-use names from issue #130.
+
+    Gap 1: %accum_zero — used only as scf.for iter_init → count == 1 → freed at loop entry.
+    Gap 2: %c_init     — used only as linalg.matmul outs → count == 1 → freed before matmul result lands.
+    Gap 3: %accum_itr  — used only as arith.addf operand → count == 1 → freed before %accum_next lands.
+
+    Names used in more than one place must have count > 1 so they are NOT consumed on first fetch.
+    """
+
+    def _get_use_counts(self):
+        from ktir_cpu.parser import KTIRParser
+        module = KTIRParser().parse_module(MATMUL_UC_MLIR)
+        return module.get_function("matmul_uc_test").use_counts
+
+    def test_gap1_accum_zero_single_use(self):
+        """Gap 1: %accum_zero is only the iter_init of scf.for — count must be 1."""
+        uc = self._get_use_counts()
+        assert uc.get("%accum_zero", 0) == 1
+
+    def test_gap2_c_init_single_use(self):
+        """Gap 2: %c_init is only the outs of linalg.matmul — count must be 1."""
+        uc = self._get_use_counts()
+        assert uc.get("%c_init", 0) == 1
+
+    def test_gap3_accum_itr_single_use(self):
+        """Gap 3: %accum_itr is only an operand of arith.addf — count must be 1."""
+        uc = self._get_use_counts()
+        assert uc.get("%accum_itr", 0) == 1
+
+    def test_multi_use_names_not_single(self):
+        """Names used more than once must have count > 1 so they are not consumed early.
+
+        %pid_m is used as the index base for both %a_acc (inside the loop) and
+        %c_acc (after the loop) — two distinct use sites, so count must be >= 2.
+        """
+        uc = self._get_use_counts()
+        assert uc.get("%pid_m", 0) >= 2, (
+            f"Expected %pid_m to have >= 2 uses, got {uc.get('%pid_m', 0)}"
+        )
+
+
+class TestLastUseMatmulKernel:
+    """End-to-end LX tests for the matmul kernel (issue #130).
+
+    MATMUL_LX_MLIR: BM=512, BN=256, BK=64 — accumulator tile = 256 KB.
+    LX cap is tightened to 1 MB for both tests.
+
+    With _LX_BASELINE: %accum_itr + %c_init + %a_dot_b + %accum_next all
+    coexist (4 × 256 KB = 1 MB), plus %a (64 KB) and %b (32 KB) → overflow.
+    With _LX_FULL: single-use tiles are freed before their consumer's result
+    lands → peak stays within 1 MB.
+    """
+
+    LX_CAP = 1 * 1024 * 1024  # 1 MB
+
+    def _run(self, lx_options):
+        from ktir_cpu.interpreter import KTIRInterpreter
+
+        class _PatchedInterpreter(KTIRInterpreter):
+            """Applies lx_options and LX cap after each _prepare_execution call."""
+            def _prepare_execution(self, grid_shape):
+                super()._prepare_execution(grid_shape)
+                for core in self.grid_executor.cores:
+                    core.lx.capacity = TestLastUseMatmulKernel.LX_CAP
+                    core.lx_options = lx_options
+
+        BM, BN, BK, K = 512, 256, 64, 256
+        a = np.random.rand(BM, K).astype(np.float16)
+        b = np.random.rand(K, BN).astype(np.float16)
+        c = np.zeros((BM, BN), dtype=np.float16)
+        interp = _PatchedInterpreter()
+        interp.load(MATMUL_LX_MLIR)
+        return interp.execute_function(
+            "matmul_lx_test", a_ptr=a, b_ptr=b, c_ptr=c,
+            K=K, BM=BM, BN=BN, BK=BK,
+        )
+
+    def test_fits_in_lx_with_consume_on(self):
+        """With consume_last_use on, peak LX stays within 1 MB — no overflow."""
+        self._run(_LX_FULL)  # must not raise
+
+    def test_overflows_lx_with_consume_off(self):
+        """With consume_last_use off, peak LX exceeds 1 MB — overflow expected."""
+        with pytest.raises(MemoryError, match="LX scratchpad overflow"):
+            self._run(_LX_DEDUP)
+
+    def test_addf_loop_body_lx_accounting(self):
+        """Unit: fetch two single-use tiles (lx → 0 each step), register result (lx = N)."""
+        N = 393216  # 384*512*2 bytes
+        ctx = _make_context(lx_options=_LX_FULL)
+        ctx.set_value("%accum_itr", _make_tile((384, 512)))
+        ctx.set_value("%a_dot_b",   _make_tile((384, 512)))
+        ctx._use_counts = {"%accum_itr": 1, "%a_dot_b": 1}
+
+        assert ctx.lx.used == N * 2
+        ctx.get_value("%accum_itr")
+        assert ctx.lx.used == N
+        ctx.get_value("%a_dot_b")
+        assert ctx.lx.used == 0
+        ctx.set_value("%accum_next", _make_tile((384, 512)))
+        assert ctx.lx.used == N
+

--- a/tests/test_lx_scoping.py
+++ b/tests/test_lx_scoping.py
@@ -243,7 +243,24 @@ class TestScopeStack:
 # ---------------------------------------------------------------------------
 
 class TestLXTracking:
-    """Test that set_value auto-tracking correctly manages lx.used."""
+    """set_value auto-tracking: every Tile binding charges lx.used exactly once.
+
+    Tile size used in alias tests: tensor<32x1024xf16> = 32*1024*2 = 65536 bytes.
+
+    Alias dedup (_LX_DEDUP vs _LX_BASELINE)
+    ----------------------------------------
+    Two SSA names can point to the same Python Tile object (e.g. linalg.reduce
+    binds %result and %outs to the same buffer).  Without dedup, each binding
+    charges separately:
+
+      _LX_BASELINE — no id() tracking:
+        set_value("%a", tile)  →  lx.used = 65536   (charged)
+        set_value("%b", tile)  →  lx.used = 131072  (charged again — wrong)
+
+      _LX_DEDUP — refcount by id():
+        set_value("%a", tile)  →  lx.used = 65536   (first binding, charged)
+        set_value("%b", tile)  →  lx.used = 65536   (same id(), refcount 1→2, no charge)
+    """
 
     def test_set_value_tile_increments_used(self):
         ctx = _make_context()
@@ -776,7 +793,7 @@ class TestNextPtrRewind:
     pop_scope so it stays in lockstep with lx.used.
     """
 
-    def test_issue_26_reproducer_next_ptr_bounded_in_loop(self):
+    def test_next_ptr_returns_to_zero_each_iteration(self):
         """The exact failure mode from issue #26.
 
         Before the fix, next_ptr advanced by 2048 (tile size, stick-aligned)
@@ -890,10 +907,31 @@ class TestNextPtrRewind:
 # ---------------------------------------------------------------------------
 
 class TestConsumeOnLastUse:
-    """Tests for the consume_last_use feature (issue #130).
+    """consume_last_use: free a Tile at its last fetch instead of at scope exit.
 
-    Each test pairs _LX_DEDUP (consume off) and _LX_FULL (consume on)
-    to show the expected lx.used in each configuration.
+    Motivating pattern — a binary op where both inputs are single-use:
+
+        %a = ktdp.load ...          # tensor<16x16xf16> = 512 bytes
+        %b = ktdp.load ...          # tensor<16x16xf16> = 512 bytes
+        %r = arith.addf %a, %b     # handler fetches %a then %b, then registers %r
+
+    Without consume_last_use (_LX_DEDUP):
+        after set_value("%a"):       lx.used = 512
+        after set_value("%b"):       lx.used = 1024
+        get_value("%a") — no free:   lx.used = 1024
+        get_value("%b") — no free:   lx.used = 1024
+        set_value("%r", result):     lx.used = 1536   ← all three live simultaneously
+
+    With consume_last_use (_LX_FULL), use_counts = {%a:1, %b:1}:
+        after set_value("%a"):       lx.used = 512
+        after set_value("%b"):       lx.used = 1024
+        get_value("%a") — freed:     lx.used =  512   ← %a gone before handler returns
+        get_value("%b") — freed:     lx.used =    0   ← %b gone before result lands
+        set_value("%r", result):     lx.used =  512   ← net: replaced two inputs with one output
+
+    Guard: only the topmost scope is eligible for early-free.  An outer-scope
+    name with use_count==1 that is read N times inside a loop is NOT consumed
+    on first fetch — the topmost-scope check (scope is _scope_stack[-1]) blocks it.
     """
 
     def test_single_use_tile_lx_used(self):
@@ -967,13 +1005,38 @@ class TestConsumeOnLastUse:
 
 
 class TestUseCountsParsed:
-    """Verify _build_use_counts identifies the three single-use names from issue #130.
+    """_build_use_counts correctly counts operand occurrences across the whole function.
 
-    Gap 1: %accum_zero — used only as scf.for iter_init → count == 1 → freed at loop entry.
-    Gap 2: %c_init     — used only as linalg.matmul outs → count == 1 → freed before matmul result lands.
-    Gap 3: %accum_itr  — used only as arith.addf operand → count == 1 → freed before %accum_next lands.
+    The use-count map is a flat dict: SSA name → number of times it appears
+    as an operand across all ops and nested regions.  A name with count == 1
+    is eligible for consume-on-last-use; count > 1 must never be consumed early.
 
-    Names used in more than one place must have count > 1 so they are NOT consumed on first fetch.
+    Verified against MATMUL_UC_MLIR (8×8 tiles, one scf.for loop):
+
+        // function body
+        %accum_zero = arith.constant dense<0.0>            ← defined here
+        %c = scf.for ... iter_args(%accum_itr = %accum_zero) {
+            // loop body (nested region)
+            %c_init  = tensor.empty()                      ← defined here
+            %a_dot_b = linalg.matmul ... outs(%c_init)     ← %c_init used here (count=1)
+            %accum_next = arith.addf %accum_itr, %a_dot_b  ← %accum_itr used here (count=1)
+                                                           ← %a_dot_b used here (count=1)
+            scf.yield %accum_next
+        }                                                  ← %accum_zero used as iter_init (count=1)
+
+        // after loop
+        ktdp.store %c, %c_acc                              ← %pid_m used here
+
+        // %pid_m also appears inside the loop as index for %a_acc
+        // → two occurrences across function body + loop region → count >= 2
+
+    Name          Where used                         count   eligible?
+    ----------    --------------------------------   -----   ---------
+    %accum_zero   scf.for iter_init                    1     yes — freed when loop starts
+    %c_init       linalg.matmul outs                   1     yes — freed before %a_dot_b lands
+    %accum_itr    arith.addf operand                   1     yes (count) but blocked by
+                                                             topmost-scope guard at runtime
+    %pid_m        %a_acc index, %c_acc index            2     no  — must not be consumed early
     """
 
     def _get_use_counts(self):
@@ -982,42 +1045,79 @@ class TestUseCountsParsed:
         return module.get_function("matmul_uc_test").use_counts
 
     def test_gap1_accum_zero_single_use(self):
-        """Gap 1: %accum_zero is only the iter_init of scf.for — count must be 1."""
+        """%accum_zero appears once — as the iter_init of scf.for."""
         uc = self._get_use_counts()
         assert uc.get("%accum_zero", 0) == 1
 
     def test_gap2_c_init_single_use(self):
-        """Gap 2: %c_init is only the outs of linalg.matmul — count must be 1."""
+        """%c_init appears once — as the outs buffer of linalg.matmul."""
         uc = self._get_use_counts()
         assert uc.get("%c_init", 0) == 1
 
     def test_gap3_accum_itr_single_use(self):
-        """Gap 3: %accum_itr is only an operand of arith.addf — count must be 1."""
+        """%accum_itr appears once — as the left operand of arith.addf."""
         uc = self._get_use_counts()
         assert uc.get("%accum_itr", 0) == 1
 
     def test_multi_use_names_not_single(self):
-        """Names used more than once must have count > 1 so they are not consumed early.
-
-        %pid_m is used as the index base for both %a_acc (inside the loop) and
-        %c_acc (after the loop) — two distinct use sites, so count must be >= 2.
-        """
+        """%pid_m appears twice: once as index for %a_acc inside the loop, once for %c_acc after it."""
         uc = self._get_use_counts()
         assert uc.get("%pid_m", 0) >= 2, (
-            f"Expected %pid_m to have >= 2 uses, got {uc.get('%pid_m', 0)}"
+            f"Expected %pid_m count >= 2, got {uc.get('%pid_m', 0)}"
         )
 
 
 class TestLastUseMatmulKernel:
-    """End-to-end LX tests for the matmul kernel (issue #130).
+    """End-to-end LX accounting for MATMUL_LX_MLIR (issue #130).
 
-    MATMUL_LX_MLIR: BM=512, BN=256, BK=64 — accumulator tile = 256 KB.
-    LX cap is tightened to 1 MB for both tests.
+    Kernel: BM=512, BN=256, BK=64, K=256 (4 iterations).
+    LX cap tightened to 1 MB = 1048576 bytes.
 
-    With _LX_BASELINE: %accum_itr + %c_init + %a_dot_b + %accum_next all
-    coexist (4 × 256 KB = 1 MB), plus %a (64 KB) and %b (32 KB) → overflow.
-    With _LX_FULL: single-use tiles are freed before their consumer's result
-    lands → peak stays within 1 MB.
+    Tile sizes (f16 = 2 bytes/elem):
+        %accum_itr / %accum_next  512×256×2 = 262144 bytes  (256 KB)
+        %c_init / %a_dot_b        512×256×2 = 262144 bytes  (256 KB)
+        %a                        512×64×2  =  65536 bytes  ( 64 KB)
+        %b                         64×256×2 =  32768 bytes  ( 32 KB)
+
+    Per-iteration peak, _LX_DEDUP (consume off):
+        parent scope:  %accum_itr                    262144
+        body scope:    %a + %b + %c_init + %a_dot_b   65536+32768+262144+262144
+                       + %accum_next                 +262144
+                                                     -------
+        peak =  262144 + 65536 + 32768 + 262144 + 262144 + 262144 = 1146880 bytes
+        → exceeds 1 MB cap → MemoryError
+
+    Per-iteration peak, _LX_FULL (consume on), use_counts all 1:
+        parent: %accum_itr alive                      lx = 262144
+        body:
+          ktdp.load  → %a registered                  lx = 327680
+          ktdp.load  → %b registered                  lx = 360448
+          tensor.empty → %c_init registered            lx = 622592
+          linalg.matmul fetches %c_init (count=1, topmost) → freed
+                         %c_init consumed              lx = 360448
+                         %a_dot_b registered           lx = 622592
+          arith.addf fetches %a (count=1, topmost)   → freed
+                         %a consumed                   lx = 557056
+                     fetches %b (count=1, topmost)   → freed
+                         %b consumed                   lx = 524288
+                     fetches %accum_itr (count=1, but parent scope — guard blocks)
+                         %accum_itr stays              lx = 524288
+                     fetches %a_dot_b (count=1, topmost) → freed
+                         %a_dot_b consumed             lx = 262144
+                         %accum_next registered        lx = 524288
+        peak = 524288 bytes (512 KB) — within 1 MB cap → no overflow
+
+    Remaining limitation — simultaneous window for %accum_itr:
+        %accum_itr lives in the parent scope, not the body scope.
+        The topmost-scope guard blocks early-free even though use_count == 1,
+        because %accum_itr is fetched on every iteration (the global count
+        of 1 reflects that it appears once as an operand of arith.addf, but
+        that one appearance is executed K/BK times).
+        As a result, %accum_itr and %accum_next are both live simultaneously
+        inside each iteration body — hence peak = 2 × 256 KB = 512 KB
+        rather than the theoretical minimum of 256 KB.
+        The set_value rebind after each iteration frees %accum_itr promptly,
+        but cannot act before %accum_next is charged.
     """
 
     LX_CAP = 1 * 1024 * 1024  # 1 MB

--- a/tests/test_lx_scoping.py
+++ b/tests/test_lx_scoping.py
@@ -952,6 +952,30 @@ class TestConsumeOnLastUse:
         assert ctx_on.lx.used == 0     # freed at fetch — consume on
         assert not ctx_on.has_value("%a")
 
+    def test_peek_does_not_consume(self):
+        """peek=True reads without consuming; subsequent normal get_value still consumes.
+
+        Sequence:
+            set_value("%a", tile)    lx.used = 512
+            get_value("%a", peek=T)  lx.used = 512  — no consume, tile still in scope
+            get_value("%a")          lx.used = 0    — consume fires here, not earlier
+        """
+        tile = _make_tile((16, 16))  # 512 bytes
+
+        ctx = _make_context(lx_options=_LX_FULL)
+        ctx.set_value("%a", tile)
+        ctx._use_counts = {"%a": 1}
+
+        result = ctx.get_value("%a", peek=True)
+        assert result is tile
+        assert ctx.lx.used == 512        # peek did not free
+        assert ctx.has_value("%a")       # still in scope
+
+        result2 = ctx.get_value("%a")
+        assert result2 is tile
+        assert ctx.lx.used == 0          # consumed on normal fetch
+        assert not ctx.has_value("%a")
+
     def test_multi_use_tile_not_consumed(self):
         """Multi-use tile (count > 1) is never consumed regardless of consume_last_use."""
         tile = _make_tile((32, 64))  # 4096 bytes


### PR DESCRIPTION
## Background

Issue #130 documents an LX overflow in a matmul kernel that should fit in 2 MB on real hardware but exhausts the interpreter's 2 MB budget. The root cause is that the interpreter's scope-based LX tracking is too conservative in two distinct ways:

**1. Aliased tiles inflate `lx.used`** — `linalg.matmul` binds its output to both `%a_dot_b` and the `outs` buffer `%c_init`. Without tracking that these are the same Python object, `set_value` charges LX twice for a single allocation.

**2. Single-use tiles stay live until scope exit** — within a loop body, tiles that are produced and consumed within a single iteration (e.g. `%accum_zero` initialising the iter-arg) linger in scope until `pop_scope` at the end of the iteration, needlessly inflating peak LX. The fix for (1) in PR #118 corrected the double-charge but left the second gap open. This PR closes gap 2.

## Strategy

### Parse-time use-count map

At `load()` time, `KTIRInterpreter._build_use_counts` does a single recursive walk over all ops and nested regions, counting how many times each SSA name appears as an operand:

```python
_use_counts: Dict[str, int]   # SSA name → total operand occurrences
```

SSA names are unique across a function, so a flat global map suffices — no per-region threading is needed.

### Consume-on-last-use in `get_value`

When `use_count == 1`, the name is being fetched for the last time. `get_value` removes it from scope and frees LX before the consuming op runs, so the new result tile can reuse the freed slot at no net increase in `lx.used`:

```python
if (isinstance(value, Tile)
        and self._use_counts.get(name, 0) == 1
        and scope is self._scope_stack[-1]):   # topmost-scope guard
    del scope[name]
    self._tile_refcount[id(value)] -= 1
    if self._tile_refcount[id(value)] == 0:
        self.lx.used -= value.size_bytes()
```

The **topmost-scope guard** (`scope is self._scope_stack[-1]`) is essential. An outer-scope name with a global `use_count == 1` that is fetched per iteration inside a loop (e.g. `%accum_itr`) would otherwise be consumed on the first iteration and raise `KeyError` on subsequent ones. The guard restricts early-freeing to names that live in the currently-active scope.

### LXOptions — independently toggleable flags

Both mechanisms (alias_dedup from #118 and consume_last_use from this PR) are now controlled by a single `LXOptions` dataclass:

```python
@dataclass
class LXOptions:
    alias_dedup: bool = True       # refcount by id(Tile) — PR #118
    consume_last_use: bool = True  # free at last fetch — this PR
```

Tests use explicit presets to isolate each feature:

```python
_LX_BASELINE = LXOptions(alias_dedup=False, consume_last_use=False)
_LX_DEDUP    = LXOptions(alias_dedup=True,  consume_last_use=False)
_LX_FULL     = LXOptions(alias_dedup=True,  consume_last_use=True)
```

## Known limitation: simultaneous window for iter-arg tiles

Consume-on-last-use cannot eliminate the peak-LX cost of loop carry variables. In each iteration, `%accum_itr` (parent scope) and `%accum_next` (new tile from `arith.addf`) must both be live simultaneously at the moment `%accum_next` is charged. The topmost-scope guard correctly blocks early consumption of `%accum_itr` — it lives in the parent scope and is fetched on every iteration.

After the body scope pops, the `scf.for` rebinds `%accum_itr := %accum_next`, which frees the old carry tile promptly. But the peak has already occurred. See `docs/lx_tracking.md` for the full accounting.

## Changes

- `ktir_cpu/memory.py` — adds `LXOptions` dataclass
- `ktir_cpu/grid.py` — wires `lx_options` into `CoreContext`; branches on each flag in `set_value`, `get_value`, `pop_scope`
- `ktir_cpu/interpreter.py` — adds `_build_use_counts`; installs `_use_counts` on all cores before `execute_with_communication`
- `tests/test_lx_scoping.py` — restructured around `_LX_BASELINE`/`_LX_DEDUP`/`_LX_FULL` presets; module-level MLIR constants; ASCII-art accounting in docstrings
- `tests/test_examples.py` — removes `test_softmax_lx_overflow` (premise invalidated; overflow property tested directly in `test_lx_scoping.py`)
- `docs/lx_tracking.md` — new design doc covering both complications, the topmost-scope guard, the simultaneous-window limitation, and `LXOptions`