### PR TITLE
Fixes #87 — Frontend parser support for distributed memory views

### DIFF
--- a/ktir_cpu/dialects/arith_ops.py
+++ b/ktir_cpu/dialects/arith_ops.py
@@ -314,7 +314,7 @@ def arith__select(op, context, env):
 
 @register_parser("arith.constant")
 def parse_arith_constant(op_text, parse_ctx):
-    from ..parser_utils import parse_numeric, parse_tensor_type, parse_dense_payload
+    from ..parser_utils import parse_numeric, parse_tensor_or_memref_type, parse_dense_payload
 
     result_match = re.match(r'arith\.constant\s*(.*)', op_text)
     if not result_match:
@@ -357,7 +357,7 @@ def parse_arith_constant(op_text, parse_ctx):
         inner = braced_match.group(1).strip()
         result_type = braced_match.group(2).strip()
 
-        _type_info = parse_tensor_type(result_type)
+        _type_info = parse_tensor_or_memref_type(result_type)
         elem_dtype = _type_info.get("dtype") if _type_info else result_type
 
         dense_match = re.match(r'dense<([^>]+)>', inner)
@@ -384,7 +384,7 @@ def parse_arith_constant(op_text, parse_ctx):
         simple_match = re.match(r'(-?(?:0[xX][0-9a-fA-F]+|[\d.eE+\-]+))\s*:\s*(.+)$', rest)
         if dense_match:
             result_type = dense_match.group(2).strip()
-            type_info = parse_tensor_type(result_type)
+            type_info = parse_tensor_or_memref_type(result_type)
             elem_dtype = type_info.get("dtype") if type_info else None
             _set_dense(dense_match.group(1), elem_dtype)
             _set_tensor_attrs(type_info, result_type)
@@ -399,7 +399,7 @@ def parse_arith_constant(op_text, parse_ctx):
             type_only_match = re.match(r':\s*(.+)$', rest)
             if type_only_match:
                 result_type = type_only_match.group(1).strip()
-                type_info = parse_tensor_type(result_type) if result_type and "tensor<" in result_type else None
+                type_info = parse_tensor_or_memref_type(result_type) if result_type and "tensor<" in result_type else None
                 _set_tensor_attrs(type_info, result_type or "")
             attributes.setdefault("value", 0)
 

--- a/ktir_cpu/dialects/ktdp_ops.py
+++ b/ktir_cpu/dialects/ktdp_ops.py
@@ -34,7 +34,7 @@ from ..ops.comm_ops import CommPlan, RingReduceBackend
 from ..ops.grid_ops import GridOps
 from ..ops.memory_ops import MemoryOps
 from ..parser_ast import enumerate_membership_keys, parse_affine_map, parse_affine_set
-from ..parser_utils import _extract_bracket_content, extract_named_attr, find_ssa_names, parse_attr_block, parse_tensor_type, split_top_level
+from ..parser_utils import _extract_bracket_content, extract_named_attr, find_ssa_names, parse_attr_block, parse_multi_result_lhs, parse_tensor_or_memref_type, split_top_level
 from .registry import ParseContext, register, register_parser
 
 
@@ -338,15 +338,8 @@ def parse_construct_memory_view(op_text, parse_ctx: ParseContext):
     memref_match = re.search(r'(?:}\s*)?:\s*(?:index\s*->\s*)?memref<([^>]+)>', op_text)
     if not memref_match:
         raise ValueError("construct_memory_view: could not parse dtype from memref<> type")
