### PR TITLE
fix: in-place outs invariant + structural assertion (#135)

### DIFF
--- a/ktir_cpu/dialects/linalg_ops.py
+++ b/ktir_cpu/dialects/linalg_ops.py
@@ -297,7 +297,7 @@ def linalg__broadcast(op, context, env):
     return Tile(result, inp.dtype, out_shape)
 
 
-@register("linalg.matmul", latency_category=LC.COMPUTE_MATMUL)
+@register("linalg.matmul", latency_category=LC.COMPUTE_MATMUL, inplace_outs=True)
 def linalg__matmul(op, context, env):
     """Execute linalg.matmul: result = outs + ins[0] @ ins[1].
 
@@ -328,7 +328,7 @@ def linalg__matmul(op, context, env):
     return result
 
 
-@register("linalg.batch_matmul", latency_category=LC.COMPUTE_MATMUL)
+@register("linalg.batch_matmul", latency_category=LC.COMPUTE_MATMUL, inplace_outs=True)
 def linalg__batch_matmul(op, context, env):
     """Execute linalg.batch_matmul: result = outs + ins[0] @ ins[1] (batched).
 

--- a/ktir_cpu/dialects/linalg_ops.py
+++ b/ktir_cpu/dialects/linalg_ops.py
@@ -317,10 +317,14 @@ def linalg__matmul(op, context, env):
     tile_b = context.get_value(op.operands[1])  # ins[1] = B
     result = ArithOps.matmul(tile_a, tile_b)    # A @ B
     # Accumulate into outs (operands[2] = C) when present.
+    # In-place update: mirrors hardware behavior where the accumulator is a
+    # physical buffer written in-place. Returning the same Tile object means
+    # alias_dedup sees the same id() and doesn't double-charge LX.
     if len(op.operands) > 2:
         acc = context.get_value(op.operands[2])
         if isinstance(acc, Tile):
-            result = Tile(acc.data + result.data, acc.dtype, acc.shape)
+            acc.data += result.data
+            return acc
     return result
 
 
@@ -342,7 +346,8 @@ def linalg__batch_matmul(op, context, env):
     if len(op.operands) > 2:
         acc = context.get_value(op.operands[2])
         if isinstance(acc, Tile):
-            result = Tile(acc.data + result.data, acc.dtype, acc.shape)
+            acc.data += result.data
+            return acc
     return result
 
 

--- a/ktir_cpu/dialects/registry.py
+++ b/ktir_cpu/dialects/registry.py
@@ -41,6 +41,10 @@ _REGISTRY: Dict[str, HandlerFn] = {}
 
 _LATENCY_CATEGORIES: Dict[str, str] = {}
 
+# Ops registered with inplace_outs=True — their outs buffer is an in-place
+# accumulator and the handler must return the same Tile object.
+_INPLACE_OPS_SET: set = set()
+
 
 def get_latency_category(op_name: str) -> str:
     """Return the latency category for *op_name*, defaulting to ``"zero"``.
@@ -84,7 +88,7 @@ def make_parse_context(aliases: Dict[str, str]) -> "ParseContext":
     return ParseContext(aliases=aliases)
 
 
-def register(*op_names: str, latency_category: str = "zero"):
+def register(*op_names: str, latency_category: str = "zero", inplace_outs: bool = False):
     """Decorator that registers a dialect operation handler.
 
     Usage::
@@ -100,14 +104,27 @@ def register(*op_names: str, latency_category: str = "zero"):
         @register()  # infers "arith.addf" from function name "arith__addf"
         def arith__addf(op, context, env):
             ...
+
+    Args:
+        inplace_outs: When True, the op's outs buffer is an in-place accumulator
+            and parsers will populate ``Operation.outs_operands``.  The structural
+            assertion in ``_execute_op`` then verifies the handler returns the
+            same Tile object.
     """
     def decorator(fn: HandlerFn) -> HandlerFn:
         names = op_names or (fn.__name__.replace("__", "."),)
         for name in names:
             _REGISTRY[name] = fn
             _LATENCY_CATEGORIES[name] = latency_category
+            if inplace_outs:
+                _INPLACE_OPS_SET.add(name)
         return fn
     return decorator
+
+
+def is_inplace_outs(op_name: str) -> bool:
+    """Return whether *op_name* was registered with ``inplace_outs=True``."""
+    return op_name in _INPLACE_OPS_SET
 
 
 def dispatch(op_name: str) -> Optional[HandlerFn]:
@@ -116,13 +133,14 @@ def dispatch(op_name: str) -> Optional[HandlerFn]:
 
 
 def temp_registry():
-    """Context manager that restores _REGISTRY and _LATENCY_CATEGORIES on exit."""
+    """Context manager that restores _REGISTRY, _LATENCY_CATEGORIES, and _INPLACE_OPS_SET on exit."""
     from contextlib import contextmanager
 
     @contextmanager
     def _ctx():
         saved_registry = _REGISTRY.copy()
         saved_latency = _LATENCY_CATEGORIES.copy()
+        saved_inplace = _INPLACE_OPS_SET.copy()
         try:
             yield
         finally:
@@ -130,6 +148,8 @@ def temp_registry():
             _REGISTRY.update(saved_registry)
             _LATENCY_CATEGORIES.clear()
             _LATENCY_CATEGORIES.update(saved_latency)
+            _INPLACE_OPS_SET.clear()
+            _INPLACE_OPS_SET.update(saved_inplace)
 
     return _ctx()
 

--- a/ktir_cpu/dialects/registry.py
+++ b/ktir_cpu/dialects/registry.py
@@ -115,6 +115,25 @@ def dispatch(op_name: str) -> Optional[HandlerFn]:
     return _REGISTRY.get(op_name)
 
 
+def temp_registry():
+    """Context manager that restores _REGISTRY and _LATENCY_CATEGORIES on exit."""
+    from contextlib import contextmanager
+
+    @contextmanager
+    def _ctx():
+        saved_registry = _REGISTRY.copy()
+        saved_latency = _LATENCY_CATEGORIES.copy()
+        try:
+            yield
+        finally:
+            _REGISTRY.clear()
+            _REGISTRY.update(saved_registry)
+            _LATENCY_CATEGORIES.clear()
+            _LATENCY_CATEGORIES.update(saved_latency)
+
+    return _ctx()
+
+
 @dataclass
 class ParseContext:
     """Parse-time context passed to dialect parsers alongside the op text.

--- a/ktir_cpu/interpreter.py
+++ b/ktir_cpu/interpreter.py
@@ -36,10 +36,6 @@ from .dtypes import to_ktir_dtype as _ktir_dtype, stick_to_elem_idx as _stick_to
 from .memory import HBMSimulator
 from .ops.memory_ops import hbm_read, hbm_write
 
-# Ops where outs is an in-place accumulator (result includes outs values).
-# The structural assertion only applies to these ops.
-_INPLACE_OPS = frozenset({"linalg.matmul", "linalg.batch_matmul"})
-
 
 class KTIRInterpreter:
     """Main KTIR interpreter.
@@ -230,7 +226,6 @@ class KTIRInterpreter:
         # Structural invariant: accumulating ops must return the same outs object.
         # Only applies to ops where result = f(ins) + outs (in-place accumulation).
         if (op.outs_operands and not op.regions
-                and op.op_type in _INPLACE_OPS
                 and result is not None and not inspect.isgenerator(result)):
             for outs_name in op.outs_operands:
                 try:

--- a/ktir_cpu/interpreter.py
+++ b/ktir_cpu/interpreter.py
@@ -223,6 +223,20 @@ class KTIRInterpreter:
             print(f"Error executing {op.op_type} on core {context.core_id}: {e}")
             raise
 
+        # Structural invariant: leaf ops with outs must return the same object.
+        if (op.outs_operands and not op.regions
+                and result is not None and not inspect.isgenerator(result)):
+            for outs_name in op.outs_operands:
+                try:
+                    outs_tile = context.get_value(outs_name, peek=True)
+                except KeyError:
+                    continue
+                if isinstance(outs_tile, Tile) and isinstance(result, Tile):
+                    assert id(result) == id(outs_tile), (
+                        f"{op.op_type}: handler returned new Tile instead of "
+                        f"mutating outs {outs_name!r}"
+                    )
+
         # Store result in context.
         # Only Tile values (tensor data backed by NumPy arrays) occupy LX.
         # Other result types — TileRef (metadata), AccessTile (coordinates),

--- a/ktir_cpu/interpreter.py
+++ b/ktir_cpu/interpreter.py
@@ -36,6 +36,10 @@ from .dtypes import to_ktir_dtype as _ktir_dtype, stick_to_elem_idx as _stick_to
 from .memory import HBMSimulator
 from .ops.memory_ops import hbm_read, hbm_write
 
+# Ops where outs is an in-place accumulator (result includes outs values).
+# The structural assertion only applies to these ops.
+_INPLACE_OPS = frozenset({"linalg.matmul", "linalg.batch_matmul"})
+
 
 class KTIRInterpreter:
     """Main KTIR interpreter.
@@ -223,8 +227,10 @@ class KTIRInterpreter:
             print(f"Error executing {op.op_type} on core {context.core_id}: {e}")
             raise
 
-        # Structural invariant: leaf ops with outs must return the same object.
+        # Structural invariant: accumulating ops must return the same outs object.
+        # Only applies to ops where result = f(ins) + outs (in-place accumulation).
         if (op.outs_operands and not op.regions
+                and op.op_type in _INPLACE_OPS
                 and result is not None and not inspect.isgenerator(result)):
             for outs_name in op.outs_operands:
                 try:

--- a/ktir_cpu/ir_types.py
+++ b/ktir_cpu/ir_types.py
@@ -379,6 +379,7 @@ class Operation:
     attributes: Dict[str, Any]  # Operation attributes
     result_type: Optional[str]  # Result type string
     regions: List[List['Operation']] = field(default_factory=list)  # For control flow
+    outs_operands: List[str] = field(default_factory=list)  # SSA names from outs(...)
 
     def __repr__(self):
         if self.result:

--- a/ktir_cpu/mlir_frontend/parser.py
+++ b/ktir_cpu/mlir_frontend/parser.py
@@ -134,6 +134,11 @@ class MLIRTypeAdapter:
         handler(mlir_op, attributes, result_type, operands)
 
         outs_operands = attributes.pop("_outs_operands", [])
+        if not outs_operands:
+            from ..dialects.registry import is_inplace_outs
+            if is_inplace_outs(mlir_op.name):
+                from ..parser_utils import extract_outs_operands
+                outs_operands = extract_outs_operands(mlir_op.get_asm())
 
         return Operation(
             result=result,
@@ -216,29 +221,11 @@ MLIRTypeAdapter.install(
     "ktdp.get_compute_tile_id",
     "ktdp.load",
     "ktdp.store",
+    "linalg.matmul",
+    "linalg.batch_matmul",
     # emitted by the bindings walk but not present in text IR
     "ktdp.region_terminator",
 )(_no_attrs)
-
-
-def _adapt_linalg_matmul_like(mlir_op, attributes, result_type, operands):
-    """Handler for linalg.matmul/batch_matmul.
-
-    Populates _outs_operands so the structural assertion in _execute_op can
-    verify the handler returns the same Tile object as outs (in-place invariant).
-    If a future op has the same accumulate-into-outs semantics (e.g. linalg.conv),
-    add it to the MLIRTypeAdapter.install() call below.
-    """
-    from ..parser_utils import extract_outs_operands
-    outs = extract_outs_operands(mlir_op.get_asm())
-    if outs:
-        attributes["_outs_operands"] = outs
-
-
-MLIRTypeAdapter.install(
-    "linalg.matmul",
-    "linalg.batch_matmul",
-)(_adapt_linalg_matmul_like)
 
 
 @MLIRTypeAdapter.install("scf.for")

--- a/ktir_cpu/mlir_frontend/parser.py
+++ b/ktir_cpu/mlir_frontend/parser.py
@@ -133,6 +133,8 @@ class MLIRTypeAdapter:
             )
         handler(mlir_op, attributes, result_type, operands)
 
+        outs_operands = attributes.pop("_outs_operands", [])
+
         return Operation(
             result=result,
             op_type=mlir_op.name,
@@ -140,6 +142,7 @@ class MLIRTypeAdapter:
             attributes=attributes,
             result_type=result_type,
             regions=regions,
+            outs_operands=outs_operands,
         )
 
     def adapt_block(self, block) -> List[Operation]:
@@ -158,8 +161,6 @@ MLIRTypeAdapter.install(
     "func.return",
     "linalg.add",
     "linalg.fill",
-    "linalg.matmul",
-    "linalg.batch_matmul",
     "linalg.yield",
     "scf.yield",
     "scf.if",
@@ -218,6 +219,24 @@ MLIRTypeAdapter.install(
     # emitted by the bindings walk but not present in text IR
     "ktdp.region_terminator",
 )(_no_attrs)
+
+
+def _adapt_linalg_matmul_like(mlir_op, attributes, result_type, operands):
+    """Handler for linalg.matmul/batch_matmul: fixed 2 ins, 1 outs.
+
+    Populates _outs_operands so the structural assertion in _execute_op can
+    verify the handler returns the same Tile object as outs (in-place invariant).
+    If a future op has the same accumulate-into-outs semantics (e.g. linalg.conv),
+    add it to the MLIRTypeAdapter.install() call below.
+    """
+    if len(operands) > 2:
+        attributes["_outs_operands"] = operands[2:]
+
+
+MLIRTypeAdapter.install(
+    "linalg.matmul",
+    "linalg.batch_matmul",
+)(_adapt_linalg_matmul_like)
 
 
 @MLIRTypeAdapter.install("scf.for")

--- a/ktir_cpu/mlir_frontend/parser.py
+++ b/ktir_cpu/mlir_frontend/parser.py
@@ -222,15 +222,17 @@ MLIRTypeAdapter.install(
 
 
 def _adapt_linalg_matmul_like(mlir_op, attributes, result_type, operands):
-    """Handler for linalg.matmul/batch_matmul: fixed 2 ins, 1 outs.
+    """Handler for linalg.matmul/batch_matmul.
 
     Populates _outs_operands so the structural assertion in _execute_op can
     verify the handler returns the same Tile object as outs (in-place invariant).
     If a future op has the same accumulate-into-outs semantics (e.g. linalg.conv),
     add it to the MLIRTypeAdapter.install() call below.
     """
-    if len(operands) > 2:
-        attributes["_outs_operands"] = operands[2:]
+    from ..parser_utils import extract_outs_operands
+    outs = extract_outs_operands(mlir_op.get_asm())
+    if outs:
+        attributes["_outs_operands"] = outs
 
 
 MLIRTypeAdapter.install(

--- a/ktir_cpu/mlir_frontend/parser.py
+++ b/ktir_cpu/mlir_frontend/parser.py
@@ -133,12 +133,10 @@ class MLIRTypeAdapter:
             )
         handler(mlir_op, attributes, result_type, operands)
 
-        outs_operands = attributes.pop("_outs_operands", [])
-        if not outs_operands:
-            from ..dialects.registry import is_inplace_outs
-            if is_inplace_outs(mlir_op.name):
-                from ..parser_utils import extract_outs_operands
-                outs_operands = extract_outs_operands(mlir_op.get_asm())
+        from ..dialects.registry import is_inplace_outs
+        from ..parser_utils import extract_outs_operands
+        outs_operands = (extract_outs_operands(mlir_op.get_asm())
+                         if is_inplace_outs(mlir_op.name) else [])
 
         return Operation(
             result=result,

--- a/ktir_cpu/parser.py
+++ b/ktir_cpu/parser.py
@@ -621,7 +621,8 @@ class KTIRParser(KTIRParserBase):
                 attributes["_result_dtype"] = type_info.get("dtype", "f16")
 
         from .parser_utils import extract_outs_operands
-        outs_ops = extract_outs_operands(rest)
+        from .dialects.registry import is_inplace_outs
+        outs_ops = extract_outs_operands(rest) if is_inplace_outs(op_type) else []
 
         return Operation(
             result=result,

--- a/ktir_cpu/parser.py
+++ b/ktir_cpu/parser.py
@@ -620,12 +620,19 @@ class KTIRParser(KTIRParserBase):
                 attributes["_result_shape"] = type_info["shape"]
                 attributes["_result_dtype"] = type_info.get("dtype", "f16")
 
+        outs_ops = []
+        if op_type in ("linalg.matmul", "linalg.batch_matmul"):
+            outs_match = re.search(r'\bouts\s*\(([^)]+)\)', rest)
+            if outs_match:
+                outs_ops = find_ssa_names(outs_match.group(1).split(':')[0])
+
         return Operation(
             result=result,
             op_type=op_type,
             operands=operands,
             attributes=attributes,
-            result_type=result_type
+            result_type=result_type,
+            outs_operands=outs_ops,
         )
 
     def _extract_operands(self, text: str, result: Optional[str]) -> List[str]:

--- a/ktir_cpu/parser.py
+++ b/ktir_cpu/parser.py
@@ -620,11 +620,8 @@ class KTIRParser(KTIRParserBase):
                 attributes["_result_shape"] = type_info["shape"]
                 attributes["_result_dtype"] = type_info.get("dtype", "f16")
 
-        outs_ops = []
-        if op_type in ("linalg.matmul", "linalg.batch_matmul"):
-            outs_match = re.search(r'\bouts\s*\(([^)]+)\)', rest)
-            if outs_match:
-                outs_ops = find_ssa_names(outs_match.group(1).split(':')[0])
+        from .parser_utils import extract_outs_operands
+        outs_ops = extract_outs_operands(rest)
 
         return Operation(
             result=result,

--- a/ktir_cpu/parser_utils.py
+++ b/ktir_cpu/parser_utils.py
@@ -36,7 +36,12 @@ _OUTS_RE = re.compile(r'\bouts\s*\(([^)]+)\)')
 def extract_outs_operands(op_text: str) -> list[str]:
     """Extract SSA names from the ``outs(...)`` clause of a linalg op text."""
     m = _OUTS_RE.search(op_text)
-    return find_ssa_names(m.group(1).split(':')[0]) if m else []
+    if not m:
+        return []
+    names = []
+    for segment in split_top_level(m.group(1)):
+        names.extend(find_ssa_names(segment.split(':')[0]))
+    return names
 
 
 def parse_multi_result_lhs(lhs_text: str) -> list[str]:

--- a/ktir_cpu/parser_utils.py
+++ b/ktir_cpu/parser_utils.py
@@ -30,6 +30,15 @@ def find_ssa_names(text: str) -> list[str]:
     return _SSA_RE.findall(text)
 
 
+_OUTS_RE = re.compile(r'\bouts\s*\(([^)]+)\)')
+
+
+def extract_outs_operands(op_text: str) -> list[str]:
+    """Extract SSA names from the ``outs(...)`` clause of a linalg op text."""
+    m = _OUTS_RE.search(op_text)
+    return find_ssa_names(m.group(1).split(':')[0]) if m else []
+
+
 def parse_multi_result_lhs(lhs_text: str) -> list[str]:
     """Parse the LHS of a multi-result MLIR assignment.
 

--- a/tests/test_lx_scoping.py
+++ b/tests/test_lx_scoping.py
@@ -1193,3 +1193,280 @@ class TestLastUseMatmulKernel:
         ctx.set_value("%accum_next", _make_tile((384, 512)))
         assert ctx.lx.used == N
 
+
+# ---------------------------------------------------------------------------
+# Fused matmul / batch_matmul: outs = accumulator iter_arg (issue #135)
+# ---------------------------------------------------------------------------
+
+# Fused matmul kernel: linalg.matmul outs(%accum_itr) directly yields the
+# result as %accum_next. No separate arith.addf — the accumulator IS the outs.
+# BM=64, BN=32, BK=16, K=64 (4 iterations).
+# Accumulator = 64*32*2 = 4096 bytes.
+# If the handler creates a new Tile, peak = 3*4096 = 12288 bytes (overcounted).
+# With in-place fix, peak = 1*4096 + loads = 4096 + 2048 + 1024 = 7168 bytes.
+FUSED_MATMUL_MLIR = """
+module {
+  func.func @fused_matmul_test(
+      %a_ptr: index, %b_ptr: index, %c_ptr: index,
+      %K: index, %BM: index, %BN: index, %BK: index
+  ) attributes {grid = [1]} {
+    %pid_m, %pid_n = ktdp.get_compute_tile_id : index, index
+
+    %a_view = ktdp.construct_memory_view %a_ptr, sizes: [64, 64], strides: [64, 1] {
+      coordinate_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 63 >= 0, d1 >= 0, -d1 + 63 >= 0)>,
+      memory_space = #ktdp.spyre_memory_space<HBM>
+    } : memref<64x64xf16>
+
+    %b_view = ktdp.construct_memory_view %b_ptr, sizes: [64, 32], strides: [32, 1] {
+      coordinate_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 63 >= 0, d1 >= 0, -d1 + 31 >= 0)>,
+      memory_space = #ktdp.spyre_memory_space<HBM>
+    } : memref<64x32xf16>
+
+    %c_view = ktdp.construct_memory_view %c_ptr, sizes: [64, 32], strides: [32, 1] {
+      coordinate_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 63 >= 0, d1 >= 0, -d1 + 31 >= 0)>,
+      memory_space = #ktdp.spyre_memory_space<HBM>
+    } : memref<64x32xf16>
+
+    %c0 = arith.constant 0 : index
+    %accum_zero = arith.constant dense<0.0> : tensor<64x32xf16>
+
+    %c = scf.for %off_k = %c0 to %K step %BK iter_args(%accum_itr = %accum_zero) -> (tensor<64x32xf16>) {
+      %a_acc = ktdp.construct_access_tile %a_view[%pid_m, %off_k] {
+        access_tile_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 63 >= 0, d1 >= 0, -d1 + 15 >= 0)>,
+        access_tile_order = affine_map<(d0, d1) -> (d0, d1)>
+      } : memref<64x64xf16> -> !ktdp.access_tile<64x16xindex>
+
+      %b_acc = ktdp.construct_access_tile %b_view[%off_k, %pid_n] {
+        access_tile_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 15 >= 0, d1 >= 0, -d1 + 31 >= 0)>,
+        access_tile_order = affine_map<(d0, d1) -> (d0, d1)>
+      } : memref<64x32xf16> -> !ktdp.access_tile<16x32xindex>
+
+      %a = ktdp.load %a_acc : !ktdp.access_tile<64x16xindex> -> tensor<64x16xf16>
+      %b = ktdp.load %b_acc : !ktdp.access_tile<16x32xindex> -> tensor<16x32xf16>
+
+      %accum_next = linalg.matmul ins(%a, %b : tensor<64x16xf16>, tensor<16x32xf16>)
+                                  outs(%accum_itr : tensor<64x32xf16>) -> tensor<64x32xf16>
+
+      scf.yield %accum_next : tensor<64x32xf16>
+    }
+
+    %c_acc = ktdp.construct_access_tile %c_view[%pid_m, %pid_n] {
+      access_tile_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 63 >= 0, d1 >= 0, -d1 + 31 >= 0)>,
+      access_tile_order = affine_map<(d0, d1) -> (d0, d1)>
+    } : memref<64x32xf16> -> !ktdp.access_tile<64x32xindex>
+
+    ktdp.store %c, %c_acc : tensor<64x32xf16>, !ktdp.access_tile<64x32xindex>
+    return
+  }
+}
+"""
+
+
+
+class TestFusedMatmulLX:
+    """Issue #135: fused matmul outs(%accum_itr) must not overcount LX.
+
+    When the handler returns the same Tile object as outs, alias_dedup sees
+    one refcount key for %accum_itr and %accum_next — LX is charged once.
+
+    Tile sizes (f16 = 2 bytes/elem):
+        accumulator  64×32×2 = 4096 bytes
+        %a           64×16×2 = 2048 bytes
+        %b           16×32×2 = 1024 bytes
+
+    With in-place fix (dedup on): peak = accum + a + b = 7168 bytes.
+    Without fix (3x overcount): peak = 3*4096 + 2048 + 1024 = 15360 bytes.
+
+    LX cap set to 10240 bytes — passes with fix, overflows without.
+    """
+
+    LX_CAP = 10240  # 10 KB — fits if accum charged once, overflows if 3x
+
+    def _run_fused_matmul(self, lx_options):
+        from ktir_cpu.interpreter import KTIRInterpreter
+
+        cap = TestFusedMatmulLX.LX_CAP
+
+        class _Patched(KTIRInterpreter):
+            def _prepare_execution(self, grid_shape):
+                super()._prepare_execution(grid_shape)
+                for core in self.grid_executor.cores:
+                    core.lx.capacity = cap
+                    core.lx_options = lx_options
+
+        BM, BN, BK, K = 64, 32, 16, 64
+        a = np.random.rand(BM, K).astype(np.float16)
+        b = np.random.rand(K, BN).astype(np.float16)
+        c = np.zeros((BM, BN), dtype=np.float16)
+        interp = _Patched()
+        interp.load(FUSED_MATMUL_MLIR)
+        interp.execute_function(
+            "fused_matmul_test", a_ptr=a, b_ptr=b, c_ptr=c,
+            K=K, BM=BM, BN=BN, BK=BK,
+        )
+
+    def test_fused_matmul_fits_with_dedup(self):
+        """With alias_dedup + in-place fix, fused matmul fits in tight LX."""
+        self._run_fused_matmul(_LX_DEDUP)  # must not raise
+
+    def test_fused_matmul_fits_with_full(self):
+        """With full LX tracking + in-place fix, fused matmul fits."""
+        self._run_fused_matmul(_LX_FULL)  # must not raise
+
+
+class TestFusedBatchMatmulLX:
+    """Issue #135: batch_matmul in-place fix — unit-level LX verification.
+
+    Directly exercises the handler's alias behavior through CoreContext
+    without full HBM simulation (3D access tiles are complex to set up).
+
+    Simulates 2 iterations of:
+        %accum_next = linalg.batch_matmul ins(%a, %b) outs(%accum_itr)
+        scf.yield %accum_next
+
+    With in-place fix: %accum_next is the same object as %accum_itr,
+    so alias_dedup charges LX only once for the accumulator.
+    """
+
+    def test_batch_matmul_returns_same_object(self):
+        """Handler returns the same Tile as outs — alias chain preserved."""
+        from ktir_cpu.dialects.linalg_ops import linalg__batch_matmul
+        from ktir_cpu.ir_types import Operation
+
+        ctx = _make_context(lx_options=_LX_DEDUP)
+        a_tile = Tile(np.ones((2, 4, 3), dtype=np.float16), "f16", (2, 4, 3))
+        b_tile = Tile(np.ones((2, 3, 5), dtype=np.float16), "f16", (2, 3, 5))
+        acc_tile = Tile(np.zeros((2, 4, 5), dtype=np.float16), "f16", (2, 4, 5))
+
+        ctx.set_value("%a", a_tile)
+        ctx.set_value("%b", b_tile)
+        ctx.set_value("%acc", acc_tile)
+
+        op = Operation(
+            result="%r", op_type="linalg.batch_matmul",
+            operands=["%a", "%b", "%acc"], attributes={},
+            result_type="tensor<2x4x5xf16>",
+            outs_operands=["%acc"],
+        )
+
+        result = linalg__batch_matmul(op, ctx, None)
+        assert result is acc_tile, "batch_matmul must return same object as outs"
+
+    def test_batch_matmul_lx_not_overcounted(self):
+        """Simulated loop: alias_dedup charges accumulator once, not 3x."""
+        ctx = _make_context(lx_options=_LX_DEDUP)
+
+        # Simulate: %accum_zero bound in parent scope
+        accum = Tile(np.zeros((2, 4, 5), dtype=np.float16), "f16", (2, 4, 5))
+        accum_bytes = accum.size_bytes()  # 2*4*5*2 = 80
+        ctx.set_value("%accum_itr", accum)
+        assert ctx.lx.used == accum_bytes
+
+        # Iteration 1: bind %accum_next to same object (in-place result)
+        ctx.set_value("%accum_next", accum)  # same id → refcount++, no new charge
+        assert ctx.lx.used == accum_bytes, (
+            f"LX overcounted: {ctx.lx.used} != {accum_bytes}"
+        )
+
+        # Rebind iter_arg: %accum_itr = %accum_next (same object)
+        ctx.set_value("%accum_itr", accum)
+        assert ctx.lx.used == accum_bytes
+
+    def test_batch_matmul_correctness(self):
+        """batch_matmul produces correct numerical result."""
+        from ktir_cpu.dialects.linalg_ops import linalg__batch_matmul
+        from ktir_cpu.ir_types import Operation
+
+        ctx = _make_context(lx_options=_LX_DEDUP)
+        a_data = np.ones((2, 4, 3), dtype=np.float16) * 2
+        b_data = np.ones((2, 3, 5), dtype=np.float16) * 3
+        acc_data = np.ones((2, 4, 5), dtype=np.float16)
+
+        ctx.set_value("%a", Tile(a_data, "f16", (2, 4, 3)))
+        ctx.set_value("%b", Tile(b_data, "f16", (2, 3, 5)))
+        acc_tile = Tile(acc_data, "f16", (2, 4, 5))
+        ctx.set_value("%acc", acc_tile)
+
+        op = Operation(
+            result="%r", op_type="linalg.batch_matmul",
+            operands=["%a", "%b", "%acc"], attributes={},
+            result_type="tensor<2x4x5xf16>",
+            outs_operands=["%acc"],
+        )
+
+        result = linalg__batch_matmul(op, ctx, None)
+        # Expected: acc + a @ b = 1 + 2*3*3 = 19 (each element)
+        expected = np.full((2, 4, 5), 19.0, dtype=np.float16)
+        np.testing.assert_array_equal(result.data, expected)
+
+
+class TestOutsStructuralAssertion:
+    """Verify the structural outs-invariant assertion fires on violations."""
+
+    def test_assertion_catches_new_tile(self):
+        """A handler that returns a new Tile instead of mutating outs triggers assert."""
+        from ktir_cpu.interpreter import KTIRInterpreter
+        from ktir_cpu.ir_types import Operation
+        from ktir_cpu.dialects.registry import register, temp_registry
+
+        with temp_registry():
+            @register("test.broken_matmul", latency_category=None)
+            def broken_handler(op, context, env):
+                acc = context.get_value(op.operands[2])
+                if isinstance(acc, Tile):
+                    return Tile(acc.data.copy(), acc.dtype, acc.shape)  # NEW object!
+                return Tile(np.zeros((4, 4), dtype=np.float16), "f16", (4, 4))
+
+            op = Operation(
+                result="%r",
+                op_type="test.broken_matmul",
+                operands=["%a", "%b", "%c"],
+                attributes={},
+                result_type="tensor<4x4xf16>",
+                outs_operands=["%c"],
+            )
+
+            ctx = _make_context(lx_options=_LX_DEDUP)
+            ctx.set_value("%a", _make_tile((4, 4)))
+            ctx.set_value("%b", _make_tile((4, 4)))
+            ctx.set_value("%c", _make_tile((4, 4)))
+
+            interp = KTIRInterpreter()
+            interp.load('module { func.func @dummy() attributes {grid = [1]} { return } }')
+
+            with pytest.raises(AssertionError, match="handler returned new Tile"):
+                interp._execute_op(op, ctx)
+
+    def test_no_assertion_for_correct_handler(self):
+        """A handler that returns the same outs object does not trigger."""
+        from ktir_cpu.interpreter import KTIRInterpreter
+        from ktir_cpu.ir_types import Operation
+        from ktir_cpu.dialects.registry import register, temp_registry
+
+        with temp_registry():
+            @register("test.correct_matmul", latency_category=None)
+            def correct_handler(op, context, env):
+                acc = context.get_value(op.operands[2])
+                if isinstance(acc, Tile):
+                    acc.data += 1.0  # in-place
+                    return acc       # same object
+                return Tile(np.zeros((4, 4), dtype=np.float16), "f16", (4, 4))
+
+            op = Operation(
+                result="%r",
+                op_type="test.correct_matmul",
+                operands=["%a", "%b", "%c"],
+                attributes={},
+                result_type="tensor<4x4xf16>",
+                outs_operands=["%c"],
+            )
+
+            ctx = _make_context(lx_options=_LX_DEDUP)
+            ctx.set_value("%a", _make_tile((4, 4)))
+            ctx.set_value("%b", _make_tile((4, 4)))
+            ctx.set_value("%c", _make_tile((4, 4)))
+
+            interp = KTIRInterpreter()
+            interp.load('module { func.func @dummy() attributes {grid = [1]} { return } }')
+            interp._execute_op(op, ctx)  # must not raise
+

--- a/tests/test_lx_scoping.py
+++ b/tests/test_lx_scoping.py
@@ -1410,7 +1410,7 @@ class TestOutsStructuralAssertion:
         from ktir_cpu.dialects.registry import register, temp_registry
 
         with temp_registry():
-            @register("test.broken_matmul", latency_category=None)
+            @register("linalg.batch_matmul", latency_category=None)
             def broken_handler(op, context, env):
                 acc = context.get_value(op.operands[2])
                 if isinstance(acc, Tile):
@@ -1419,7 +1419,7 @@ class TestOutsStructuralAssertion:
 
             op = Operation(
                 result="%r",
-                op_type="test.broken_matmul",
+                op_type="linalg.batch_matmul",
                 operands=["%a", "%b", "%c"],
                 attributes={},
                 result_type="tensor<4x4xf16>",
@@ -1444,7 +1444,7 @@ class TestOutsStructuralAssertion:
         from ktir_cpu.dialects.registry import register, temp_registry
 
         with temp_registry():
-            @register("test.correct_matmul", latency_category=None)
+            @register("linalg.matmul", latency_category=None)
             def correct_handler(op, context, env):
                 acc = context.get_value(op.operands[2])
                 if isinstance(acc, Tile):
@@ -1454,7 +1454,7 @@ class TestOutsStructuralAssertion:
 
             op = Operation(
                 result="%r",
-                op_type="test.correct_matmul",
+                op_type="linalg.matmul",
                 operands=["%a", "%b", "%c"],
                 attributes={},
                 result_type="tensor<4x4xf16>",

--- a/tests/test_parser_utils.py
+++ b/tests/test_parser_utils.py
@@ -21,7 +21,7 @@ mis-tokenised these by splitting on the ``x`` inside the dtype.
 
 import pytest
 
-from ktir_cpu.parser_utils import parse_tensor_type
+from ktir_cpu.parser_utils import parse_tensor_type, extract_outs_operands
 
 
 # ---------------------------------------------------------------------------
@@ -163,3 +163,25 @@ def test_parse_tensor_type_nested_bracket_dtype(type_str, expected_shape, expect
     """
     info = parse_tensor_type(type_str)
     assert info == {"shape": expected_shape, "dtype": expected_dtype}
+
+
+# ---------------------------------------------------------------------------
+# extract_outs_operands
+# ---------------------------------------------------------------------------
+
+def test_extract_outs_operands_single():
+    assert extract_outs_operands(
+        "linalg.matmul ins(%a, %b : tensor<4x4xf16>, tensor<4x4xf16>) "
+        "outs(%c : tensor<4x4xf16>) -> tensor<4x4xf16>"
+    ) == ["%c"]
+
+
+def test_extract_outs_operands_multi():
+    assert extract_outs_operands(
+        "linalg.generic ins(%a : tensor<4xf16>) "
+        "outs(%c : tensor<4xf16>, %d : tensor<4xf16>)"
+    ) == ["%c", "%d"]
+
+
+def test_extract_outs_operands_none():
+    assert extract_outs_operands("arith.addf %x, %y : f16") == []


### PR DESCRIPTION
## Background

The `linalg.matmul` and `linalg.batch_matmul` handlers create a **new `Tile` object** for the accumulator result. This breaks the alias chain between `%accum_itr` and `%accum_next` in `scf.for` iter_arg loops. Since `alias_dedup` (PR #118) tracks allocations by `id(Tile)`, each new object receives a separate LX charge — causing 3× overcount of the accumulator buffer.

**Impact:** Compute-bound matmul configs (AI > 384) that should fit in 2 MB LX overflow because peak is `3×BM×BN×2` instead of `1×BM×BN×2`.

Example: BM=640, BN=1024, BK=32 (AI=393.8):
- Before fix: peak = 3×1280 + 104 = 3944 KB → **overflows 2 MB**
- After fix: peak = 1×1280 + 104 = 1384 KB → **fits easily**

## Strategy

Two complementary measures, following @fabianlim's [structural check proposal](https://github.com/torch-spyre/ktir-cpu/issues/135):

**1. Fix the handlers (immediate cure):**
Both `linalg.matmul` and `linalg.batch_matmul` now accumulate in-place (`acc.data += result.data; return acc`), preserving Python object identity. On hardware, the `outs` buffer is a physical address written in-place — the interpreter must mirror this.

**2. Structural assertion (systemic safeguard):**
Rather than relying on developer discipline for every future outs-bearing handler, we assert the invariant centrally in `_execute_op`: any leaf op (no regions) with `outs_operands` must return the **same Tile object** as its outs buffer. This catches violations at the point of origin — not downstream in LX tracking anomalies.

To support the assertion, a new `outs_operands` field is added to the `Operation` dataclass. It is populated by both the MLIR frontend parser (via a new `_adapt_linalg_matmul_like` adapter) and the fallback regex parser. Currently scoped to ops where `outs` is semantically an in-place accumulator (matmul, batch_matmul); ops where `outs` is just a destination shape (linalg.add, linalg.fill, linalg.generic) are excluded.

## How the three LX mechanisms compose

| Mechanism | What it does | LX saved |
|-----------|-------------|----------|
| PR #118 `alias_dedup` | Same object across SSA names → single charge | 1×BM×BN×2 |
| PR #134 `consume_last_use` | Free `%a`, `%b` after matmul fetches them | (BM×BK + BK×BN)×2 |
| **This fix** (in-place + assertion) | `%accum_next` = same object as `%accum_itr` | 1–2×BM×BN×2 |

## Changes

| File | Change |
|------|--------|
| `ktir_cpu/dialects/linalg_ops.py` | In-place accumulation for both `matmul` and `batch_matmul` |
| `ktir_cpu/ir_types.py` | `outs_operands: List[str]` field on `Operation` |
| `ktir_cpu/mlir_frontend/parser.py` | `_adapt_linalg_matmul_like` adapter + `adapt_op` extracts `_outs_operands` |
| `ktir_cpu/parser.py` | Fallback parser populates `outs_operands` for matmul/batch_matmul |
| `ktir_cpu/interpreter.py` | Structural assertion in `_execute_op` |
| `tests/test_lx_scoping.py` | 7 new tests: end-to-end fused matmul LX, unit-level batch_matmul, assertion verification |

## Verification sweep

```
  BM     BN     BK      AI   accum     a+b     DEDUP      FULL   bound
-------------------------------------------------------------------------
  640   1024     32   393.8   1280 KB    104 KB        OK        OK   compute
  640   1024     64   393.8   1280 KB    208 KB        OK        OK   compute
  640   1024    128   393.8   1280 KB    416 KB        OK        OK   compute
  768   1024     32   438.9   1536 KB    112 KB        OK        OK   compute
  768   1024     64   438.9   1536 KB    224 KB        OK        OK   compute
 1024    768     32   438.9   1536 KB    112 KB        OK        OK   compute
 1024   1024     32   512.0   2048 KB    128 KB  OVERFLOW  OVERFLOW   compute (legitimate — accum = full LX)
```

## Test plan

- [x] Full test suite: `uv run pytest tests/ -q` → 1029 passed, 0 failures
- [x] Issue verification script (BM=640, BN=1024, BK=32): both `_LX_DEDUP` and `_LX_FULL` pass
- [x] Broader sweep: all configs with accum < 2 MB fit; 1024×1024 legitimately overflows
- [x] Structural assertion fires on broken handler (test confirms `AssertionError` with identifying message)
- [x] Correct handler does not trigger assertion

Closes #135