### PR TITLE
Constants are 0-LX literals: fix nested-loop iter_arg init corruption

### DIFF
--- a/ktir_cpu/dialects/arith_ops.py
+++ b/ktir_cpu/dialects/arith_ops.py
@@ -205,7 +205,7 @@ def arith__cmpf(op, context, env):
 # Constants & casts
 # ---------------------------------------------------------------------------
 
-@register("arith.constant")
+@register("arith.constant", no_lx_charge=True)
 def arith__constant(op, context, env):
     value = op.attributes.get("value", 0)
     if op.attributes.get("is_tensor"):

--- a/ktir_cpu/dialects/registry.py
+++ b/ktir_cpu/dialects/registry.py
@@ -45,6 +45,12 @@ _LATENCY_CATEGORIES: Dict[str, str] = {}
 # accumulator and the handler must return the same Tile object.
 _INPLACE_OPS_SET: set = set()
 
+# Ops registered with no_lx_charge=True — their result is a compile-time
+# literal (e.g. arith.constant) that does not occupy the LX scratchpad. LX is
+# charged only when a consuming op materializes the literal into a real working
+# tile (see CoreContext.set_value / scf.for iter_arg binding).
+_NO_LX_CHARGE_OPS_SET: set = set()
+
 
 def get_latency_category(op_name: str) -> str:
     """Return the latency category for *op_name*, defaulting to ``"zero"``.
@@ -88,7 +94,8 @@ def make_parse_context(aliases: Dict[str, str]) -> "ParseContext":
     return ParseContext(aliases=aliases)
 
 
-def register(*op_names: str, latency_category: str = "zero", inplace_outs: bool = False):
+def register(*op_names: str, latency_category: str = "zero", inplace_outs: bool = False,
+             no_lx_charge: bool = False):
     """Decorator that registers a dialect operation handler.
 
     Usage::
