### PR TITLE
fix: exclude cross-core comm bytes from roofline arithmetic intensity

### DIFF
--- a/ktir_cpu/latency.py
+++ b/ktir_cpu/latency.py
@@ -116,11 +116,13 @@ class CoreLatencyCounters:
     """Per-core cycle counters."""
     memory_cycles: float = 0.0
     comm_cycles: float = 0.0
-    total_bytes: int = 0
-    # Per-category flops and cycles — keys are LatencyCategory string values.
+    # Per-category flops, cycles, and bytes — keys are LatencyCategory string values.
     # Compute categories: "compute_matmul", "compute_float", "compute_transcendental", "compute_int".
     flops_by_category: Dict[str, float] = field(default_factory=dict)
     cycles_by_category: Dict[str, float] = field(default_factory=dict)
+    # Bytes split by transport: the roofline uses DRAM-only traffic for arithmetic
+    # intensity, while comm/ring bytes stay separately readable (dram_bytes / comm_bytes).
+    bytes_by_category: Dict[str, int] = field(default_factory=dict)
     trace: Optional[List[_TraceEntry]] = None
 
     @property
@@ -135,6 +137,29 @@ class CoreLatencyCounters:
     def total_flops(self) -> float:
         return sum(self.flops_by_category.values())
 
+    @property
+    def total_bytes(self) -> int:
+        """All bytes moved by this core, across every transport (HBM + comm/ring)."""
+        return sum(self.bytes_by_category.values())
+
+    @property
+    def comm_bytes(self) -> int:
+        """Bytes this core moved over the cross-core comm transport (ring)."""
+        return self.bytes_by_category.get("comm", 0)
+
+    @property
+    def dram_bytes(self) -> int:
+        """Bytes crossing the HBM/DRAM boundary — the ``"memory"`` category.
+
+        The traffic the roofline's HBM bandwidth ceiling governs, hence the correct
+        denominator for arithmetic intensity. It sums only the ``"memory"`` category
+        (HBM load/store bytes): a per-transport whitelist, so any other transport —
+        comm/ring, or a future interconnect — contributes only if explicitly
+        categorised ``"memory"``. On-chip LX ops record 0 bytes, so they never
+        enter here.
+        """
+        return self.bytes_by_category.get("memory", 0)
+
     def record(self, category: str, cycles: float, op_type: str = "",
                flops: float = 0.0, nbytes: int = 0):
         if category.startswith("compute_"):
@@ -145,7 +170,10 @@ class CoreLatencyCounters:
         elif category == "comm":
             self.comm_cycles += cycles
 
-        self.total_bytes += nbytes
+        # Bucket bytes by transport so the roofline can isolate HBM/DRAM traffic
+        # (dram_bytes) from comm/ring traffic (comm_bytes); total_bytes sums both.
+        if nbytes:
+            self.bytes_by_category[category] = self.bytes_by_category.get(category, 0) + nbytes
 
         if self.trace is not None:
             self.trace.append(_TraceEntry(op_type=op_type, cycles=cycles, category=category))
@@ -578,13 +606,15 @@ class LatencyReport:
             cats = unit_categories[unit_name]
             flops = sum(critical.flops_by_category.get(c, 0.0) for c in cats)
             achieved = flops / elapsed_s if elapsed_s > 0 else 0.0
-            # Per-unit arithmetic intensity: this unit's own FLOPs over the
-            # kernel's total bytes (NCU convention — numerator split per
-            # pipeline, denominator the shared byte traffic). Each unit gets its
-            # own ceiling instead of sharing one mixed AI, so the other unit's
-            # FLOPs no longer inflate this unit's ceiling.
-            unit_ai = (flops / critical.total_bytes
-                       if critical.total_bytes > 0 else float('inf'))
+            # Per-unit arithmetic intensity: this unit's own FLOPs over the kernel's
+            # DRAM bytes (NCU convention — numerator split per pipeline, denominator
+            # the shared byte traffic). The denominator is dram_bytes: the HBM
+            # bandwidth ceiling governs HBM traffic only, so comm/ring bytes (a
+            # different interconnect) are excluded — otherwise a comm kernel's
+            # byte-rate could exceed HBM peak and put the point above the roof. Each
+            # unit gets its own ceiling, so the other unit's FLOPs don't inflate it.
+            unit_ai = (flops / critical.dram_bytes
+                       if critical.dram_bytes > 0 else float('inf'))
             # Roofline ceiling at this unit's own AI.
             ceiling = min(peak, peak_bw * unit_ai)
             # Cores are homogeneous: every core shares the same clock and

--- a/ktir_cpu/latency.py
+++ b/ktir_cpu/latency.py
@@ -712,7 +712,16 @@ class LatencyReport:
             lines.append("Roofline Analysis (critical-path core)")
             lines.append("-" * 60)
             ai = rf["arithmetic_intensity"]
-            ai_str = f"{ai:.2f} FLOP/B" if ai != float('inf') else "inf (no memory traffic)"
+            # AI == inf means dram_bytes == 0 (no HBM). Split by total_bytes, not by
+            # naming a transport, so a comm-only kernel (or a future non-HBM
+            # interconnect) reads "no HBM traffic" instead of the misleading "no
+            # memory traffic" — it did move bytes, just not over HBM.
+            if ai != float('inf'):
+                ai_str = f"{ai:.2f} FLOP/B"
+            elif critical.total_bytes > 0:
+                ai_str = "inf (no HBM traffic)"
+            else:
+                ai_str = "inf (no memory traffic)"
             dom_unit = rf["units"][rf["dominant_unit"]]
             lines.append(f"  Arithmetic intensity : {ai_str}")
             lines.append(f"  Peak bandwidth       : {rf['peak_bw_gb_s']:.2f} GB/s")