-    parts = memref_match.group(1).split('x')
-    dtype = parts[-1]
-    if len(parts) <= 1:
-        raise ValueError(
-            f"construct_memory_view: memref<{memref_match.group(1)}> has no dimensions"
-        )
-    # '?' in the memref type means the dimension is dynamic (value only known at
-    # runtime).  We keep it as None until we can substitute the SSA size below.
-    memref_dims = [None if p == "?" else int(p) for p in parts[:-1]]
+    memref_dims, dtype = parse_memref_dims(memref_match.group(1))
+    memref_dims = list(memref_dims)
     if sizes is not None:
         if len(sizes) != len(memref_dims):
             raise ValueError(
@@ -458,14 +451,7 @@ def parse_construct_distributed_memory_view(op_text, parse_ctx: ParseContext):
         raise ValueError(
             "construct_distributed_memory_view: could not parse result memref<> type"
         )
-    parts = memref_match.group(1).split('x')
-    if len(parts) <= 1:
-        raise ValueError(
-            f"construct_distributed_memory_view: memref<{memref_match.group(1)}> "
-            "has no dimensions"
-        )
-    dtype = parts[-1]
-    shape = tuple(int(p) for p in parts[:-1])
+    shape, dtype = parse_memref_dims(memref_match.group(1))
 
     return Operation(
         result=None,

--- a/ktir_cpu/dialects/ktdp_ops.py
+++ b/ktir_cpu/dialects/ktdp_ops.py
@@ -338,8 +338,13 @@ def parse_construct_memory_view(op_text, parse_ctx: ParseContext):
     memref_match = re.search(r'(?:}\s*)?:\s*(?:index\s*->\s*)?memref<([^>]+)>', op_text)
     if not memref_match:
         raise ValueError("construct_memory_view: could not parse dtype from memref<> type")
-    memref_dims, dtype = parse_memref_dims(memref_match.group(1))
-    memref_dims = list(memref_dims)
+    info = parse_tensor_or_memref_type(memref_match.group(1), keep_dynamic_dims=True)
+    if not info:
+        raise ValueError(
+            f"construct_memory_view: memref<{memref_match.group(1)}> has no dimensions"
+        )
+    dtype = info["dtype"]
+    memref_dims = list(info["shape"])
     if sizes is not None:
         if len(sizes) != len(memref_dims):
             raise ValueError(
@@ -451,7 +456,14 @@ def parse_construct_distributed_memory_view(op_text, parse_ctx: ParseContext):
         raise ValueError(
             "construct_distributed_memory_view: could not parse result memref<> type"
         )
-    shape, dtype = parse_memref_dims(memref_match.group(1))
+    info = parse_tensor_or_memref_type(memref_match.group(1))
+    if not info:
+        raise ValueError(
+            f"construct_distributed_memory_view: memref<{memref_match.group(1)}> "
+            "has no dimensions"
+        )
+    shape = info["shape"]
+    dtype = info["dtype"]
 
     return Operation(
         result=None,
@@ -1171,7 +1183,7 @@ def parse_inter_tile_reduce(op_text, parse_ctx: ParseContext):
     result_type = arrow_match.group(1).strip() if arrow_match else None
     result_shape = None
     if result_type is not None:
-        parsed = parse_tensor_type(result_type)
+        parsed = parse_tensor_or_memref_type(result_type)
         if parsed is not None:
             result_shape = parsed["shape"]
 

--- a/ktir_cpu/dialects/tensor_ops.py
+++ b/ktir_cpu/dialects/tensor_ops.py
@@ -22,7 +22,7 @@ import numpy as np
 from ..grid import CoreContext
 from ..dtypes import to_np_dtype
 from ..ir_types import Operation, Tile
-from ..parser_utils import find_ssa_names
+from ..parser_utils import find_ssa_names, parse_memref_dims
 from .registry import register, register_parser
 
 
@@ -449,17 +449,12 @@ def _parse_reshape_op(op_text, op_name):
     target_dtype = "f16"
     into_match = re.search(r'into\s+(?:tile|tensor)<([^>]+)>', op_text)
     if into_match:
-        inner = into_match.group(1)
-        parts = inner.split('x')
-        shape_parts = []
-        for p in parts[:-1]:
-            try:
-                shape_parts.append(int(p))
-            except ValueError:
-                pass
-        if shape_parts:
-            target_shape = tuple(shape_parts)
-            target_dtype = parts[-1]
+        try:
+            dims, dtype = parse_memref_dims(into_match.group(1))
+            target_shape = tuple(d for d in dims if d is not None)
+            target_dtype = dtype
+        except ValueError:
+            pass
 
     attributes = {}
     if target_shape:

--- a/ktir_cpu/dialects/tensor_ops.py
+++ b/ktir_cpu/dialects/tensor_ops.py
@@ -22,7 +22,7 @@ import numpy as np
 from ..grid import CoreContext
 from ..dtypes import to_np_dtype
 from ..ir_types import Operation, Tile
-from ..parser_utils import find_ssa_names, parse_memref_dims
+from ..parser_utils import find_ssa_names, parse_tensor_or_memref_type
 from .registry import register, register_parser
 
 
@@ -357,12 +357,12 @@ def tensor__generate(op, context, env):
 @register_parser("tensor.empty")
 def parse_tensor_empty(op_text, parse_ctx):
     """Parse tensor.empty() : tensor<1x1024xf16>"""
-    from ..parser_utils import parse_tensor_type
+    from ..parser_utils import parse_tensor_or_memref_type
     result_match = re.match(r'tensor\.empty\s*\(\s*\)\s*:\s*(.+)', op_text)
     if not result_match:
         return None
     type_str = result_match.group(1).strip()
-    type_info = parse_tensor_type(type_str)
+    type_info = parse_tensor_or_memref_type(type_str)
     attributes = {}
     if type_info:
         attributes["shape"] = type_info["shape"]
@@ -378,7 +378,7 @@ def parse_tensor_empty(op_text, parse_ctx):
 
 @register_parser("tensor.splat")
 def parse_tensor_splat(op_text, parse_ctx):
-    from ..parser_utils import parse_tensor_type
+    from ..parser_utils import parse_tensor_or_memref_type
     result_match = re.match(r'tensor\.splat\s+(%\w+)\s*(?::\s*(.+))?', op_text)
     if not result_match:
         return None
@@ -395,7 +395,7 @@ def parse_tensor_splat(op_text, parse_ctx):
 
     attributes = {}
 
-    type_info = parse_tensor_type(result_type)
+    type_info = parse_tensor_or_memref_type(result_type)
     if type_info:
         attributes["shape"] = type_info["shape"]
         attributes["dtype"] = type_info.get("dtype", "f16")
@@ -449,12 +449,10 @@ def _parse_reshape_op(op_text, op_name):
     target_dtype = "f16"
     into_match = re.search(r'into\s+(?:tile|tensor)<([^>]+)>', op_text)
     if into_match:
-        try:
-            dims, dtype = parse_memref_dims(into_match.group(1))
-            target_shape = tuple(d for d in dims if d is not None)
-            target_dtype = dtype
-        except ValueError:
-            pass
+        info = parse_tensor_or_memref_type(into_match.group(1))
+        if info:
+            target_shape = tuple(d for d in info["shape"] if d is not None)
+            target_dtype = info["dtype"]
 
     attributes = {}
     if target_shape:
@@ -520,7 +518,7 @@ def parse_tensor_generate(op_text, parse_ctx):
       - result_name: %mask
       - shape/dtype from the trailing `: tensor<16x16xf16>` type annotation
     """
-    from ..parser_utils import parse_tensor_type
+    from ..parser_utils import parse_tensor_or_memref_type
 
     # Match: tensor.generate ...
     result_match = re.match(r'tensor\.generate', op_text)
@@ -534,7 +532,7 @@ def parse_tensor_generate(op_text, parse_ctx):
     type_match = re.search(r':\s*(tensor<[^>]+>)\s*$', op_text)
     if not type_match:
         raise ValueError(f"tensor.generate: missing result type in '{op_text}'")
-    type_info = parse_tensor_type(type_match.group(1))
+    type_info = parse_tensor_or_memref_type(type_match.group(1))
     if type_info:
         attributes["shape"] = type_info["shape"]
         attributes["dtype"] = type_info.get("dtype", "f16")
@@ -566,7 +564,7 @@ def parse_tensor_reshape(op_text, parse_ctx):
     from the trailing result-type annotation (after `->`), since that is
     always statically pinned, while the shape operand may be runtime.
     """
-    from ..parser_utils import parse_tensor_type
+    from ..parser_utils import parse_tensor_or_memref_type
     m = re.match(
         r'tensor\.reshape\s+(%\w+)\s*\(\s*(%\w+)\s*\)', op_text
     )
@@ -578,7 +576,7 @@ def parse_tensor_reshape(op_text, parse_ctx):
     if not arrow:
         raise ValueError(f"tensor.reshape: missing result type in '{op_text}'")
     result_type = arrow.group(1)
-    info = parse_tensor_type(result_type)
+    info = parse_tensor_or_memref_type(result_type)
     if info is None:
         raise ValueError(
             f"tensor.reshape: cannot parse result type {result_type!r} in '{op_text}'"
@@ -599,7 +597,7 @@ def parse_tensor_reshape(op_text, parse_ctx):
 @register_parser("tensor.from_elements")
 def parse_tensor_from_elements(op_text, parse_ctx):
     """Parse `%shape = tensor.from_elements %d0, %d1, ... : tensor<NxT>`."""
-    from ..parser_utils import parse_tensor_type
+    from ..parser_utils import parse_tensor_or_memref_type
     m = re.match(
         r'tensor\.from_elements\s+(.*?)\s*:\s*(tensor<[^>]+>)', op_text
     )
@@ -609,7 +607,7 @@ def parse_tensor_from_elements(op_text, parse_ctx):
     type_str = m.group(2)
     operands = find_ssa_names(operand_text)
 
-    info = parse_tensor_type(type_str)
+    info = parse_tensor_or_memref_type(type_str)
     if info is None:
         raise ValueError(
             f"tensor.from_elements: cannot parse result type {type_str!r} in '{op_text}'"
@@ -665,7 +663,7 @@ def parse_tensor_extract_slice(op_text, parse_ctx):
     Supports mixed static/dynamic entries: ``%off`` tokens become _KDYNAMIC
     in the static array and are appended to operands after the source.
     """
-    from ..parser_utils import parse_tensor_type
+    from ..parser_utils import parse_tensor_or_memref_type
     m = re.match(r'tensor\.extract_slice\s+(%\w+)', op_text)
     if not m:
         return None
@@ -677,7 +675,7 @@ def parse_tensor_extract_slice(op_text, parse_ctx):
     if not result_type_m:
         raise ValueError(f"tensor.extract_slice: missing result type in {op_text!r}")
     result_type = result_type_m.group(1)
-    info = parse_tensor_type(result_type)
+    info = parse_tensor_or_memref_type(result_type)
     if info is None:
         raise ValueError(f"tensor.extract_slice: cannot parse result type {result_type!r}")
 
@@ -703,7 +701,7 @@ def parse_tensor_insert_slice(op_text, parse_ctx):
     Supports mixed static/dynamic entries: ``%off`` tokens become _KDYNAMIC
     in the static array and are appended to operands after source and dest.
     """
-    from ..parser_utils import parse_tensor_type
+    from ..parser_utils import parse_tensor_or_memref_type
     m = re.match(
         r'tensor\.insert_slice\s+(%\w+)\s+into\s+(%\w+)', op_text
     )
@@ -718,7 +716,7 @@ def parse_tensor_insert_slice(op_text, parse_ctx):
     if not result_type_m:
         raise ValueError(f"tensor.insert_slice: missing result type in {op_text!r}")
     result_type = result_type_m.group(1)
-    info = parse_tensor_type(result_type)
+    info = parse_tensor_or_memref_type(result_type)
     if info is None:
         raise ValueError(f"tensor.insert_slice: cannot parse result type {result_type!r}")
 

--- a/ktir_cpu/mlir_frontend/parser.py
+++ b/ktir_cpu/mlir_frontend/parser.py
@@ -334,18 +334,14 @@ def _adapt_construct_memory_view(mlir_op, attributes, result_type, operands):
 @MLIRTypeAdapter.install("ktdp.construct_distributed_memory_view")
 def _adapt_construct_distributed_memory_view(mlir_op, attributes, result_type, operands):
     """Extract shape and dtype from the result memref type."""
-    m = re.search(r'memref<([^>]+)>', result_type)
+    from ..parser_utils import parse_memref_dims
+
+    m = re.search(r'memref<([^>]+)>\s*$', result_type)
     if not m:
         raise ValueError(
             f"ktdp.construct_distributed_memory_view: cannot parse result type {result_type!r}"
         )
-    parts = m.group(1).split('x')
-    if len(parts) <= 1:
-        raise ValueError(
-            f"ktdp.construct_distributed_memory_view: memref<{m.group(1)}> has no dimensions"
-        )
-    attributes["dtype"] = parts[-1]
-    attributes["shape"] = tuple(int(p) for p in parts[:-1])
+    attributes["shape"], attributes["dtype"] = parse_memref_dims(m.group(1))
 
 
 @MLIRTypeAdapter.install("ktdp.construct_indirect_access_tile")

--- a/ktir_cpu/mlir_frontend/parser.py
+++ b/ktir_cpu/mlir_frontend/parser.py
@@ -456,8 +456,8 @@ def _adapt_linalg_reduce(mlir_op, attributes, result_type, operands):
 @MLIRTypeAdapter.install("tensor.empty")
 def _adapt_tensor_empty(mlir_op, attributes, result_type, operands):
     """Synthesize shape/dtype from result type."""
-    from ..parser_utils import parse_tensor_type
-    info = parse_tensor_type(result_type)
+    from ..parser_utils import parse_tensor_or_memref_type
+    info = parse_tensor_or_memref_type(result_type)
     if info is None:
         raise ValueError(f"tensor.empty: cannot parse result type {result_type!r}")
     attributes["shape"] = info["shape"]
@@ -467,8 +467,8 @@ def _adapt_tensor_empty(mlir_op, attributes, result_type, operands):
 @MLIRTypeAdapter.install("tensor.expand_shape")
 def _adapt_tensor_expand_shape(mlir_op, attributes, result_type, operands):
     """Synthesize target_shape/dtype from result type."""
-    from ..parser_utils import parse_tensor_type
-    info = parse_tensor_type(result_type)
+    from ..parser_utils import parse_tensor_or_memref_type
+    info = parse_tensor_or_memref_type(result_type)
     if info is None:
         raise ValueError(f"tensor.expand_shape: cannot parse result type {result_type!r}")
     attributes["target_shape"] = info["shape"]
@@ -478,8 +478,8 @@ def _adapt_tensor_expand_shape(mlir_op, attributes, result_type, operands):
 @MLIRTypeAdapter.install("tensor.collapse_shape")
 def _adapt_tensor_collapse_shape(mlir_op, attributes, result_type, operands):
     """Synthesize target_shape/dtype from result type."""
-    from ..parser_utils import parse_tensor_type
-    info = parse_tensor_type(result_type)
+    from ..parser_utils import parse_tensor_or_memref_type
+    info = parse_tensor_or_memref_type(result_type)
     if info is None:
         raise ValueError(f"tensor.collapse_shape: cannot parse result type {result_type!r}")
     attributes["target_shape"] = info["shape"]
@@ -494,8 +494,8 @@ def _adapt_tensor_reshape(mlir_op, attributes, result_type, operands):
     well-formed; only the result type is consulted, since it always pins
     the target shape statically.
     """
-    from ..parser_utils import parse_tensor_type
-    info = parse_tensor_type(result_type)
+    from ..parser_utils import parse_tensor_or_memref_type
+    info = parse_tensor_or_memref_type(result_type)
     if info is None:
         raise ValueError(f"tensor.reshape: cannot parse result type {result_type!r}")
     attributes["target_shape"] = info["shape"]
@@ -505,8 +505,8 @@ def _adapt_tensor_reshape(mlir_op, attributes, result_type, operands):
 @MLIRTypeAdapter.install("tensor.from_elements")
 def _adapt_tensor_from_elements(mlir_op, attributes, result_type, operands):
     """Synthesize shape/dtype from result type — operands carry the values."""
-    from ..parser_utils import parse_tensor_type
-    info = parse_tensor_type(result_type)
+    from ..parser_utils import parse_tensor_or_memref_type
+    info = parse_tensor_or_memref_type(result_type)
     if info is None:
         raise ValueError(f"tensor.from_elements: cannot parse result type {result_type!r}")
     attributes["shape"] = info["shape"]
@@ -516,8 +516,8 @@ def _adapt_tensor_from_elements(mlir_op, attributes, result_type, operands):
 @MLIRTypeAdapter.install("tensor.splat")
 def _adapt_tensor_splat(mlir_op, attributes, result_type, operands):
     """Synthesize shape/dtype from result type."""
-    from ..parser_utils import parse_tensor_type
-    info = parse_tensor_type(result_type)
+    from ..parser_utils import parse_tensor_or_memref_type
+    info = parse_tensor_or_memref_type(result_type)
     if info is None:
         raise ValueError(f"tensor.splat: cannot parse result type {result_type!r}")
     attributes["shape"] = info["shape"]
@@ -554,8 +554,8 @@ def _adapt_arith_constant(mlir_op, attributes, result_type, operands):
     else:
         raise TypeError(f"arith.constant: unhandled value attr type {type(val_attr)}")
     if result_type and "tensor<" in result_type:
-        from ..parser_utils import parse_tensor_type
-        info = parse_tensor_type(result_type)
+        from ..parser_utils import parse_tensor_or_memref_type
+        info = parse_tensor_or_memref_type(result_type)
         attributes["shape"] = info["shape"]
         attributes["dtype"] = info["dtype"]
         attributes["is_tensor"] = True
@@ -661,8 +661,8 @@ def _adapt_arith_cmpf(mlir_op, attributes, result_type, operands):
 @MLIRTypeAdapter.install("tensor.generate")
 def _adapt_tensor_generate(mlir_op, attributes, result_type, operands):
     """Synthesize shape/dtype from result type."""
-    from ..parser_utils import parse_tensor_type
-    info = parse_tensor_type(result_type)
+    from ..parser_utils import parse_tensor_or_memref_type
+    info = parse_tensor_or_memref_type(result_type)
     if info is None:
         raise ValueError(f"tensor.generate: cannot parse result type {result_type!r}")
     attributes["shape"] = info["shape"]
@@ -675,8 +675,8 @@ _DYNAMIC_SIZE = -(1 << 63)  # ShapedType::kDynamic in MLIR
 @MLIRTypeAdapter.install("tensor.extract_slice")
 def _adapt_tensor_extract_slice(mlir_op, attributes, result_type, operands):
     """Extract static_offsets/sizes/strides and result shape from the op."""
-    from ..parser_utils import parse_tensor_type
-    info = parse_tensor_type(result_type)
+    from ..parser_utils import parse_tensor_or_memref_type
+    info = parse_tensor_or_memref_type(result_type)
     if info is None:
         raise ValueError(f"tensor.extract_slice: cannot parse result type {result_type!r}")
     attributes["result_shape"] = info["shape"]
@@ -689,8 +689,8 @@ def _adapt_tensor_extract_slice(mlir_op, attributes, result_type, operands):
 @MLIRTypeAdapter.install("tensor.insert_slice")
 def _adapt_tensor_insert_slice(mlir_op, attributes, result_type, operands):
     """Extract static_offsets/sizes/strides and result shape from the op."""
-    from ..parser_utils import parse_tensor_type
-    info = parse_tensor_type(result_type)
+    from ..parser_utils import parse_tensor_or_memref_type
+    info = parse_tensor_or_memref_type(result_type)
     if info is None:
         raise ValueError(f"tensor.insert_slice: cannot parse result type {result_type!r}")
     attributes["result_shape"] = info["shape"]

--- a/ktir_cpu/mlir_frontend/parser.py
+++ b/ktir_cpu/mlir_frontend/parser.py
@@ -311,20 +311,41 @@ def _adapt_construct_memory_view(mlir_op, attributes, result_type, operands):
     if not m:
         raise ValueError(f"ktdp.construct_memory_view: cannot parse dtype from {result_type!r}")
     attributes["dtype"] = m.group(1)
-    # str(memory_space attr) → "#ktdp.spyre_memory_space<HBM>"
-    ms = re.search(r'#ktdp\.spyre_memory_space<(\w+)>',
-                   str(mlir_op.attributes["memory_space"]))
+    # str(memory_space attr) -> "#ktdp.spyre_memory_space<HBM>" or "<LX, core = 0>"
+    ms = re.search(
+        r'#ktdp\.spyre_memory_space<\s*(\w+)(?:\s*,\s*core\s*=\s*(\d+))?\s*>',
+        str(mlir_op.attributes["memory_space"]),
+    )
     if not ms:
         raise ValueError(
             f"ktdp.construct_memory_view: cannot parse memory_space from "
             f"{mlir_op.attributes['memory_space']!r}"
         )
     attributes["memory_space"] = ms.group(1)
+    if ms.group(2) is not None:
+        attributes["lx_core_id"] = int(ms.group(2))
     # str(coordinate_set attr) → "affine_set<(d0) : ...>"
     if "coordinate_set" in mlir_op.attributes:
         attributes["coordinate_set"] = parse_affine_set(
             str(mlir_op.attributes["coordinate_set"])
         )
+
+
+@MLIRTypeAdapter.install("ktdp.construct_distributed_memory_view")
+def _adapt_construct_distributed_memory_view(mlir_op, attributes, result_type, operands):
+    """Extract shape and dtype from the result memref type."""
+    m = re.search(r'memref<([^>]+)>', result_type)
+    if not m:
+        raise ValueError(
+            f"ktdp.construct_distributed_memory_view: cannot parse result type {result_type!r}"
+        )
+    parts = m.group(1).split('x')
+    if len(parts) <= 1:
+        raise ValueError(
+            f"ktdp.construct_distributed_memory_view: memref<{m.group(1)}> has no dimensions"
+        )
+    attributes["dtype"] = parts[-1]
+    attributes["shape"] = tuple(int(p) for p in parts[:-1])
 
 
 @MLIRTypeAdapter.install("ktdp.construct_indirect_access_tile")

--- a/ktir_cpu/parser.py
+++ b/ktir_cpu/parser.py
@@ -25,7 +25,7 @@ from abc import ABC, abstractmethod
 from typing import Dict, List, Optional, Tuple
 from .ir_types import Operation, IRFunction, IRModule
 from .dialects import dispatch_parser, make_parse_context, ParseContext
-from .parser_utils import parse_attr_block, parse_tensor_type, parse_numeric
+from .parser_utils import parse_attr_block, parse_tensor_or_memref_type, parse_numeric
 from .parser_utils import find_ssa_names, parse_multi_result_lhs
 
 
@@ -631,7 +631,7 @@ class KTIRParser(KTIRParserBase):
         # For operations that have result type info, extract shape/dtype
         # and put them in attributes for the interpreter.
         if result_type:
-            type_info = parse_tensor_type(result_type)
+            type_info = parse_tensor_or_memref_type(result_type)
             if type_info and "shape" not in attributes:
                 attributes["_result_shape"] = type_info["shape"]
                 attributes["_result_dtype"] = type_info.get("dtype", "f16")

--- a/ktir_cpu/parser_utils.py
+++ b/ktir_cpu/parser_utils.py
@@ -135,6 +135,33 @@ def parse_tensor_type(type_str: str) -> Optional[Dict]:
         return None
     return {"shape": tuple(dims), "dtype": dtype}
 
+
+def parse_memref_dims(inner: str):
+    """Parse the inner content of memref<...> or similar into (dims, dtype).
+
+    Handles dtypes containing 'x' (e.g. 'index') by matching dim tokens
+    from the left. Dynamic dims ('?') are returned as None.
+
+    Args:
+        inner: The string inside angle brackets, e.g. "128x32xindex"
+
+    Returns:
+        (dims, dtype) where dims is a tuple of int|None and dtype is a string.
+
+    Raises:
+        ValueError: if no dimension tokens are found.
+    """
+    prefix = re.match(r'^((?:\d+\s*x\s*|[?]\s*x\s*)+)', inner)
+    if not prefix:
+        raise ValueError(f"no dimensions found in '{inner}'")
+    dims = tuple(
+        None if d == '?' else int(d)
+        for d in re.findall(r'(\d+|[?])\s*x', prefix.group(1))
+    )
+    dtype = inner[prefix.end():].split(',')[0].strip()
+    return dims, dtype
+
+
 def parse_numeric(s: str, dtype: Optional[str] = None) -> Any:
     """Parse a numeric string to a Python int or float.
 

--- a/ktir_cpu/parser_utils.py
+++ b/ktir_cpu/parser_utils.py
@@ -102,38 +102,39 @@ def parse_multi_result_lhs(lhs_text: str) -> list[str]:
     return names
 
 
-def parse_tensor_type(type_str: str) -> Optional[Dict]:
-    """Parse a tensor type string, returning shape and dtype if it matches.
+def parse_tensor_or_memref_type(type_str: str, *, keep_dynamic_dims=False) -> Optional[Dict]:
+    """Parse a tensor/memref type or bare dims string into shape and dtype.
+
+    Accepts:
+      - ``"tensor<128x32xf16>"``
+      - ``"memref<128x32xf16, #mem_space>"``
+      - ``"128x32xf16"``  (bare inner content)
 
     Args:
-        type_str: Type string (e.g., "tensor<256xf16>")
+        keep_dynamic_dims: If True, dynamic dims (``?``) are kept as None
+            in the shape tuple. If False (default), they are dropped.
 
     Returns:
-        {"shape": tuple, "dtype": str} if tensor type, else None
-
-    Walks the leading dim prefix by matching digit-tokens followed by 'x',
-    taking the remainder as dtype. Handles dtypes containing 'x' (e.g.
-    ``index``). Dynamic dims (``?``) are silently dropped, matching prior
-    behaviour.
+        {"shape": tuple, "dtype": str} or None on failure.
     """
-    m = re.match(r'tensor<([^>]+)>', type_str)
-    if not m:
-        return None
-    inner = m.group(1).strip()
-    # Match all ``NNN x`` dim tokens from the left. The dtype cannot start
-    # with a digit followed by 'x', so the pattern terminates at the right
-    # boundary even when the dtype itself contains 'x' (e.g. ``index``).
-    # Dynamic dims (``?``) are skipped, matching prior behaviour.
+    m = re.match(r'(?:tensor|memref)<([^>]+)>', type_str)
+    inner = m.group(1).strip() if m else type_str.strip()
     prefix = re.match(r'^((?:\d+\s*x\s*|[?]\s*x\s*)+)', inner)
     if not prefix:
         return None
-    dims = [int(d) for d in re.findall(r'(\d+)\s*x', prefix.group(1))]
+    if keep_dynamic_dims:
+        dims = tuple(
+            None if d == '?' else int(d)
+            for d in re.findall(r'(\d+|[?])\s*x', prefix.group(1))
+        )
+    else:
+        dims = tuple(int(d) for d in re.findall(r'(\d+)\s*x', prefix.group(1)))
     if not dims:
         return None
     dtype = inner[prefix.end():].split(',')[0].strip()
     if not dtype:
         return None
-    return {"shape": tuple(dims), "dtype": dtype}
+    return {"shape": dims, "dtype": dtype}
 
 
 def parse_memref_dims(inner: str):

--- a/tests/mlir_frontend/test_distributed_view_adapt.py
+++ b/tests/mlir_frontend/test_distributed_view_adapt.py
@@ -1,0 +1,46 @@
+"""Frontend adapter test for ktdp.construct_distributed_memory_view.
+
+Mirrors tests/test_distributed_view.py::test_distributed_view_copy_rfc but
+drives parsing through MLIRFrontendParser instead of the regex parser.
+"""
+
+import numpy as np
+import pytest
+
+from ktir_cpu import KTIRInterpreter
+from ktir_cpu.mlir_frontend.parser import MLIRFrontendParser
+
+import sys, os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from test_distributed_view import _write_strided
+from conftest import get_test_params
+
+
+@pytest.mark.parametrize("path,func_name,entry", get_test_params("distributed_view_copy"))
+def test_distributed_view_copy_rfc_frontend(path, func_name, entry):
+    """construct_distributed_memory_view via MLIRFrontendParser - RFC §C.3."""
+    interp = KTIRInterpreter(parser=MLIRFrontendParser())
+    interp.load(path)
+    _orig = interp._prepare_execution
+
+    def _prepare_and_seed(grid_shape):
+        _orig(grid_shape)
+        hbm = interp.memory.hbm
+        lx0 = interp.memory.get_lx(0)
+        lx1 = interp.memory.get_lx(1)
+        full = np.arange(192 * 64, dtype=np.float16).reshape(192, 64)
+        hbm.write(0, full[0:96, :].flatten())
+        _write_strided(lx0, 12288, full[96:128, :].copy(), strides=[1, 64])
+        lx1.write(16384 * 2, full[128:192, :].flatten())
+        hbm.write(24576 * 2 // hbm.STICK_BYTES, np.zeros(192 * 64, dtype=np.float16))
+        lx0.next_ptr = 16384 * 2 + 8128
+        lx1.next_ptr = 16384 * 2 + 8192
+
+    interp._prepare_execution = _prepare_and_seed
+    interp.execute_function(func_name)
+
+    expected = np.arange(192 * 64, dtype=np.float16).reshape(192, 64)
+    b = interp.memory.hbm.read(
+        24576 * 2 // interp.memory.hbm.STICK_BYTES, 192 * 64, "f16"
+    ).reshape(192, 64)
+    np.testing.assert_array_equal(b, expected)

--- a/tests/mlir_frontend/test_registry_consistency.py
+++ b/tests/mlir_frontend/test_registry_consistency.py
@@ -67,11 +67,6 @@ FRONTEND_UNSUPPORTED = {
                           "Blocked on ktir-mlir-frontend#23.",
     "ktdp.yield_reduced": "🧪 experimental terminator; no frontend adapter yet. "
                           "Blocked on ktir-mlir-frontend#23.",
-
-    # Real spec op missing only a frontend adapter handler (distinct from the
-    # non-spec ops above).
-    "ktdp.construct_distributed_memory_view": "real ktdp dialect op; no frontend "
-                   "adapter handler yet. Tracked in issue #87.",
 }
 
 

--- a/tests/test_dialects_parse.py
+++ b/tests/test_dialects_parse.py
@@ -1323,34 +1323,36 @@ class TestParseAttrList:
         assert len(result) == 1
 
 
-from ktir_cpu.parser_utils import parse_tensor_type
+from ktir_cpu.parser_utils import parse_tensor_or_memref_type
 
 
-class TestParseTensorType:
+class TestParseTensorOrMemrefType:
     def test_basic_float(self):
-        assert parse_tensor_type("tensor<256xf16>") == {"shape": (256,), "dtype": "f16"}
+        assert parse_tensor_or_memref_type("tensor<256xf16>") == {"shape": (256,), "dtype": "f16"}
 
     def test_basic_int(self):
-        assert parse_tensor_type("tensor<10xi32>") == {"shape": (10,), "dtype": "i32"}
+        assert parse_tensor_or_memref_type("tensor<10xi32>") == {"shape": (10,), "dtype": "i32"}
 
     def test_multi_dim(self):
-        assert parse_tensor_type("tensor<1x64xf32>") == {"shape": (1, 64), "dtype": "f32"}
+        assert parse_tensor_or_memref_type("tensor<1x64xf32>") == {"shape": (1, 64), "dtype": "f32"}
 
     def test_index_dtype(self):
         # Regression: 'index' contains 'x'; old split('x') would corrupt the dtype.
-        assert parse_tensor_type("tensor<2xindex>") == {"shape": (2,), "dtype": "index"}
-        assert parse_tensor_type("tensor<2x3xindex>") == {"shape": (2, 3), "dtype": "index"}
+        assert parse_tensor_or_memref_type("tensor<2xindex>") == {"shape": (2,), "dtype": "index"}
+        assert parse_tensor_or_memref_type("tensor<2x3xindex>") == {"shape": (2, 3), "dtype": "index"}
 
     def test_dynamic_dims_dropped(self):
-        assert parse_tensor_type("tensor<?x4xf32>") == {"shape": (4,), "dtype": "f32"}
-        assert parse_tensor_type("tensor<?xf16>") is None
+        assert parse_tensor_or_memref_type("tensor<?x4xf32>") == {"shape": (4,), "dtype": "f32"}
+        assert parse_tensor_or_memref_type("tensor<?xf16>") is None
 
     def test_rank0_returns_none(self):
-        assert parse_tensor_type("tensor<f32>") is None
+        assert parse_tensor_or_memref_type("tensor<f32>") is None
 
-    def test_non_tensor_returns_none(self):
-        assert parse_tensor_type("memref<10xf32>") is None
-        assert parse_tensor_type("f32") is None
+    def test_memref_accepted(self):
+        assert parse_tensor_or_memref_type("memref<10xf32>") == {"shape": (10,), "dtype": "f32"}
+
+    def test_non_type_returns_none(self):
+        assert parse_tensor_or_memref_type("f32") is None
 
     @pytest.mark.xfail(strict=True, reason="nested '<>' in dtype unsupported; regex stops at first '>'")
     @pytest.mark.parametrize("type_str,expected", [
@@ -1359,7 +1361,7 @@ class TestParseTensorType:
         ("tensor<4xvector<4xf32>>", {"shape": (4,), "dtype": "vector<4xf32>"}),
     ])
     def test_nested_bracket_dtype_unsupported(self, type_str, expected):
-        assert parse_tensor_type(type_str) == expected
+        assert parse_tensor_or_memref_type(type_str) == expected
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_distributed_view.py
+++ b/tests/test_distributed_view.py
@@ -1186,3 +1186,18 @@ def test_distributed_store_slow_path_cross_boundary():
     p1_mask[0:2, 4:8] = True
     assert np.all(p0_full[~p0_mask] == SENTINEL), "P0 trampled outside C_i (slow path)"
     assert np.all(p1_full[~p1_mask] == SENTINEL), "P1 trampled outside C_i (slow path)"
+
+
+def test_parse_distributed_view_index_dtype():
+    """split('x') must not break on dtypes containing 'x' like 'index'."""
+    from ktir_cpu.dialects.ktdp_ops import parse_construct_distributed_memory_view
+    from ktir_cpu.parser import ParseContext
+
+    op_text = (
+        "%dv = ktdp.construct_distributed_memory_view "
+        "(%v0, %v1 : memref<64x32xindex>, memref<64x32xindex>) "
+        ": memref<128x32xindex>"
+    )
+    op = parse_construct_distributed_memory_view(op_text, ParseContext(aliases={}))
+    assert op.attributes["shape"] == (128, 32)
+    assert op.attributes["dtype"] == "index"

--- a/tests/test_distributed_view.py
+++ b/tests/test_distributed_view.py
@@ -1191,13 +1191,21 @@ def test_distributed_store_slow_path_cross_boundary():
 def test_parse_distributed_view_index_dtype():
     """split('x') must not break on dtypes containing 'x' like 'index'."""
     from ktir_cpu.dialects.ktdp_ops import parse_construct_distributed_memory_view
-    from ktir_cpu.parser import ParseContext
+    from ktir_cpu.parser import KTIRParser, ParseContext
 
-    op_text = (
+    # Dialect parser directly (body only, no LHS — as the dispatcher delivers it)
+    body_text = (
         "ktdp.construct_distributed_memory_view "
         "(%v0, %v1 : memref<64x32xindex>, memref<64x32xindex>) "
         ": memref<128x32xindex>"
     )
-    op = parse_construct_distributed_memory_view(op_text, ParseContext(aliases={}))
+    op = parse_construct_distributed_memory_view(body_text, ParseContext(aliases={}))
     assert op.attributes["shape"] == (128, 32)
     assert op.attributes["dtype"] == "index"
+
+    # Dispatcher integration (full op line with LHS assignment)
+    full_op = "%dv = " + body_text
+    op2 = KTIRParser()._parse_operation_text(full_op)
+    assert op2.result == "%dv"
+    assert op2.attributes["shape"] == (128, 32)
+    assert op2.attributes["dtype"] == "index"

--- a/tests/test_distributed_view.py
+++ b/tests/test_distributed_view.py
@@ -1194,7 +1194,7 @@ def test_parse_distributed_view_index_dtype():
     from ktir_cpu.parser import ParseContext
 
     op_text = (
-        "%dv = ktdp.construct_distributed_memory_view "
+        "ktdp.construct_distributed_memory_view "
         "(%v0, %v1 : memref<64x32xindex>, memref<64x32xindex>) "
         ": memref<128x32xindex>"
     )

--- a/tests/test_parser_utils.py
+++ b/tests/test_parser_utils.py
@@ -21,7 +21,7 @@ mis-tokenised these by splitting on the ``x`` inside the dtype.
 
 import pytest
 
-from ktir_cpu.parser_utils import parse_multi_result_lhs, parse_tensor_type, extract_outs_operands
+from ktir_cpu.parser_utils import parse_multi_result_lhs, parse_tensor_or_memref_type, extract_outs_operands
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_parser_utils.py
+++ b/tests/test_parser_utils.py
@@ -45,9 +45,9 @@ from ktir_cpu.parser_utils import parse_multi_result_lhs, parse_tensor_or_memref
         ("tensor<1x16x1x128xf16>", (1, 16, 1, 128), "f16"),
     ],
 )
-def test_parse_tensor_type_basic(type_str, expected_shape, expected_dtype):
+def test_parse_tensor_or_memref_type_basic(type_str, expected_shape, expected_dtype):
     """Plain numeric/float dtypes round-trip cleanly across rank 1–4."""
-    info = parse_tensor_type(type_str)
+    info = parse_tensor_or_memref_type(type_str)
     assert info == {"shape": expected_shape, "dtype": expected_dtype}
 
 
@@ -64,7 +64,7 @@ def test_parse_tensor_type_basic(type_str, expected_shape, expected_dtype):
         ("tensor<1x16x1xindex>", (1, 16, 1)),
     ],
 )
-def test_parse_tensor_type_index_dtype(type_str, expected_shape):
+def test_parse_tensor_or_memref_type_index_dtype(type_str, expected_shape):
     """``index`` dtype is preserved despite the ``x`` inside its name.
 
     Pins the regression where ``inner.split('x')`` on ``"2xindex"`` produced
@@ -73,7 +73,7 @@ def test_parse_tensor_type_index_dtype(type_str, expected_shape):
     ``tensor.reshape`` lowerings; mis-parsing it broke any KTIR containing
     ``tl.reshape`` from a 3D descriptor load.
     """
-    info = parse_tensor_type(type_str)
+    info = parse_tensor_or_memref_type(type_str)
     assert info == {"shape": expected_shape, "dtype": "index"}
 
 
@@ -84,18 +84,17 @@ def test_parse_tensor_type_index_dtype(type_str, expected_shape):
 @pytest.mark.parametrize(
     "type_str",
     [
-        "memref<10xf32>",       # Different aggregate type
-        "f32",                  # Bare element type
+        "f32",                  # Bare element type (no dims)
         "not a tensor",         # Random text
         "",                     # Empty
         "tensor<>",             # Malformed: empty body
-        "tensor<f32>",          # Rank-0 tensor — unsupported by the regex parser
-        "tensor<?xf16>",        # All-dynamic dims — no static dims to return
+        "tensor<f32>",          # Rank-0 tensor — no dim tokens
+        "tensor<?xf16>",        # All-dynamic dims — dropped → empty shape
     ],
 )
-def test_parse_tensor_type_rejects_non_tensor(type_str):
-    """Inputs that are not a ranked tensor type return ``None``."""
-    assert parse_tensor_type(type_str) is None
+def test_parse_tensor_or_memref_type_rejects_invalid(type_str):
+    """Inputs with no parseable dim tokens return ``None``."""
+    assert parse_tensor_or_memref_type(type_str) is None
 
 
 # ---------------------------------------------------------------------------
@@ -106,7 +105,7 @@ def test_parse_tensor_type_rejects_non_tensor(type_str):
 @pytest.mark.parametrize(
     "type_str, expected_shape, expected_dtype",
     [
-        # Dynamic dims ('?') are silently dropped; only static dims are kept.
+        # Dynamic dims ('?') are dropped by default.
         ("tensor<?x4xf32>", (4,), "f32"),
         ("tensor<2x?x4xindex>", (2, 4), "index"),
         # Encoding attribute (RFC-allowed second positional).
@@ -115,16 +114,35 @@ def test_parse_tensor_type_rejects_non_tensor(type_str):
         # MLIR pretty-printer whitespace tolerance.
         ("tensor< 2 x f32 >", (2,), "f32"),
         ("tensor<1 x 64 x i32>", (1, 64), "i32"),
-        # Trailing context after the closing '>' — ignored, matching the
-        # original ``re.match``-based behaviour. Calls inside the parser
-        # rely on this when they pass un-stripped MLIR fragments.
+        # Trailing context after the closing '>' — ignored.
         ("tensor<4xf32> loc(unknown)", (4,), "f32"),
         ("tensor<4xf32>, %arg0", (4,), "f32"),
+        # memref wrapper
+        ("memref<128x32xf16>", (128, 32), "f16"),
+        ("memref<4x4xi32, #ktdp.spyre_memory_space<LX>>", (4, 4), "i32"),
+        # Bare inner content (no wrapper)
+        ("64x32xindex", (64, 32), "index"),
+        ("256xbf16", (256,), "bf16"),
     ],
 )
-def test_parse_tensor_type_real_mlir_forms(type_str, expected_shape, expected_dtype):
+def test_parse_tensor_or_memref_type_real_mlir_forms(type_str, expected_shape, expected_dtype):
     """Forms that the upstream MLIR pretty-printer can produce."""
-    info = parse_tensor_type(type_str)
+    info = parse_tensor_or_memref_type(type_str)
+    assert info == {"shape": expected_shape, "dtype": expected_dtype}
+
+
+@pytest.mark.parametrize(
+    "type_str, expected_shape, expected_dtype",
+    [
+        ("tensor<?x4xf32>", (None, 4), "f32"),
+        ("tensor<?xf16>", (None,), "f16"),
+        ("memref<?x32xf32>", (None, 32), "f32"),
+        ("128x?xindex", (128, None), "index"),
+    ],
+)
+def test_parse_tensor_or_memref_type_keep_dynamic_dims(type_str, expected_shape, expected_dtype):
+    """With keep_dynamic_dims=True, '?' dims appear as None."""
+    info = parse_tensor_or_memref_type(type_str, keep_dynamic_dims=True)
     assert info == {"shape": expected_shape, "dtype": expected_dtype}
 
 
@@ -152,7 +170,7 @@ def test_parse_tensor_type_real_mlir_forms(type_str, expected_shape, expected_dt
         ("tensor<4xvector<4xf32>>", (4,), "vector<4xf32>"),
     ],
 )
-def test_parse_tensor_type_nested_bracket_dtype(type_str, expected_shape, expected_dtype):
+def test_parse_tensor_or_memref_type_nested_bracket_dtype(type_str, expected_shape, expected_dtype):
     """xfail: dtypes whose own form contains ``<...>`` are not supported.
 
     The regex stops at the first ``>``, so ``complex<f32>`` is parsed
@@ -161,7 +179,7 @@ def test_parse_tensor_type_nested_bracket_dtype(type_str, expected_shape, expect
     bracket) and the trailing ``>`` unconsumed. A depth-counting parser
     is needed to fix this — out of scope for the current change.
     """
-    info = parse_tensor_type(type_str)
+    info = parse_tensor_or_memref_type(type_str)
     assert info == {"shape": expected_shape, "dtype": expected_dtype}
 
 


### PR DESCRIPTION
## What's fixed (issue #87 )

1. **Per-core LX parsing** — Extended the memory_space regex to handle `<LX, core = N> `and set `attributes["lx_core_id"] `when matched. (previously only matched bare `<HBM>` / `<LX>`)
2. **Distributed view handler** — Added missing frontend adapter  (`MLIRTypeAdapter`) for `construct_distributed_memory_view` (extracts `shape` and `dtype` from result type)
3. **End-to-end test** — New test parses and executes the RFC §C.3  distributed-view-copy example through the MLIR frontend path (MLIRFrontendParser)

## File changes

| Fix | File | What |
|-----|------|------|
| 1 | `ktir_cpu/mlir_frontend/parser.py` | Wider regex + emit `lx_core_id` |
| 2 | `ktir_cpu/mlir_frontend/parser.py` | New `@install` handler for distributed view |
| 3 | `tests/mlir_frontend/test_distributed_view_adapt.py` | New test file |
| 3 | `tests/mlir_frontend/test_registry_consistency.py` | Remove stale allowlist entry |

## Running the frontend tests locally

The frontend tests need `mlir_ktdp` (C++ MLIR bindings). Local test were done with the steps in [Option 2 in the MLIR frontend bindings section of the README file](https://github.com/torch-spyre/ktir-cpu#mlir-frontend-bindings-optional)

**Workflow** : MLIR text → `MLIRFrontendParser` (C++ parse + `MLIRTypeAdapter`) → `IRModule` → executor → assert correctness