@@ -110,6 +117,10 @@ def register(*op_names: str, latency_category: str = "zero", inplace_outs: bool 
             and parsers will populate ``Operation.outs_operands``.  The structural
             assertion in ``_execute_op`` then verifies the handler returns the
             same Tile object.
+        no_lx_charge: When True, the op's result Tile is a compile-time literal
+            that does not occupy LX (e.g. ``arith.constant``).  ``_execute_op``
+            binds it without charging the scratchpad; a consuming op pays for
+            the real buffer when it materializes the literal.
     """
     def decorator(fn: HandlerFn) -> HandlerFn:
         names = op_names or (fn.__name__.replace("__", "."),)
@@ -118,6 +129,8 @@ def register(*op_names: str, latency_category: str = "zero", inplace_outs: bool 
             _LATENCY_CATEGORIES[name] = latency_category
             if inplace_outs:
                 _INPLACE_OPS_SET.add(name)
+            if no_lx_charge:
+                _NO_LX_CHARGE_OPS_SET.add(name)
         return fn
     return decorator
 
@@ -125,6 +138,11 @@ def register(*op_names: str, latency_category: str = "zero", inplace_outs: bool 
 def is_inplace_outs(op_name: str) -> bool:
     """Return whether *op_name* was registered with ``inplace_outs=True``."""
     return op_name in _INPLACE_OPS_SET
+
+
+def is_no_lx_charge(op_name: str) -> bool:
+    """Return whether *op_name* was registered with ``no_lx_charge=True``."""
+    return op_name in _NO_LX_CHARGE_OPS_SET
 
 
 def dispatch(op_name: str) -> Optional[HandlerFn]:

--- a/ktir_cpu/dialects/scf_ops.py
+++ b/ktir_cpu/dialects/scf_ops.py
@@ -16,11 +16,34 @@
 
 import re
 
-from ..ir_types import Operation
+from ..ir_types import Operation, Tile
 from ..latency import LatencyCategory as LC
 from ..ops.control_ops import ControlOps
 from ..parser_utils import find_ssa_names
 from .registry import register, register_parser
+
+
+def _materialize_iter_inits(context, iter_init_operands):
+    """Resolve scf.for iter_arg init values, copying constant (0-LX) literals.
+
+    The inner-loop accumulator init is, in practice, always a compile-time
+    literal (``tl.zeros`` → ``arith.constant``), which carries no LX. The loop
+    body accumulates into the iter_arg in place (``linalg.matmul`` outs), so the
+    iter_arg must be its own buffer — otherwise the in-place write corrupts the
+    shared literal, which is re-read on every outer iteration of an enclosing
+    loop.
+
+    We always hand the loop a private ``copy()`` of any Tile init. For the
+    constant case this is free of LX concern (the source literal is uncharged;
+    the copy is a genuine working buffer charged at the loop, where the
+    accumulator really lives). For the rare non-constant init it is still
+    correct — a fresh buffer is never wrong, only marginally more LX.
+    """
+    values = []
+    for name in iter_init_operands:
+        val = context.get_value(name, peek=True)
+        values.append(val.copy() if isinstance(val, Tile) else val)
+    return values
 
 
 @register("scf.if")
@@ -40,8 +63,7 @@ def scf__for(op, context, env):
     body_region = op.regions[0] if op.regions else []
 
     iter_arg_names = op.attributes.get("iter_args", [])
-    iter_init_operands = op.operands[3:]
-    iter_init_values = [context.get_value(n) for n in iter_init_operands]
+    iter_init_values = _materialize_iter_inits(context, op.operands[3:])
 
     result = yield from ControlOps.for_op_with_comms(
         context, lb, ub, step, iter_var, body_region, env.execute_region_with_comms,

--- a/ktir_cpu/grid.py
+++ b/ktir_cpu/grid.py
@@ -92,6 +92,10 @@ class CoreContext:
         self.lx_options = lx_options if lx_options is not None else LXOptions()
         self._scope_stack: List[Dict[str, Any]] = [{}]  # bottom = function body
         self._tile_refcount: Dict[int, int] = {}  # id(Tile) -> refcount
+        # id(Tile) for tiles that do not occupy LX (compile-time literals from
+        # no_lx_charge ops, e.g. arith.constant). Their binds/unbinds skip every
+        # lx.used adjustment so the scratchpad reflects only real working tiles.
+        self._uncharged_tiles: set = set()
         self._lx_next_ptr_stack: List[int] = []  # watermarks for lx.next_ptr rewind on pop_scope
         self._use_counts: Dict[str, int] = {}  # SSA name -> use count for current region
         # Scheduler-managed cross-core access — both functions are set by
@@ -225,13 +229,7 @@ class CoreContext:
         scope = self._scope_stack.pop()
         for value in scope.values():
             if isinstance(value, Tile):
-                if self.lx_options.alias_dedup:
-                    self._tile_refcount[id(value)] -= 1
-                    if self._tile_refcount[id(value)] == 0:
-                        del self._tile_refcount[id(value)]
-                        self.lx.used -= value.size_bytes()
-                else:
-                    self.lx.used -= value.size_bytes()
+                self._release_tile(value)
         self.lx.next_ptr = self._lx_next_ptr_stack.pop()
         assert len(self._lx_next_ptr_stack) == len(self._scope_stack) - 1
 
@@ -254,7 +252,7 @@ class CoreContext:
     # SSA value access
     # ------------------------------------------------------------------
 
-    def set_value(self, name: str, value: Any):
+    def set_value(self, name: str, value: Any, *, charge: bool = True):
         """Set SSA value in the topmost scope, auto-tracking Tile LX usage.
 
         - First binding of a Tile id: charges lx.used once.
@@ -265,38 +263,61 @@ class CoreContext:
         (e.g. when ``linalg.reduce`` binds its result to both the SSA result name
         and the ``outs`` buffer name).  This is valid because Python assignment
         creates a second reference to the same object — it does not copy the data.
+
+        ``charge=False`` binds a Tile that does not occupy LX — a compile-time
+        literal from a ``no_lx_charge`` op (e.g. ``arith.constant``). Its id is
+        recorded in ``_uncharged_tiles`` so this bind and every later unbind
+        (overwrite, pop_scope, consume) skips the lx.used adjustment. A
+        consuming op pays for the real buffer when it materializes the literal.
         """
         old = self._scope_stack[-1].get(name)
         if isinstance(old, Tile):
-            if self.lx_options.alias_dedup:
-                self._tile_refcount[id(old)] -= 1
-                if self._tile_refcount[id(old)] == 0:
-                    del self._tile_refcount[id(old)]
-                    self.lx.used -= old.size_bytes()
-            else:
-                self.lx.used -= old.size_bytes()
+            self._release_tile(old)
         self._scope_stack[-1][name] = value
         if isinstance(value, Tile):
+            uncharged = (not charge) or id(value) in self._uncharged_tiles
+            if uncharged:
+                self._uncharged_tiles.add(id(value))
+                # Still refcount so the id is released cleanly, but never touch lx.used.
+                if self.lx_options.alias_dedup:
+                    self._tile_refcount[id(value)] = self._tile_refcount.get(id(value), 0) + 1
+                return
             if self.lx_options.alias_dedup:
                 if self._tile_refcount.get(id(value), 0) == 0:
-                    if self.lx.used + value.size_bytes() > self.lx.capacity:
-                        raise MemoryError(
-                            f"LX scratchpad overflow on core {self.core_id}: "
-                            f"requested {value.size_bytes()} bytes, "
-                            f"available {self.lx.capacity - self.lx.used} bytes "
-                            f"(capacity {self.lx.capacity} bytes)"
-                        )
-                    self.lx.used += value.size_bytes()
+                    self._charge_lx(value)
                 self._tile_refcount[id(value)] = self._tile_refcount.get(id(value), 0) + 1
             else:
-                if self.lx.used + value.size_bytes() > self.lx.capacity:
-                    raise MemoryError(
-                        f"LX scratchpad overflow on core {self.core_id}: "
-                        f"requested {value.size_bytes()} bytes, "
-                        f"available {self.lx.capacity - self.lx.used} bytes "
-                        f"(capacity {self.lx.capacity} bytes)"
-                    )
-                self.lx.used += value.size_bytes()
+                self._charge_lx(value)
+
+    def _charge_lx(self, value: "Tile") -> None:
+        """Add *value*'s footprint to lx.used, raising on overflow."""
+        if self.lx.used + value.size_bytes() > self.lx.capacity:
+            raise MemoryError(
+                f"LX scratchpad overflow on core {self.core_id}: "
+                f"requested {value.size_bytes()} bytes, "
+                f"available {self.lx.capacity - self.lx.used} bytes "
+                f"(capacity {self.lx.capacity} bytes)"
+            )
+        self.lx.used += value.size_bytes()
+
+    def _release_tile(self, tile: "Tile") -> None:
+        """Drop one reference to *tile*, freeing its LX when the last one goes.
+
+        Uncharged tiles (compile-time literals) never touched lx.used, so their
+        release only updates bookkeeping.
+        """
+        uncharged = id(tile) in self._uncharged_tiles
+        if self.lx_options.alias_dedup:
+            self._tile_refcount[id(tile)] -= 1
+            if self._tile_refcount[id(tile)] == 0:
+                del self._tile_refcount[id(tile)]
+                self._uncharged_tiles.discard(id(tile))
+                if not uncharged:
+                    self.lx.used -= tile.size_bytes()
+        else:
+            self._uncharged_tiles.discard(id(tile))
+            if not uncharged:
+                self.lx.used -= tile.size_bytes()
 
     def get_value(self, name: str, *, peek: bool = False) -> Any:
         """Get SSA value, searching top-to-bottom.
@@ -324,13 +345,7 @@ class CoreContext:
                         and self._use_counts.get(name, 0) == 1
                         and scope is self._scope_stack[-1]):
                     del scope[name]
-                    if self.lx_options.alias_dedup:
-                        self._tile_refcount[id(value)] -= 1
-                        if self._tile_refcount[id(value)] == 0:
-                            del self._tile_refcount[id(value)]
-                            self.lx.used -= value.size_bytes()
-                    else:
-                        self.lx.used -= value.size_bytes()
+                    self._release_tile(value)
                 return value
         raise KeyError(f"Value '{name}' not found in core {self.core_id}")
 
@@ -342,6 +357,7 @@ class CoreContext:
         """Clear all scopes and LX (for next round of execution)."""
         self._scope_stack = [{}]
         self._tile_refcount.clear()
+        self._uncharged_tiles.clear()
         self._lx_next_ptr_stack.clear()
         self.lx.clear()
 

--- a/ktir_cpu/interpreter.py
+++ b/ktir_cpu/interpreter.py
@@ -251,8 +251,10 @@ class KTIRInterpreter:
                 raise RuntimeError(
                     f"{op.op_type}: expected {len(names)} result(s), got {len(values)}"
                 )
+            from .dialects.registry import is_no_lx_charge
+            charge = not is_no_lx_charge(op.op_type)
             for name, val in zip(names, values):
-                context.set_value(name, val)
+                context.set_value(name, val, charge=charge)
 
         # Record latency.
         # Sync handlers: charge now, with the final value.
@@ -363,8 +365,10 @@ class KTIRInterpreter:
                 # returning it.  Overwrite with the resolved tile now that the
                 # scheduler has driven the generator to completion.
                 if op.result is not None and result is not None:
+                    from .dialects.registry import is_no_lx_charge
+                    charge = not is_no_lx_charge(op.op_type)
                     names = op.result if isinstance(op.result, list) else [op.result]
                     values = result if isinstance(result, tuple) else [result]
                     for name, val in zip(names, values):
-                        context.set_value(name, val)
+                        context.set_value(name, val, charge=charge)
         return result

--- a/ktir_cpu/mlir_frontend/parser.py
+++ b/ktir_cpu/mlir_frontend/parser.py
@@ -780,9 +780,12 @@ class MLIRFrontendParser(KTIRParserBase):
             dims += [1] * (3 - len(dims))
             grid = tuple(dims)
 
+        operations = self._adapter.adapt_block(block)
+        from ..parser_utils import build_use_counts
         return IRFunction(
             name=sym_name,
             arguments=arguments,
-            operations=self._adapter.adapt_block(block),
+            operations=operations,
             grid=grid,
+            use_counts=build_use_counts(operations),
         )

--- a/ktir_cpu/parser.py
+++ b/ktir_cpu/parser.py
@@ -274,15 +274,9 @@ class KTIRParser(KTIRParserBase):
 
     @staticmethod
     def _build_use_counts(ops) -> Dict[str, int]:
-        """Count operand uses recursively across all ops and nested regions."""
-        counts: Dict[str, int] = {}
-        for op in ops:
-            for name in op.operands:
-                counts[name] = counts.get(name, 0) + 1
-            for region in op.regions:
-                for name, n in KTIRParser._build_use_counts(region).items():
-                    counts[name] = counts.get(name, 0) + n
-        return counts
+        """Operand use counts; see parser_utils.build_use_counts."""
+        from .parser_utils import build_use_counts
+        return build_use_counts(ops)
 
     @staticmethod
     def _preprocess_text(text: str) -> str:

--- a/ktir_cpu/parser_utils.py
+++ b/ktir_cpu/parser_utils.py
@@ -44,6 +44,31 @@ def extract_outs_operands(op_text: str) -> list[str]:
     return names
 
 
+def build_use_counts(ops) -> Dict[str, int]:
+    """Count operand uses recursively across all ops and nested regions.
+
+    Shared by both parsers (regex ``KTIRParser`` and ``MLIRFrontendParser``)
+    so they produce identical ``use_counts``. Operates on duck-typed
+    ``Operation`` objects (``.result``, ``.operands``, ``.regions``) — no
+    import of ir_types needed.
+
+    This is a purely *textual* operand count — a name used once syntactically
+    has count 1 even if that use sits inside a loop body and runs many times.
+    ``consume_last_use`` (the only consumer) compensates with its
+    topmost-scope guard, which blocks early-free of outer-scope names fetched
+    per iteration. Loop-carried-state safety (constant accumulator inits) is
+    handled separately by the ``no_lx_charge`` literal model, not by counting.
+    """
+    counts: Dict[str, int] = {}
+    for op in ops:
+        for name in op.operands:
+            counts[name] = counts.get(name, 0) + 1
+        for region in op.regions:
+            for name, n in build_use_counts(region).items():
+                counts[name] = counts.get(name, 0) + n
+    return counts
+
+
 def parse_multi_result_lhs(lhs_text: str) -> list[str]:
     """Parse the LHS of a multi-result MLIR assignment.
 

--- a/tests/test_lx_scoping.py
+++ b/tests/test_lx_scoping.py
@@ -1095,7 +1095,6 @@ class TestLastUseMatmulKernel:
     """End-to-end LX accounting for MATMUL_LX_MLIR (issue #130).
 
     Kernel: BM=512, BN=256, BK=64, K=256 (4 iterations).
-    LX cap tightened to 1 MB = 1048576 bytes.
 
     Tile sizes (f16 = 2 bytes/elem):
         %accum_itr / %accum_next  512×256×2 = 262144 bytes  (256 KB)
@@ -1103,59 +1102,71 @@ class TestLastUseMatmulKernel:
         %a                        512×64×2  =  65536 bytes  ( 64 KB)
         %b                         64×256×2 =  32768 bytes  ( 32 KB)
 
-    Per-iteration peak, _LX_DEDUP (consume off):
-        parent scope:  %accum_itr                    262144
-        body scope:    %a + %b + %c_init + %a_dot_b   65536+32768+262144+262144
-                       + %accum_next                 +262144
-                                                     -------
-        peak =  262144 + 65536 + 32768 + 262144 + 262144 + 262144 = 1146880 bytes
-        → exceeds 1 MB cap → MemoryError
+    %accum_zero is an arith.constant (no_lx_charge) — a 0-LX literal. The
+    scf.for binding materializes it into a fresh, charged %accum_itr buffer
+    (256 KB), so the accumulator cost appears at the loop, not the constant.
+    (%a_view/%b_view/%c_view are memory-view descriptors, not LX tiles — 0 LX.)
 
-    Per-iteration peak, _LX_FULL (consume on), use_counts all 1:
-        parent: %accum_itr alive                      lx = 262144
+    Per-iteration trace, _LX_DEDUP (consume off):
+        parent: %accum_itr  (materialized from %accum_zero)   lx = 262144
         body:
-          ktdp.load  → %a registered                  lx = 327680
-          ktdp.load  → %b registered                  lx = 360448
-          tensor.empty → %c_init registered            lx = 622592
-          linalg.matmul fetches %c_init (count=1, topmost) → freed
-                         %c_init consumed              lx = 360448
-                         %a_dot_b registered           lx = 622592
-          arith.addf fetches %a (count=1, topmost)   → freed
-                         %a consumed                   lx = 557056
-                     fetches %b (count=1, topmost)   → freed
-                         %b consumed                   lx = 524288
-                     fetches %accum_itr (count=1, but parent scope — guard blocks)
-                         %accum_itr stays              lx = 524288
-                     fetches %a_dot_b (count=1, topmost) → freed
-                         %a_dot_b consumed             lx = 262144
-                         %accum_next registered        lx = 524288
-        peak = 524288 bytes (512 KB) — within 1 MB cap → no overflow
+          ktdp.load    → %a            +65536                 lx = 327680
+          ktdp.load    → %b            +32768                 lx = 360448
+          tensor.empty → %c_init      +262144                 lx = 622592
+          linalg.matmul→ %a_dot_b     +262144 (reuses %c_init id, outs)  lx = 622592
+          arith.addf   → %accum_next  +262144                 lx = 884736  ← peak
+        pop body scope frees %a, %b, %c_init/%a_dot_b, %accum_next; rebind
+        %accum_itr = %accum_next for the next iteration.
+        peak = 884736 bytes (864 KB)
+
+    Per-iteration trace, _LX_FULL (consume on), use_counts all 1:
+        parent: %accum_itr alive                              lx = 262144
+        body:
+          ktdp.load    → %a            +65536                 lx = 327680
+          ktdp.load    → %b            +32768                 lx = 360448
+          tensor.empty → %c_init      +262144                 lx = 622592  ← peak
+          linalg.matmul fetches %a (last use, topmost) → freed   lx = 557056
+                        fetches %b (last use, topmost) → freed    lx = 524288
+                        fetches %c_init (last use, topmost)→ freed lx = 262144
+                        → %a_dot_b registered (outs id)        lx = 524288
+          arith.addf   fetches %a_dot_b (last use)→ freed      lx = 262144
+                       fetches %accum_itr (parent scope — guard blocks)
+                        → %accum_next registered               lx = 524288
+        peak = 622592 bytes (608 KB)
+
+    consume_last_use lowers the peak (864 KB → 608 KB) by freeing %a / %b /
+    %c_init at their last fetch instead of at scope exit.
 
     Remaining limitation — simultaneous window for %accum_itr:
-        %accum_itr lives in the parent scope, not the body scope.
-        The topmost-scope guard blocks early-free even though use_count == 1,
-        because %accum_itr is fetched on every iteration (the global count
-        of 1 reflects that it appears once as an operand of arith.addf, but
-        that one appearance is executed K/BK times).
-        As a result, %accum_itr and %accum_next are both live simultaneously
-        inside each iteration body — hence peak = 2 × 256 KB = 512 KB
-        rather than the theoretical minimum of 256 KB.
-        The set_value rebind after each iteration frees %accum_itr promptly,
-        but cannot act before %accum_next is charged.
+        %accum_itr lives in the parent scope, not the body scope, so the
+        topmost-scope guard blocks its early-free; it and %accum_next are both
+        live inside each iteration body (hence the 524288 tail in the consume-on
+        trace). The set_value rebind after each iteration frees the old
+        %accum_itr, but only after %accum_next is charged.
     """
 
-    LX_CAP = 1 * 1024 * 1024  # 1 MB
+    LX_CAP = 1 * 1024 * 1024  # 1 MB — both modes fit under the const=0 model;
+                              # the test asserts the measured peaks, not overflow.
 
     def _run(self, lx_options):
+        """Run the kernel and return the max LX peak observed across cores."""
         from ktir_cpu.interpreter import KTIRInterpreter
 
+        peak = {"v": 0}
+
         class _PatchedInterpreter(KTIRInterpreter):
-            """Applies lx_options and LX cap after each _prepare_execution call."""
+            """Applies lx_options and LX cap, and tracks peak lx.used."""
             def _prepare_execution(self, grid_shape):
                 super()._prepare_execution(grid_shape)
                 for core in self.grid_executor.cores:
                     core.lx.capacity = TestLastUseMatmulKernel.LX_CAP
                     core.lx_options = lx_options
+                    _orig = core._charge_lx
+
+                    def _charge(value, _c=core, _o=_orig):
+                        _o(value)
+                        peak["v"] = max(peak["v"], _c.lx.used)
+                    core._charge_lx = _charge
 
         BM, BN, BK, K = 512, 256, 64, 256
         a = np.random.rand(BM, K).astype(np.float16)
@@ -1163,19 +1174,19 @@ class TestLastUseMatmulKernel:
         c = np.zeros((BM, BN), dtype=np.float16)
         interp = _PatchedInterpreter()
         interp.load(MATMUL_LX_MLIR)
-        return interp.execute_function(
+        interp.execute_function(
             "matmul_lx_test", a_ptr=a, b_ptr=b, c_ptr=c,
             K=K, BM=BM, BN=BN, BK=BK,
         )
+        return peak["v"]
 
-    def test_fits_in_lx_with_consume_on(self):
-        """With consume_last_use on, peak LX stays within 1 MB — no overflow."""
-        self._run(_LX_FULL)  # must not raise
+    def test_consume_on_peak(self):
+        """consume_last_use on: peak LX = 608 KB (within 1 MB), no overflow."""
+        assert self._run(_LX_FULL) == 622592
 
-    def test_overflows_lx_with_consume_off(self):
-        """With consume_last_use off, peak LX exceeds 1 MB — overflow expected."""
-        with pytest.raises(MemoryError, match="LX scratchpad overflow"):
-            self._run(_LX_DEDUP)
+    def test_consume_off_higher_peak(self):
+        """consume_last_use off: peak LX = 864 KB — higher than consume-on, still fits."""
+        assert self._run(_LX_DEDUP) == 884736
 
     def test_addf_loop_body_lx_accounting(self):
         """Unit: fetch two single-use tiles (lx → 0 each step), register result (lx = N)."""
@@ -1469,4 +1480,178 @@ class TestOutsStructuralAssertion:
             interp = KTIRInterpreter()
             interp.load('module { func.func @dummy() attributes {grid = [1]} { return } }')
             interp._execute_op(op, ctx)  # must not raise
+
+
+# Real round-tripped KTIR from the matmul__bmm Triton fixture (dump_round_trip.py).
+# Compiled with: B=4, M=128, K=32, N=64, BLOCK_B=1, BLOCK_M=16, BLOCK_K=16, BLOCK_N=16
+# %cst is defined once outside all loops; outer scf.for loops over m-tiles and
+# n-tiles each run a K-reduction with iter_args(%arg6 = %cst).
+# Without the fix, %cst is mutated after the first K-reduction and subsequent
+# N-tile iterations accumulate on the corrupted value, producing 64/96/128
+# instead of 32 everywhere.
+MULTI_TILE_BMM_MLIR = """
+#map = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+#set = affine_set<(d0, d1, d2) : (d0 >= 0, -d0 + 3 >= 0, d1 >= 0, -d1 + 127 >= 0, d2 >= 0, -d2 + 31 >= 0)>
+#set1 = affine_set<(d0, d1, d2) : (d0 >= 0, -d0 + 3 >= 0, d1 >= 0, -d1 + 31 >= 0, d2 >= 0, -d2 + 63 >= 0)>
+#set2 = affine_set<(d0, d1, d2) : (d0 >= 0, -d0 + 3 >= 0, d1 >= 0, -d1 + 127 >= 0, d2 >= 0, -d2 + 63 >= 0)>
+#set3 = affine_set<(d0, d1, d2) : (d0 >= 0, -d0 >= 0, d1 >= 0, -d1 + 15 >= 0, d2 >= 0, -d2 + 15 >= 0)>
+module {
+  func.func @bmm_matmul_kernel(%arg0: index, %arg1: index, %arg2: index) attributes {grid = [32]} {
+    %cst = arith.constant dense<0.000000e+00> : tensor<1x16x16xf32>
+    %c2_i32 = arith.constant 2 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c16_i32 = arith.constant 16 : i32
+    %c32_i32 = arith.constant 32 : i32
+    %m_blocks = arith.constant 8 : i32
+    %c4_i32 = arith.constant 4 : i32
+
+    %pid = ktdp.get_compute_tile_id : index
+    %pid_0 = arith.index_cast %pid : index to i32
+    %bm_end = arith.addi %pid_0, %c1_i32 : i32
+    %bm_end_1 = arith.minsi %bm_end, %c32_i32 : i32
+
+    %a_desc = ktdp.construct_memory_view %arg0, sizes: [4, 128, 32], strides: [4096, 32, 1] {coordinate_set = #set, memory_space = #ktdp.spyre_memory_space<HBM>} : memref<4x128x32xf32>
+    %b_desc = ktdp.construct_memory_view %arg1, sizes: [4, 32, 64], strides: [2048, 64, 1] {coordinate_set = #set1, memory_space = #ktdp.spyre_memory_space<HBM>} : memref<4x32x64xf32>
+    %c_desc = ktdp.construct_memory_view %arg2, sizes: [4, 128, 64], strides: [8192, 64, 1] {coordinate_set = #set2, memory_space = #ktdp.spyre_memory_space<HBM>} : memref<4x128x64xf32>
+
+    scf.for %arg3 = %pid_0 to %bm_end_1 step %c1_i32  : i32 {
+      %b = arith.divsi %arg3, %m_blocks : i32
+      %m = arith.remsi %arg3, %m_blocks : i32
+
+      scf.for %arg4 = %c0_i32 to %c4_i32 step %c1_i32  : i32 {
+        %acc = scf.for %arg5 = %c0_i32 to %c2_i32 step %c1_i32 iter_args(%arg6 = %cst) -> (tensor<1x16x16xf32>)  : i32 {
+          %a_tile = arith.muli %m, %c16_i32 : i32
+          %a_tile_2 = arith.muli %arg5, %c16_i32 : i32
+          %a_tile_3 = arith.index_cast %b : i32 to index
+          %a_tile_4 = arith.index_cast %a_tile : i32 to index
+          %a_tile_5 = arith.index_cast %a_tile_2 : i32 to index
+
+          %a_tile_6 = ktdp.construct_access_tile %a_desc[%a_tile_3, %a_tile_4, %a_tile_5] {access_tile_order = #map, access_tile_set = #set3} : memref<4x128x32xf32> -> !ktdp.access_tile<1x16x16xindex>
+          %a_tile_7 = ktdp.load %a_tile_6 : <1x16x16xindex> -> tensor<1x16x16xf32>
+          %b_tile = arith.muli %arg4, %c16_i32 : i32
+          %b_tile_8 = arith.index_cast %b_tile : i32 to index
+
+          %b_tile_9 = ktdp.construct_access_tile %b_desc[%a_tile_3, %a_tile_5, %b_tile_8] {access_tile_order = #map, access_tile_set = #set3} : memref<4x32x64xf32> -> !ktdp.access_tile<1x16x16xindex>
+          %b_tile_10 = ktdp.load %b_tile_9 : <1x16x16xindex> -> tensor<1x16x16xf32>
+          %acc_11 = linalg.batch_matmul ins(%a_tile_7, %b_tile_10 : tensor<1x16x16xf32>, tensor<1x16x16xf32>) outs(%arg6 : tensor<1x16x16xf32>) -> tensor<1x16x16xf32>
+          scf.yield %acc_11 : tensor<1x16x16xf32>
+        }
+        %0 = arith.muli %m, %c16_i32 : i32
+        %1 = arith.muli %arg4, %c16_i32 : i32
+        %2 = arith.index_cast %b : i32 to index
+        %3 = arith.index_cast %0 : i32 to index
+        %4 = arith.index_cast %1 : i32 to index
+
+        %5 = ktdp.construct_access_tile %c_desc[%2, %3, %4] {access_tile_order = #map, access_tile_set = #set3} : memref<4x128x64xf32> -> !ktdp.access_tile<1x16x16xindex>
+        ktdp.store %acc, %5 : tensor<1x16x16xf32>, <1x16x16xindex>
+      }
+    }
+    return
+  }
+}
+"""
+
+
+class TestConstantIterArgMutation:
+    """Regression: batch_matmul must not mutate %cst shared across outer loop iterations.
+
+    The real generated bmm KTIR defines %cst once outside all loops and uses it
+    as the iter_arg init for every K-reduction loop.  Without the fix, %cst is
+    mutated after the first N-tile iteration and subsequent iterations accumulate
+    on the corrupted value, producing 64/96/128 instead of 32 everywhere.
+
+    Fix: %cst is an arith.constant (no_lx_charge) — a 0-LX literal. The scf.for
+    iter_arg binding materializes it into a fresh, charged accumulator buffer
+    per loop entry, so the in-place matmul accumulation never touches the shared
+    literal and each outer iteration restarts from a clean zero.
+    """
+
+    def test_multi_tile_bmm_correctness(self):
+        """Every output tile must equal K=32, not multiples of 32 (cst corrupted)."""
+        from ktir_cpu.interpreter import KTIRInterpreter
+
+        # B=4, M=128, K=32, N=64, ones everywhere.
+        # Each output tile: A_tile(1x16x16) @ B_tile(1x16x16) with K=2 steps of 16
+        # = 16 + 16 = 32.0 everywhere.
+        # If %cst is corrupted, tile (m=0,n=1) starts from 32 and gives 64, etc.
+        B, M, K, N = 4, 128, 32, 64
+        a = np.ones((B, M, K), dtype=np.float32)
+        b = np.ones((B, K, N), dtype=np.float32)
+        c = np.zeros((B, M, N), dtype=np.float32)
+
+        interp = KTIRInterpreter()
+        interp.load(MULTI_TILE_BMM_MLIR)
+        result = interp.execute_function("bmm_matmul_kernel", arg0=a, arg1=b, arg2=c)
+        out = result["arg2"]
+
+        expected = np.full_like(out, 32.0)
+        np.testing.assert_array_equal(out, expected,
+            err_msg=f"unique values {np.unique(out)} — expected all 32.0 (cst corrupted?)")
+
+    def test_iter_arg_init_is_distinct_object_from_constant(self):
+        """Unit: scf.for must hand the loop a *copy* of a constant init.
+
+        Directly exercises _materialize_iter_inits — the aliasing fix. A
+        constant Tile bound with charge=False (an arith.constant literal) must
+        be materialized into a *distinct* Tile object for the iter_arg, so a
+        later in-place mutation of the iter_arg cannot corrupt the literal.
+        """
+        from ktir_cpu.dialects.scf_ops import _materialize_iter_inits
+
+        ctx = _make_context()
+        cst = _make_tile((16, 16), dtype="f32")
+        cst.data[:] = 7.0
+        ctx.set_value("%cst", cst, charge=False)   # 0-LX literal, like arith.constant
+        assert ctx.lx.used == 0
+
+        init_values = _materialize_iter_inits(ctx, ["%cst"])
+        (iter_arg,) = init_values
+
+        # The iter_arg is a different object than the constant ...
+        assert iter_arg is not cst, "iter_arg aliases the constant — in-place mutation will corrupt it"
+        assert id(iter_arg) not in ctx._uncharged_tiles, "the materialized copy must be a real (chargeable) buffer"
+
+        # ... so mutating it in place (as linalg.matmul outs does) leaves %cst clean.
+        iter_arg.data += 1.0
+        assert np.all(cst.data == 7.0), "constant literal was corrupted by iter_arg mutation"
+
+    def test_constant_init_is_uncharged_before_materialize(self):
+        """Sanity: the constant init really is an uncharged literal pre-copy."""
+        from ktir_cpu.dialects.scf_ops import _materialize_iter_inits
+
+        ctx = _make_context()
+        cst = _make_tile((32, 32), dtype="f32")  # 4 KB if it were charged
+        ctx.set_value("%cst", cst, charge=False)
+        assert id(cst) in ctx._uncharged_tiles
+        assert ctx.lx.used == 0
+
+        # Materializing charges the fresh copy (a real working buffer), not the literal.
+        ctx.set_value("%itr", _materialize_iter_inits(ctx, ["%cst"])[0])
+        assert ctx.lx.used == cst.size_bytes()
+
+
+class TestConstantNoLXCharge:
+    """arith.constant tensors are 0-LX literals; consumers pay for real buffers."""
+
+    def test_constant_tensor_costs_zero_lx(self):
+        """Binding an arith.constant tensor result must not charge LX."""
+        from ktir_cpu.interpreter import KTIRInterpreter
+
+        mlir = """
+        module {
+          func.func @k(%arg0: index) attributes {grid = [1]} {
+            %cst = arith.constant dense<0.000000e+00> : tensor<64x64xf32>
+            return
+          }
+        }
+        """
+        interp = KTIRInterpreter()
+        interp.load(mlir)
+        interp.execute_function("k", arg0=np.zeros((1,), dtype=np.float32))
+        # The 64x64xf32 constant (16 KB) must not have occupied LX.
+        for core in interp.grid_executor.cores:
+            assert core.lx.used == 0, (
+                f"constant charged LX: core {core.core_id} lx.used={core.lx.used}"
+            )
 


### PR DESCRIPTION
## Problem

A constant defined once outside a nested loop (e.g. `tl.zeros` lowered to
`arith.constant`) is used as the `iter_args` init of an inner loop. The
interpreter aliased the iter_arg to the **same Tile object** as the constant,
and the in-place accumulation in `linalg.matmul` / `linalg.batch_matmul` then
mutated that shared object. Every subsequent outer-loop iteration re-read the
dirtied init, producing multiples of the correct value (64/96/128 instead of
32) in the bmm/matmul kernels.

## Fix — constants don't occupy LX

The clean model: an `arith.constant` is a compile-time literal that occupies
**no** LX scratchpad. LX is charged only when a consuming op materializes the
literal into a real working buffer.

- `register(..., no_lx_charge=True)` marks such ops (mirrors `inplace_outs`);
  `is_no_lx_charge` exposes it.
- `_execute_op` binds a `no_lx_charge` result with `set_value(..., charge=False)`.
  The context records the Tile id in `_uncharged_tiles`; shared `_charge_lx` /
  `_release_tile` helpers ensure every LX adjust site honors the exemption.
- `scf.for` materializes a constant iter_arg init by **copying** it into a
  fresh, charged accumulator buffer — so in-place accumulation never touches
  the shared literal, and each outer iteration restarts from a clean zero.

Because the only values that aliased into in-place accumulators were constants,
this addresses the cause directly. It **replaces** the earlier loop-aware
`use_count` approach (and its `scf.for` hardcode in `build_use_counts`);
`build_use_counts` is reverted to the simple textual counter, kept shared
across both parsers.

## Tests

- `TestConstantIterArgMutation` — corruption regression (round-tripped bmm KTIR).
- `TestConstantNoLXCharge` — an `arith.constant` tensor costs 0 LX.
- `TestLastUseMatmulKernel` — accounting updated for the const=0 model.
- Full ktir-cpu suite: 1155 passed, 7 skipped, 13 xfailed.
- Full Spyre suite: 522 passed; all 8 previously-failing matmul/bmm numerical
  variants now pass.

## Follow-up (revisit before merge)

- **`outs_operands` inconsistency at `mlir_frontend/parser.py:139`.** The
  structured MLIR walk still derives `outs_operands` by regex-parsing the
  printed ASM (`extract_outs_operands(mlir_op.get_asm())`) instead of reading
  the op's structured operand segments (DPS `outs` group). Same "rely on text,
  not structure" class as the original bug; should read outs from structured
  operands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)