--- a/tests/test_latency.py
+++ b/tests/test_latency.py
@@ -424,14 +424,16 @@ class TestRoofline:
         total_bytes = 71680
         c = CoreLatencyCounters()
         c.record("compute_matmul", cycles=1.0, flops=524288.0)
-        c.record("compute_float", cycles=496.0, flops=28480.0, nbytes=total_bytes)
+        c.record("compute_float", cycles=496.0, flops=28480.0)
+        # Bytes are HBM traffic — recorded on a memory op (the shared AI denominator).
+        c.record("memory", cycles=1.0, nbytes=total_bytes)
 
         rf = LatencyReport(config=HardwareConfig(), counters={0: c}).roofline()
 
         # FLOP-heaviest is systolic; cycle-heaviest (the bottleneck) is simd.
         assert rf["dominant_unit"] == "simd"
 
-        # Each unit's AI is its own FLOPs over the shared total bytes — distinct,
+        # Each unit's AI is its own FLOPs over the shared DRAM bytes — distinct,
         # not one mixed value shared by both.
         ai_sys = rf["units"]["systolic"]["arithmetic_intensity"]
         ai_simd = rf["units"]["simd"]["arithmetic_intensity"]
@@ -2138,16 +2140,12 @@ class TestRingReduceLatency:
             # no other op in the trace contributes to the comm bucket.
             assert cc.comm_cycles == pytest.approx(expected_comm_cycles)
 
-            # Cumulative comm bytes for this core (the only comm op is
-            # the reduce, so total_bytes - HBM-side load/store bytes
-            # equals the ring's per-core wire load).  We pin the comm
-            # bytes via the cycle assertion above; this asserts the
-            # aggregate counter agrees: ring bytes contribute exactly
-            # ``per_core_ring_bytes`` to ``total_bytes``.
-            # Note ``total_bytes`` also includes HBM bytes from
-            # ``ktdp.load`` / ``ktdp.store``, so we can't pin it on its
-            # own — we just assert it's at least the ring bytes.
-            assert cc.total_bytes >= per_core_ring_bytes
+            # Per-transport byte split. The ring reduce is this core's only comm
+            # op, so comm_bytes is exactly the per-core wire load (derived above
+            # from the kernel/config, not hardcoded); total_bytes still sums both
+            # transports (HBM + comm).
+            assert cc.comm_bytes == per_core_ring_bytes
+            assert cc.total_bytes == cc.dram_bytes + cc.comm_bytes
 
             # Each core loads its own row from HBM exactly once.
             assert ops.count("ktdp.load") == 1
@@ -2167,6 +2165,12 @@ class TestRingReduceLatency:
         per_core_total = {cid: cc.total_cycles for cid, cc in rep.counters.items()}
         assert rep.kernel_cycles == max(per_core_total.values())
         assert per_core_total[0] >= max(per_core_total[c] for c in (1, 2, 3))
+
+        # Roofline invariant on a comm kernel: arithmetic intensity uses dram_bytes
+        # (HBM only), so ring/comm bytes do not inflate the denominator and push the
+        # attained point above the HBM ceiling. With the old total_bytes denominator
+        # this kernel reported efficiency > 1 (point above the roof).
+        assert 0 < rep.roofline()["efficiency"] <= 1.0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
**Fix roofline arithmetic intensity to exclude cross-core comm (ring) bytes**

Surfaced while adding the comm-latency view (#126); continues the roofline-correctness line of #122 / #129.

`roofline()` computed arithmetic intensity as `flops / total_bytes`, but `total_bytes` lumps in cross-core comm (ring) bytes. Ring bytes don't cross HBM, yet the roofline's bandwidth ceiling is HBM-only — so a comm kernel's attained point exceeds the HBM ceiling (`efficiency > 1`, point above the roof), breaking the invariant `test_roofline_returns_sane_values` pins (`efficiency in [0,1]`). It held until now only because comm-free kernels (matmul / vector-add) carry no ring bytes.

Where comm bytes are used — before → after (❌ marks the bug, ✅ the fix):

| comm bytes used for | before | after |
|---|---|---|
| comm latency (`bytes / ring_bw`) | `result.comm_bytes` → `comm_cycles` | unchanged (already correct) |
| **roofline AI denominator** | ❌ `total_bytes` (incl. ring) → efficiency can exceed 1 | ✅ `dram_bytes` (HBM only) → efficiency ≤ 1 |
| `total_bytes` aggregate | sum over all transports | unchanged contract (now a derived property) |
| ring-byte readout | buried in `total_bytes`, not separable | ✅ `comm_bytes` first-class (newly exposed) |

**Change.** Bytes are bucketed by transport on `CoreLatencyCounters` (`bytes_by_category`, mirroring the existing `flops_by_category` / `cycles_by_category`), exposing `total_bytes` (sum, unchanged contract), `comm_bytes` (ring), and `dram_bytes` (HBM, the `"memory"` category). `roofline()` uses `dram_bytes` for arithmetic intensity — AI = FLOP / DRAM-byte, the standard (Williams) definition. `dram_bytes` is a whitelist (the `"memory"` category), so any non-HBM transport is excluded by default; comm **cycles** are untouched (still in wall time).

**Scope.** No effect on comm-free kernels (`dram_bytes == total_bytes`); the matmul sweep is unaffected.

**Tests.** Existing byte/roofline tests pass (`total_bytes` contract intact). The real-kernel `ring_reduce` latency test now also pins `comm_bytes == per-core ring bytes`, `total_bytes == dram_bytes + comm_bytes`, and `efficiency ≤ 1` (was > 1 before the fix).
