### PR TITLE
[Experimental] feat: func.call support — multi-func KTIR modules with persistent LX state

### DIFF
--- a/examples/triton-ktir/softmax_lx_fused.ktir
+++ b/examples/triton-ktir/softmax_lx_fused.ktir
@@ -1,0 +1,135 @@
+// Single-func, on-chip-fused KTIR — softmax(x) over [512, 1024] (reduce over the 1024 axis).
+//
+// Same 5 stages as softmax_multi.ktir (max, sub, exp, sum, div), but collapsed into ONE func with
+// ONE fixed grid = [32], and with NO intermediate HBM round-trips: the only HBM traffic is the
+// input load and the output store. The function therefore takes only %X (input) and %C (output) —
+// there are no %mx/%sb/%ex/%sm intermediate pointers (contrast softmax_multi.ktir).
+//
+// How the round-trips are removed: instead of letting each stage repartition (the planner's
+// {mb:16,out:2} / {mb:32,out:1} / {mb:1,out:32}), the kernel PINS one partition for the whole
+// kernel — the reduction layout {mb:16, out:2}:
+//     core = out*16 + mb ;  out in [0,2) -> 256 rows ;  mb in [0,16) -> one feature stick (64 wide)
+// so every core holds the SAME tile [256, 64] (its stick of its row-group) across all 5 stages.
+// Consequences:
+//   - max / sum are the only cross-core ops: a local reduce over the 64 width, then an
+//     inter_tile ALL-REDUCE over the 16-stick `mb` cohort (consumer set == producer set, so every
+//     core in the cohort ends with the full row max/sum — no reduce-to-one, no reload).
+//   - sub / exp / div are PURELY LOCAL: each core already holds its x tile and the all-reduced
+//     row max/sum, so they never touch HBM or another core.
+// This is the fusion "case (a)" win (fusing-triton-kernels.md §4.2): consecutive stages share the
+// slicing, so the hand-off stays on-chip in SSA rather than round-tripping HBM.
+//
+// PHYSICAL layout (data_dti.json): logical [512,1024] is stick-on-inner,
+//   sizes [16, 512, 64] = [stick, row, stick_width], strides [64, 1024, 1].
+// The stick index (dim 0) is the `mb` reduction-cohort axis, so the all-reduce runs over dim 0.
+
+#id3 = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+
+// Cross-core cohorts ({mb:16, out:2}): 16 contiguous tiles per group, 2 groups.
+// Tile i is in group g iff 16*g <= i <= 16*g + 15.  (i = core id = out*16 + mb)
+#cohort16 = affine_set<(i)[g] : (i - 16 * g >= 0, -i + 16 * g + 15 >= 0)>
+#groups2  = affine_set<(g) : (g >= 0, -g + 1 >= 0)>
+
+module @softmax_fused {
+  func.func @softmax(%X: index, %C: index)
+      attributes {grid = [32],
+                  // the reduction partition this kernel is pinned to (the other stages fuse onto it)
+                  numWkSlicesPerDim = {mb = 16, out = 2}} {
+    %c16 = arith.constant 16 : index
+    %c64 = arith.constant 64 : index
+    %c256 = arith.constant 256 : index
+    %c0 = arith.constant 0 : index
+    %ninf = arith.constant 0xFC00 : f16            // -inf, max identity
+    %zero = arith.constant 0.000000e+00 : f16       // 0, add identity
+
+    %pid = ktdp.get_compute_tile_id : index
+    %out = arith.divsi %pid, %c16 : index           // 0..1   (row group)
+    %mb  = arith.remsi %pid, %c16 : index           // 0..15  (feature stick / reduction lane)
+    %row0 = arith.muli %out, %c256 : index
+
+    // -------- load this core's tile once: stick %mb, rows [row0, row0+256), full 64 width --------
+    %xv = ktdp.construct_memory_view %X, sizes: [16, 512, 64], strides: [32768, 64, 1]
+            {memory_space = #ktdp.spyre_memory_space<HBM>} : memref<16x512x64xf16>
+    %xt = ktdp.construct_access_tile %xv[%mb, %row0, %c0]
+            {access_tile_set = affine_set<(d0, d1, d2) : (d0 >= 0, -d0 + 0 >= 0, d1 >= 0, -d1 + 255 >= 0, d2 >= 0, -d2 + 63 >= 0)>,
+             access_tile_order = #id3} : memref<16x512x64xf16> -> !ktdp.access_tile<1x256x64xindex>
+    %x3 = ktdp.load %xt : <1x256x64xindex> -> tensor<1x256x64xf16>
+    %x  = tensor.extract_slice %x3[0, 0, 0] [1, 256, 64] [1, 1, 1] : tensor<1x256x64xf16> to tensor<256x64xf16>
+
+    // ============ stage 0: max  (cross-core all-reduce over the `mb` cohort) ============
+    %m_init = tensor.empty() : tensor<256xf16>
+    %m_fill = linalg.fill ins(%ninf : f16) outs(%m_init : tensor<256xf16>) -> tensor<256xf16>
+    %lmax = linalg.reduce { arith.maxnumf } ins(%x : tensor<256x64xf16>)
+              outs(%m_fill : tensor<256xf16>) dimensions = [1]              // local max over the 64 width
+    %mid_e = tensor.empty() : tensor<256xf16>
+    %mid = linalg.fill ins(%ninf : f16) outs(%mid_e : tensor<256xf16>) -> tensor<256xf16>
+    %mfut = ktdp.inter_tile_produce
+        producer_tiles_per_group = #cohort16,
+        groups                   = #groups2
+        : tensor<256xf16> -> !ktdp.tile_future<tensor<256xf16>>
+    {
+      ^bb0(%gid: index):
+        ktdp.yield_partial %lmax : tensor<256xf16>
+    }
+    %rowmax = ktdp.inter_tile_reduce(%mfut)
+        consumer_tiles_per_group = #cohort16,
+        groups                   = #groups2,
+        identity(%mid : tensor<256xf16>)
+        : !ktdp.tile_future<tensor<256xf16>> -> tensor<256xf16>
+    {
+      ^bb0(%lhs: tensor<256xf16>, %rhs: tensor<256xf16>):
+        %mx = arith.maxnumf %lhs, %rhs : tensor<256xf16>
+        ktdp.yield_reduced %mx : tensor<256xf16>
+    }
+
+    // ============ stage 1: sub  (purely local — x and rowmax already on this core) ============
+    %sb_e = tensor.empty() : tensor<256x64xf16>
+    %max_b = linalg.broadcast ins(%rowmax : tensor<256xf16>) outs(%sb_e : tensor<256x64xf16>) dimensions = [1]
+    %xs = arith.subf %x, %max_b : tensor<256x64xf16>
+
+    // ============ stage 2: exp  (purely local) ============
+    %xe = math.exp %xs : tensor<256x64xf16>
+
+    // ============ stage 3: sum  (cross-core all-reduce over the `mb` cohort) ============
+    %s_init = tensor.empty() : tensor<256xf16>
+    %s_fill = linalg.fill ins(%zero : f16) outs(%s_init : tensor<256xf16>) -> tensor<256xf16>
+    %lsum = linalg.reduce { arith.addf } ins(%xe : tensor<256x64xf16>)
+              outs(%s_fill : tensor<256xf16>) dimensions = [1]              // local sum over the 64 width
+    %sid_e = tensor.empty() : tensor<256xf16>
+    %sid = linalg.fill ins(%zero : f16) outs(%sid_e : tensor<256xf16>) -> tensor<256xf16>
+    %sfut = ktdp.inter_tile_produce
+        producer_tiles_per_group = #cohort16,
+        groups                   = #groups2
+        : tensor<256xf16> -> !ktdp.tile_future<tensor<256xf16>>
+    {
+      ^bb0(%gid: index):
+        ktdp.yield_partial %lsum : tensor<256xf16>
+    }
+    %rowsum = ktdp.inter_tile_reduce(%sfut)
+        consumer_tiles_per_group = #cohort16,
+        groups                   = #groups2,
+        identity(%sid : tensor<256xf16>)
+        : !ktdp.tile_future<tensor<256xf16>> -> tensor<256xf16>
+    {
+      ^bb0(%lhs: tensor<256xf16>, %rhs: tensor<256xf16>):
+        %s = arith.addf %lhs, %rhs : tensor<256xf16>
+        ktdp.yield_reduced %s : tensor<256xf16>
+    }
+
+    // ============ stage 4: div  (purely local) ============
+    %db_e = tensor.empty() : tensor<256x64xf16>
+    %sum_b = linalg.broadcast ins(%rowsum : tensor<256xf16>) outs(%db_e : tensor<256x64xf16>) dimensions = [1]
+    %y = arith.divf %xe, %sum_b : tensor<256x64xf16>
+
+    // -------- store this core's output tile (the only other HBM access) --------
+    %y3_e = tensor.empty() : tensor<1x256x64xf16>
+    %y3 = tensor.insert_slice %y into %y3_e[0, 0, 0] [1, 256, 64] [1, 1, 1] : tensor<256x64xf16> into tensor<1x256x64xf16>
+    %cv = ktdp.construct_memory_view %C, sizes: [16, 512, 64], strides: [32768, 64, 1]
+            {memory_space = #ktdp.spyre_memory_space<HBM>} : memref<16x512x64xf16>
+    %ct = ktdp.construct_access_tile %cv[%mb, %row0, %c0]
+            {access_tile_set = affine_set<(d0, d1, d2) : (d0 >= 0, -d0 + 0 >= 0, d1 >= 0, -d1 + 255 >= 0, d2 >= 0, -d2 + 63 >= 0)>,
+             access_tile_order = #id3} : memref<16x512x64xf16> -> !ktdp.access_tile<1x256x64xindex>
+    ktdp.store %y3, %ct : tensor<1x256x64xf16>, <1x256x64xindex>
+    return
+  }
+}

--- a/examples/triton-ktir/softmax_lx_fused_calls.ktir
+++ b/examples/triton-ktir/softmax_lx_fused_calls.ktir
@@ -1,0 +1,314 @@
+// LX-fused softmax using func.call — 5 stages, zero intermediate HBM traffic.
+//
+// Demonstrates multi-func KTIR: the entry point @softmax sequences 5 subfunctions
+// via func.call at the top level.  Each stage runs the full 32-core grid and
+// communicates through per-core LX scratchpad (ktdp.construct_memory_view with
+// memory_space = #ktdp.spyre_memory_space<LX>).
+//
+// Key constraint: func.call ops must appear at the TOP LEVEL of a function body,
+// never inside an scf.for or scf.if region.  The interpreter executes each callee
+// as a complete grid synchronisation point; nesting calls inside loops would
+// interleave the scheduler's comm-delivery queues in undefined ways.
+//
+// HBM traffic: 1 read (X in stage_max) + 1 write (Y in stage_div) = 2 passes.
+//
+// LX layout (per-core, compile-time byte offsets — shapes are static):
+//   x_lx        524288   [1,256,64]×f16 = 32 768 B  (x tile after stage_max)
+//   max_lx      557056   [1,256, 1]×f16 =    512 B  (all-reduced rowmax)
+//   shifted_lx  557568   [1,256,64]×f16 = 32 768 B  (x − rowmax)
+//   exp_lx      590336   [1,256,64]×f16 = 32 768 B  (exp(x − rowmax))
+//   sum_lx      623104   [1,256, 1]×f16 =    512 B  (all-reduced rowsum)
+//   Total per core ≈ 99 KB  (well within 2 MB LX capacity)
+//
+// Base 512 KB = 524288 keeps persistent buffers well above the per-stage
+// temp watermark (~33 KB: only ktdp.load bumps lx.next_ptr; ktdp.store does not).
+//
+// Physical layout: [16, 512, 64] stick-major, strides [32768, 64, 1].
+// Partition: grid=[32], {mb:16, out:2}.  Core i = out*16 + mb; each core owns
+// a [256, 64] slice (256 rows × 64-wide feature stick).
+
+#id3      = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+#cohort16 = affine_set<(i)[g] : (i - 16 * g >= 0, -i + 16 * g + 15 >= 0)>
+#groups2  = affine_set<(g) : (g >= 0, -g + 1 >= 0)>
+
+// Shared access-tile coordinate sets.
+// Full [1,256,64] tile (x, shifted, exp):
+#full_tile   = affine_set<(d0, d1, d2) : (d0 >= 0, -d0 + 0 >= 0, d1 >= 0, -d1 + 255 >= 0, d2 >= 0, -d2 + 63 >= 0)>
+// Scalar [1,256,1] tile (rowmax, rowsum):
+#scalar_tile = affine_set<(d0, d1, d2) : (d0 >= 0, -d0 + 0 >= 0, d1 >= 0, -d1 + 255 >= 0, d2 >= 0, -d2 + 0 >= 0)>
+
+module @softmax_lx_fused_calls {
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // stage_max: load X from HBM, all-reduce rowmax, persist x tile + max in LX
+  // ─────────────────────────────────────────────────────────────────────────
+  func.func @stage_max(%X: index, %x_lx: index, %max_lx: index)
+      attributes {grid = [32], numWkSlicesPerDim = {mb = 16, out = 2}} {
+    %c0   = arith.constant 0 : index
+    %c16  = arith.constant 16 : index
+    %c256 = arith.constant 256 : index
+    %ninf = arith.constant 0xFC00 : f16
+
+    %pid  = ktdp.get_compute_tile_id : index
+    %out  = arith.divsi %pid, %c16 : index
+    %mb   = arith.remsi %pid, %c16 : index
+    %row0 = arith.muli %out, %c256 : index
+
+    // Load this core's [1,256,64] slice from HBM
+    %xv = ktdp.construct_memory_view %X, sizes: [16, 512, 64], strides: [32768, 64, 1]
+            {memory_space = #ktdp.spyre_memory_space<HBM>} : memref<16x512x64xf16>
+    %xt = ktdp.construct_access_tile %xv[%mb, %row0, %c0]
+            {access_tile_set = #full_tile,
+             access_tile_order = #id3} : memref<16x512x64xf16> -> !ktdp.access_tile<1x256x64xindex>
+    %x3 = ktdp.load %xt : <1x256x64xindex> -> tensor<1x256x64xf16>
+    %x  = tensor.extract_slice %x3[0, 0, 0] [1, 256, 64] [1, 1, 1]
+            : tensor<1x256x64xf16> to tensor<256x64xf16>
+
+    // Local reduce-max over the 64-wide feature stick
+    %m_init = tensor.empty() : tensor<256xf16>
+    %m_fill = linalg.fill ins(%ninf : f16) outs(%m_init : tensor<256xf16>) -> tensor<256xf16>
+    %lmax = linalg.reduce { arith.maxnumf } ins(%x : tensor<256x64xf16>)
+              outs(%m_fill : tensor<256xf16>) dimensions = [1]
+
+    // All-reduce rowmax across the 16-core mb cohort
+    %mid_e = tensor.empty() : tensor<256xf16>
+    %mid   = linalg.fill ins(%ninf : f16) outs(%mid_e : tensor<256xf16>) -> tensor<256xf16>
+    %mfut = ktdp.inter_tile_produce
+        producer_tiles_per_group = #cohort16,
+        groups                   = #groups2
+        : tensor<256xf16> -> !ktdp.tile_future<tensor<256xf16>>
+    {
+      ^bb0(%gid: index):
+        ktdp.yield_partial %lmax : tensor<256xf16>
+    }
+    %rowmax = ktdp.inter_tile_reduce(%mfut)
+        consumer_tiles_per_group = #cohort16,
+        groups                   = #groups2,
+        identity(%mid : tensor<256xf16>)
+        : !ktdp.tile_future<tensor<256xf16>> -> tensor<256xf16>
+    {
+      ^bb0(%lhs: tensor<256xf16>, %rhs: tensor<256xf16>):
+        %mx = arith.maxnumf %lhs, %rhs : tensor<256xf16>
+        ktdp.yield_reduced %mx : tensor<256xf16>
+    }
+
+    // Persist x tile in LX so stage_sub avoids re-reading HBM
+    %xlv = ktdp.construct_memory_view %x_lx, sizes: [1, 256, 64], strides: [16384, 64, 1]
+             {memory_space = #ktdp.spyre_memory_space<LX>} : memref<1x256x64xf16>
+    %xlt = ktdp.construct_access_tile %xlv[%c0, %c0, %c0]
+             {access_tile_set = #full_tile,
+              access_tile_order = #id3} : memref<1x256x64xf16> -> !ktdp.access_tile<1x256x64xindex>
+    ktdp.store %x3, %xlt : tensor<1x256x64xf16>, <1x256x64xindex>
+
+    // Persist rowmax in LX as [1,256,1]
+    %mlv = ktdp.construct_memory_view %max_lx, sizes: [1, 256, 1], strides: [256, 1, 1]
+             {memory_space = #ktdp.spyre_memory_space<LX>} : memref<1x256x1xf16>
+    %mlt = ktdp.construct_access_tile %mlv[%c0, %c0, %c0]
+             {access_tile_set = #scalar_tile,
+              access_tile_order = #id3} : memref<1x256x1xf16> -> !ktdp.access_tile<1x256x1xindex>
+    %max3_e = tensor.empty() : tensor<1x256x1xf16>
+    %max3   = tensor.insert_slice %rowmax into %max3_e[0, 0, 0] [1, 256, 1] [1, 1, 1]
+                : tensor<256xf16> into tensor<1x256x1xf16>
+    ktdp.store %max3, %mlt : tensor<1x256x1xf16>, <1x256x1xindex>
+    return
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // stage_sub: read x and rowmax from LX, compute x - rowmax, store to LX
+  // ─────────────────────────────────────────────────────────────────────────
+  func.func @stage_sub(%x_lx: index, %max_lx: index, %shifted_lx: index)
+      attributes {grid = [32], numWkSlicesPerDim = {mb = 16, out = 2}} {
+    %c0 = arith.constant 0 : index
+
+    %xlv = ktdp.construct_memory_view %x_lx, sizes: [1, 256, 64], strides: [16384, 64, 1]
+             {memory_space = #ktdp.spyre_memory_space<LX>} : memref<1x256x64xf16>
+    %xlt = ktdp.construct_access_tile %xlv[%c0, %c0, %c0]
+             {access_tile_set = #full_tile,
+              access_tile_order = #id3} : memref<1x256x64xf16> -> !ktdp.access_tile<1x256x64xindex>
+    %x3 = ktdp.load %xlt : <1x256x64xindex> -> tensor<1x256x64xf16>
+    %x  = tensor.extract_slice %x3[0, 0, 0] [1, 256, 64] [1, 1, 1]
+            : tensor<1x256x64xf16> to tensor<256x64xf16>
+
+    %mlv = ktdp.construct_memory_view %max_lx, sizes: [1, 256, 1], strides: [256, 1, 1]
+             {memory_space = #ktdp.spyre_memory_space<LX>} : memref<1x256x1xf16>
+    %mlt = ktdp.construct_access_tile %mlv[%c0, %c0, %c0]
+             {access_tile_set = #scalar_tile,
+              access_tile_order = #id3} : memref<1x256x1xf16> -> !ktdp.access_tile<1x256x1xindex>
+    %max3   = ktdp.load %mlt : <1x256x1xindex> -> tensor<1x256x1xf16>
+    %rowmax = tensor.extract_slice %max3[0, 0, 0] [1, 256, 1] [1, 1, 1]
+                : tensor<1x256x1xf16> to tensor<256xf16>
+
+    %sb_e  = tensor.empty() : tensor<256x64xf16>
+    %max_b = linalg.broadcast ins(%rowmax : tensor<256xf16>)
+               outs(%sb_e : tensor<256x64xf16>) dimensions = [1]
+    %xs = arith.subf %x, %max_b : tensor<256x64xf16>
+
+    %slv = ktdp.construct_memory_view %shifted_lx, sizes: [1, 256, 64], strides: [16384, 64, 1]
+             {memory_space = #ktdp.spyre_memory_space<LX>} : memref<1x256x64xf16>
+    %slt = ktdp.construct_access_tile %slv[%c0, %c0, %c0]
+             {access_tile_set = #full_tile,
+              access_tile_order = #id3} : memref<1x256x64xf16> -> !ktdp.access_tile<1x256x64xindex>
+    %xs3_e = tensor.empty() : tensor<1x256x64xf16>
+    %xs3   = tensor.insert_slice %xs into %xs3_e[0, 0, 0] [1, 256, 64] [1, 1, 1]
+               : tensor<256x64xf16> into tensor<1x256x64xf16>
+    ktdp.store %xs3, %slt : tensor<1x256x64xf16>, <1x256x64xindex>
+    return
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // stage_exp: read shifted from LX, compute exp, store to LX
+  // ─────────────────────────────────────────────────────────────────────────
+  func.func @stage_exp(%shifted_lx: index, %exp_lx: index)
+      attributes {grid = [32], numWkSlicesPerDim = {mb = 16, out = 2}} {
+    %c0 = arith.constant 0 : index
+
+    %slv = ktdp.construct_memory_view %shifted_lx, sizes: [1, 256, 64], strides: [16384, 64, 1]
+             {memory_space = #ktdp.spyre_memory_space<LX>} : memref<1x256x64xf16>
+    %slt = ktdp.construct_access_tile %slv[%c0, %c0, %c0]
+             {access_tile_set = #full_tile,
+              access_tile_order = #id3} : memref<1x256x64xf16> -> !ktdp.access_tile<1x256x64xindex>
+    %xs3 = ktdp.load %slt : <1x256x64xindex> -> tensor<1x256x64xf16>
+    %xs  = tensor.extract_slice %xs3[0, 0, 0] [1, 256, 64] [1, 1, 1]
+             : tensor<1x256x64xf16> to tensor<256x64xf16>
+
+    %xe = math.exp %xs : tensor<256x64xf16>
+
+    %elv = ktdp.construct_memory_view %exp_lx, sizes: [1, 256, 64], strides: [16384, 64, 1]
+             {memory_space = #ktdp.spyre_memory_space<LX>} : memref<1x256x64xf16>
+    %elt = ktdp.construct_access_tile %elv[%c0, %c0, %c0]
+             {access_tile_set = #full_tile,
+              access_tile_order = #id3} : memref<1x256x64xf16> -> !ktdp.access_tile<1x256x64xindex>
+    %xe3_e = tensor.empty() : tensor<1x256x64xf16>
+    %xe3   = tensor.insert_slice %xe into %xe3_e[0, 0, 0] [1, 256, 64] [1, 1, 1]
+               : tensor<256x64xf16> into tensor<1x256x64xf16>
+    ktdp.store %xe3, %elt : tensor<1x256x64xf16>, <1x256x64xindex>
+    return
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // stage_sum: read exp from LX, all-reduce rowsum, persist sum in LX
+  // ─────────────────────────────────────────────────────────────────────────
+  func.func @stage_sum(%exp_lx: index, %sum_lx: index)
+      attributes {grid = [32], numWkSlicesPerDim = {mb = 16, out = 2}} {
+    %c0   = arith.constant 0 : index
+    %zero = arith.constant 0.000000e+00 : f16
+
+    %elv = ktdp.construct_memory_view %exp_lx, sizes: [1, 256, 64], strides: [16384, 64, 1]
+             {memory_space = #ktdp.spyre_memory_space<LX>} : memref<1x256x64xf16>
+    %elt = ktdp.construct_access_tile %elv[%c0, %c0, %c0]
+             {access_tile_set = #full_tile,
+              access_tile_order = #id3} : memref<1x256x64xf16> -> !ktdp.access_tile<1x256x64xindex>
+    %xe3 = ktdp.load %elt : <1x256x64xindex> -> tensor<1x256x64xf16>
+    %xe  = tensor.extract_slice %xe3[0, 0, 0] [1, 256, 64] [1, 1, 1]
+             : tensor<1x256x64xf16> to tensor<256x64xf16>
+
+    %s_init = tensor.empty() : tensor<256xf16>
+    %s_fill = linalg.fill ins(%zero : f16) outs(%s_init : tensor<256xf16>) -> tensor<256xf16>
+    %lsum = linalg.reduce { arith.addf } ins(%xe : tensor<256x64xf16>)
+              outs(%s_fill : tensor<256xf16>) dimensions = [1]
+
+    // All-reduce sum across the 16-core mb cohort
+    %sid_e = tensor.empty() : tensor<256xf16>
+    %sid   = linalg.fill ins(%zero : f16) outs(%sid_e : tensor<256xf16>) -> tensor<256xf16>
+    %sfut = ktdp.inter_tile_produce
+        producer_tiles_per_group = #cohort16,
+        groups                   = #groups2
+        : tensor<256xf16> -> !ktdp.tile_future<tensor<256xf16>>
+    {
+      ^bb0(%gid: index):
+        ktdp.yield_partial %lsum : tensor<256xf16>
+    }
+    %rowsum = ktdp.inter_tile_reduce(%sfut)
+        consumer_tiles_per_group = #cohort16,
+        groups                   = #groups2,
+        identity(%sid : tensor<256xf16>)
+        : !ktdp.tile_future<tensor<256xf16>> -> tensor<256xf16>
+    {
+      ^bb0(%lhs: tensor<256xf16>, %rhs: tensor<256xf16>):
+        %s = arith.addf %lhs, %rhs : tensor<256xf16>
+        ktdp.yield_reduced %s : tensor<256xf16>
+    }
+
+    %slv = ktdp.construct_memory_view %sum_lx, sizes: [1, 256, 1], strides: [256, 1, 1]
+             {memory_space = #ktdp.spyre_memory_space<LX>} : memref<1x256x1xf16>
+    %slt = ktdp.construct_access_tile %slv[%c0, %c0, %c0]
+             {access_tile_set = #scalar_tile,
+              access_tile_order = #id3} : memref<1x256x1xf16> -> !ktdp.access_tile<1x256x1xindex>
+    %sum3_e = tensor.empty() : tensor<1x256x1xf16>
+    %sum3   = tensor.insert_slice %rowsum into %sum3_e[0, 0, 0] [1, 256, 1] [1, 1, 1]
+                : tensor<256xf16> into tensor<1x256x1xf16>
+    ktdp.store %sum3, %slt : tensor<1x256x1xf16>, <1x256x1xindex>
+    return
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // stage_div: read exp and rowsum from LX, compute exp/rowsum, write Y to HBM
+  // ─────────────────────────────────────────────────────────────────────────
+  func.func @stage_div(%exp_lx: index, %sum_lx: index, %Y: index)
+      attributes {grid = [32], numWkSlicesPerDim = {mb = 16, out = 2}} {
+    %c0   = arith.constant 0 : index
+    %c16  = arith.constant 16 : index
+    %c256 = arith.constant 256 : index
+
+    %pid  = ktdp.get_compute_tile_id : index
+    %out  = arith.divsi %pid, %c16 : index
+    %mb   = arith.remsi %pid, %c16 : index
+    %row0 = arith.muli %out, %c256 : index
+
+    %elv = ktdp.construct_memory_view %exp_lx, sizes: [1, 256, 64], strides: [16384, 64, 1]
+             {memory_space = #ktdp.spyre_memory_space<LX>} : memref<1x256x64xf16>
+    %elt = ktdp.construct_access_tile %elv[%c0, %c0, %c0]
+             {access_tile_set = #full_tile,
+              access_tile_order = #id3} : memref<1x256x64xf16> -> !ktdp.access_tile<1x256x64xindex>
+    %xe3 = ktdp.load %elt : <1x256x64xindex> -> tensor<1x256x64xf16>
+    %xe  = tensor.extract_slice %xe3[0, 0, 0] [1, 256, 64] [1, 1, 1]
+             : tensor<1x256x64xf16> to tensor<256x64xf16>
+
+    %slv = ktdp.construct_memory_view %sum_lx, sizes: [1, 256, 1], strides: [256, 1, 1]
+             {memory_space = #ktdp.spyre_memory_space<LX>} : memref<1x256x1xf16>
+    %slt = ktdp.construct_access_tile %slv[%c0, %c0, %c0]
+             {access_tile_set = #scalar_tile,
+              access_tile_order = #id3} : memref<1x256x1xf16> -> !ktdp.access_tile<1x256x1xindex>
+    %sum3   = ktdp.load %slt : <1x256x1xindex> -> tensor<1x256x1xf16>
+    %rowsum = tensor.extract_slice %sum3[0, 0, 0] [1, 256, 1] [1, 1, 1]
+                : tensor<1x256x1xf16> to tensor<256xf16>
+
+    %db_e  = tensor.empty() : tensor<256x64xf16>
+    %sum_b = linalg.broadcast ins(%rowsum : tensor<256xf16>)
+               outs(%db_e : tensor<256x64xf16>) dimensions = [1]
+    %y = arith.divf %xe, %sum_b : tensor<256x64xf16>
+
+    %y3_e = tensor.empty() : tensor<1x256x64xf16>
+    %y3   = tensor.insert_slice %y into %y3_e[0, 0, 0] [1, 256, 64] [1, 1, 1]
+              : tensor<256x64xf16> into tensor<1x256x64xf16>
+    %cv = ktdp.construct_memory_view %Y, sizes: [16, 512, 64], strides: [32768, 64, 1]
+            {memory_space = #ktdp.spyre_memory_space<HBM>} : memref<16x512x64xf16>
+    %ct = ktdp.construct_access_tile %cv[%mb, %row0, %c0]
+            {access_tile_set = #full_tile,
+             access_tile_order = #id3} : memref<16x512x64xf16> -> !ktdp.access_tile<1x256x64xindex>
+    ktdp.store %y3, %ct : tensor<1x256x64xf16>, <1x256x64xindex>
+    return
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // @softmax: entry point.
+  //
+  // All func.call ops are at the top level — not inside any scf.for/scf.if.
+  // LX base addresses are arith.constant (compile-time; shapes are static).
+  // ─────────────────────────────────────────────────────────────────────────
+  func.func @softmax(%X: index, %Y: index)
+      attributes {grid = [32], numWkSlicesPerDim = {mb = 16, out = 2}} {
+    %x_lx       = arith.constant 524288 : index
+    %max_lx     = arith.constant 557056 : index
+    %shifted_lx = arith.constant 557568 : index
+    %exp_lx     = arith.constant 590336 : index
+    %sum_lx     = arith.constant 623104 : index
+
+    func.call @stage_max(%X, %x_lx, %max_lx)               : (index, index, index) -> ()
+    func.call @stage_sub(%x_lx, %max_lx, %shifted_lx)      : (index, index, index) -> ()
+    func.call @stage_exp(%shifted_lx, %exp_lx)              : (index, index) -> ()
+    func.call @stage_sum(%exp_lx, %sum_lx)                  : (index, index) -> ()
+    func.call @stage_div(%exp_lx, %sum_lx, %Y)              : (index, index, index) -> ()
+    return
+  }
+}

--- a/ktir_cpu/dialects/__init__.py
+++ b/ktir_cpu/dialects/__init__.py
@@ -21,6 +21,7 @@ imports of the individual dialect modules.
 
 from . import (  # noqa: F401 — imported for registration side effects
     arith_ops,
+    func_ops,
     ktdp_ops,
     linalg_ops,
     math_ops,

--- a/ktir_cpu/dialects/func_ops.py
+++ b/ktir_cpu/dialects/func_ops.py
@@ -1,0 +1,97 @@
+# Copyright 2025 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""func dialect handlers — func.return, func.call."""
+
+import re
+
+from ..ir_types import Operation
+from .registry import register, register_parser
+
+
+@register("func.return")
+def func__return(op, context, env):
+    if op.operands:
+        return context.get_value(op.operands[0])
+    return None
+
+
+# Bare "return" is a common alias used in many KTIR examples.
+@register("return")
+def _return_alias(op, context, env):
+    return func__return(op, context, env)
+
+
+@register("func.call")
+def func__call(op, context, env):
+    """Execute a func.call by inlining the callee in a fresh scope.
+
+    Pushes a new scope for the callee so callee-local SSA values don't
+    collide with caller values.  LX state (ktdp.store writes) persists
+    across func.call boundaries — only the per-stage temp watermark is
+    rewound on scope pop, not the persistent LX region above it.
+
+    Constraint: func.call must appear at the top level of a function
+    body, not inside an scf.for or scf.if region.
+    """
+    callee_name = op.attributes["callee"]
+    callee = env.module.get_function(callee_name)
+
+    # Resolve caller operands before scope / use_counts swap so peeking uses
+    # the caller's use_counts (no premature consumption of caller values).
+    arg_values = [context.get_value(operand, peek=True) for operand in op.operands]
+
+    # Push callee scope; swap use_counts so last-use tracking is correct inside.
+    context.push_scope()
+    caller_use_counts = context._use_counts
+    context._use_counts = callee.use_counts
+
+    # Bind callee args (charge=False — these are passed-in scalars, no LX).
+    for param, val in zip(callee.arg_names, arg_values):
+        context.set_value("%" + param, val, charge=False)
+
+    # Execute callee body; propagate comm yields so the scheduler sees them.
+    result = yield from env.execute_region_with_comms(context, callee.operations)
+
+    # Pop scope (frees callee Tiles, rewinds lx.next_ptr) and restore use_counts.
+    context.pop_scope()
+    context._use_counts = caller_use_counts
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Parsers
+# ---------------------------------------------------------------------------
+
+@register_parser("func.call")
+def parse_func_call(op_text, parse_ctx):
+    """Parse func.call — void and single-result forms.
+
+    Syntax (void):   func.call @name(%a, %b) : (index, index) -> ()
+    Syntax (value):  func.call @name(%a) : (index) -> index
+    """
+    m = re.match(r'func\.call\s+@(\w+)\s*\(([^)]*)\)', op_text)
+    if not m:
+        return None
+    callee = m.group(1)
+    args_text = m.group(2).strip()
+    operands = re.findall(r'%\w+', args_text) if args_text else []
+    return Operation(
+        result=None,
+        op_type="func.call",
+        operands=operands,
+        attributes={"callee": callee},
+        result_type=None,
+    )

--- a/ktir_cpu/dialects/ktdp_helpers.py
+++ b/ktir_cpu/dialects/ktdp_helpers.py
@@ -205,4 +205,6 @@ def attach_reshape(gen, target_shape):
     closure.
     """
     reduced = yield from gen
+    if reduced is None:
+        return None
     return reshape_tile_to_target(reduced, target_shape)

--- a/ktir_cpu/dialects/linalg_ops.py
+++ b/ktir_cpu/dialects/linalg_ops.py
@@ -246,20 +246,27 @@ def linalg__reduce(op, context, env):
     return result
 
 
-@register("linalg.add", latency_category=LC.COMPUTE_FLOAT)
-def linalg__add(op, context, env):
-    """Elementwise tensor add — ``%c = linalg.add ins(%a, %b) outs(%init)``.
+_LINALG_BINOP = {
+    "linalg.add": lambda a, b: a + b,
+    "linalg.max": np.maximum,
+}
 
-    Standard MLIR named op: result = a + b (the outs buffer provides the
-    destination shape only; its values are not accumulated into in v1).
+
+@register("linalg.add", "linalg.max", latency_category=LC.COMPUTE_FLOAT)
+def linalg__binop(op, context, env):
+    """Elementwise binary named ops (add, max) — ins(%a, %b) outs(%init).
+
+    The outs buffer provides the destination shape only; its values are
+    not accumulated into the result.
     """
     tile_a = context.get_value(op.operands[0])
     tile_b = context.get_value(op.operands[1])
     if not isinstance(tile_a, Tile) or not isinstance(tile_b, Tile):
         raise TypeError(
-            f"linalg.add: ins must be Tiles, got {type(tile_a)} and {type(tile_b)}"
+            f"{op.op_type}: ins must be Tiles, got {type(tile_a)} and {type(tile_b)}"
         )
-    return Tile(tile_a.data + tile_b.data, tile_a.dtype, tile_a.shape)
+    fn = _LINALG_BINOP[op.op_type]
+    return Tile(fn(tile_a.data, tile_b.data), tile_a.dtype, tile_a.shape)
 
 
 @register("linalg.fill")

--- a/ktir_cpu/dialects/registry.py
+++ b/ktir_cpu/dialects/registry.py
@@ -198,3 +198,5 @@ class ExecutionEnv:
     # may contain comm ops.  When None, scf handlers fall back to a thin
     # generator wrapper around execute_region (no comm ops will be scheduled).
     execute_region_with_comms: Callable[[CoreContext, List[Operation]], Any] = None
+    # IRModule — set at runtime so func.call handlers can look up callees.
+    module: Any = None

--- a/ktir_cpu/dialects/scf_ops.py
+++ b/ktir_cpu/dialects/scf_ops.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""SCF / func dialect handlers — if, for, yield, return."""
+"""SCF dialect handlers — scf.if, scf.for, scf.yield."""
 
 import re
 
@@ -87,55 +87,6 @@ def scf__for(op, context, env):
 def scf__yield(op, context, env):
     values = [context.get_value(name) for name in op.operands]
     return ControlOps.yield_op(values)
-
-
-@register("func.return")
-def func__return(op, context, env):
-    if op.operands:
-        return context.get_value(op.operands[0])
-    return None
-
-
-# Also register the bare "return" alias
-@register("return")
-def _return_alias(op, context, env):
-    return func__return(op, context, env)
-
-
-@register("func.call")
-def func__call(op, context, env):
-    """Execute a func.call by inlining the callee in a fresh scope.
-
-    Pushes a new scope for the callee so callee-local SSA values don't
-    collide with caller values.  LX state (lx.memory writes from
-    ktdp.store) survives scope boundaries so data stored to alloc_lx
-    buffers persists across func.call boundaries.
-    """
-    callee_name = op.attributes["callee"]
-    callee = env.module.get_function(callee_name)
-
-    # Resolve caller operands before scope / use_counts swap so peeking uses
-    # the main function's use_counts (no premature consumption of caller vals).
-    arg_values = [context.get_value(operand, peek=True) for operand in op.operands]
-
-    # Push callee scope; swap use_counts so last-use tracking is correct inside.
-    context.push_scope()
-    caller_use_counts = context._use_counts
-    context._use_counts = callee.use_counts
-
-    # Bind callee args (all index scalars — charge=False, no LX to track).
-    for param, val in zip(callee.arg_names, arg_values):
-        context.set_value("%" + param, val, charge=False)
-
-    # Execute callee body; propagate comm yields upward so the scheduler sees them.
-    result = yield from env.execute_region_with_comms(context, callee.operations)
-
-    # Restore: pop scope (frees callee's Tiles, rewinds lx.next_ptr) and
-    # restore caller's use_counts.
-    context.pop_scope()
-    context._use_counts = caller_use_counts
-
-    return result
 
 
 # ---------------------------------------------------------------------------
@@ -224,23 +175,3 @@ def parse_scf_yield(op_text, parse_ctx):
     )
 
 
-@register_parser("func.call")
-def parse_func_call(op_text, parse_ctx):
-    """Parse func.call — both void and single-result forms.
-
-    Syntax (void):   func.call @name(%a, %b) : (index, index) -> ()
-    Syntax (value):  func.call @name(%a) : (index) -> index
-    """
-    m = re.match(r'func\.call\s+@(\w+)\s*\(([^)]*)\)', op_text)
-    if not m:
-        return None
-    callee = m.group(1)
-    args_text = m.group(2).strip()
-    operands = re.findall(r'%\w+', args_text) if args_text else []
-    return Operation(
-        result=None,
-        op_type="func.call",
-        operands=operands,
-        attributes={"callee": callee},
-        result_type=None,
-    )

--- a/ktir_cpu/dialects/scf_ops.py
+++ b/ktir_cpu/dialects/scf_ops.py
@@ -102,6 +102,42 @@ def _return_alias(op, context, env):
     return func__return(op, context, env)
 
 
+@register("func.call")
+def func__call(op, context, env):
+    """Execute a func.call by inlining the callee in a fresh scope.
+
+    Pushes a new scope for the callee so callee-local SSA values don't
+    collide with caller values.  LX state (lx.memory writes from
+    ktdp.store) survives scope boundaries so data stored to alloc_lx
+    buffers persists across func.call boundaries.
+    """
+    callee_name = op.attributes["callee"]
+    callee = env.module.get_function(callee_name)
+
+    # Resolve caller operands before scope / use_counts swap so peeking uses
+    # the main function's use_counts (no premature consumption of caller vals).
+    arg_values = [context.get_value(operand, peek=True) for operand in op.operands]
+
+    # Push callee scope; swap use_counts so last-use tracking is correct inside.
+    context.push_scope()
+    caller_use_counts = context._use_counts
+    context._use_counts = callee.use_counts
+
+    # Bind callee args (all index scalars — charge=False, no LX to track).
+    for param, val in zip(callee.arg_names, arg_values):
+        context.set_value("%" + param, val, charge=False)
+
+    # Execute callee body; propagate comm yields upward so the scheduler sees them.
+    result = yield from env.execute_region_with_comms(context, callee.operations)
+
+    # Restore: pop scope (frees callee's Tiles, rewinds lx.next_ptr) and
+    # restore caller's use_counts.
+    context.pop_scope()
+    context._use_counts = caller_use_counts
+
+    return result
+
+
 # ---------------------------------------------------------------------------
 # Parsers
 # ---------------------------------------------------------------------------
@@ -184,5 +220,27 @@ def parse_scf_yield(op_text, parse_ctx):
         op_type="scf.yield",
         operands=operands,
         attributes={},
+        result_type=None,
+    )
+
+
+@register_parser("func.call")
+def parse_func_call(op_text, parse_ctx):
+    """Parse func.call — both void and single-result forms.
+
+    Syntax (void):   func.call @name(%a, %b) : (index, index) -> ()
+    Syntax (value):  func.call @name(%a) : (index) -> index
+    """
+    m = re.match(r'func\.call\s+@(\w+)\s*\(([^)]*)\)', op_text)
+    if not m:
+        return None
+    callee = m.group(1)
+    args_text = m.group(2).strip()
+    operands = re.findall(r'%\w+', args_text) if args_text else []
+    return Operation(
+        result=None,
+        op_type="func.call",
+        operands=operands,
+        attributes={"callee": callee},
         result_type=None,
     )

--- a/ktir_cpu/interpreter.py
+++ b/ktir_cpu/interpreter.py
@@ -112,6 +112,7 @@ class KTIRInterpreter:
             grid_executor=self.grid_executor,
             execute_region=self.execute_region,
             execute_region_with_comms=self.execute_region_with_comms,
+            module=self.module,
         )
         if self._latency_tracker is not None:
             self._latency_tracker.reset()

--- a/ktir_cpu/mlir_frontend/parser.py
+++ b/ktir_cpu/mlir_frontend/parser.py
@@ -134,9 +134,19 @@ class MLIRTypeAdapter:
         handler(mlir_op, attributes, result_type, operands)
 
         from ..dialects.registry import is_inplace_outs
-        from ..parser_utils import extract_outs_operands
-        outs_operands = (extract_outs_operands(mlir_op.get_asm())
+        from ..parser_utils import extract_outs_operands, extract_bb0_arg_names
+        op_asm = mlir_op.get_asm()
+        outs_operands = (extract_outs_operands(op_asm)
                          if is_inplace_outs(mlir_op.name) else [])
+        bb0_names = extract_bb0_arg_names(op_asm)
+        if bb0_names and regions:
+            regions[0].insert(0, Operation(
+                result=None,
+                op_type="region.bb0_args",
+                operands=[],
+                attributes={"names": bb0_names},
+                result_type=None,
+            ))
 
         return Operation(
             result=result,
@@ -149,18 +159,7 @@ class MLIRTypeAdapter:
         )
 
     def adapt_block(self, block) -> List[Operation]:
-        ops = []
-        block_args = list(block.arguments)
-        if block_args:
-            ops.append(Operation(
-                result=None,
-                op_type="region.bb0_args",
-                operands=[],
-                attributes={"names": [a.get_name() for a in block_args]},
-                result_type=None,
-            ))
-        ops.extend(self.adapt_op(op) for op in block.operations)
-        return ops
+        return [self.adapt_op(op) for op in block.operations]
 
 
 # ---------------------------------------------------------------------------
@@ -174,6 +173,7 @@ def _no_attrs(mlir_op, attributes, result_type, operands):
 MLIRTypeAdapter.install(
     "func.return",
     "linalg.add",
+    "linalg.max",
     "linalg.fill",
     "linalg.yield",
     "scf.yield",

--- a/ktir_cpu/mlir_frontend/parser.py
+++ b/ktir_cpu/mlir_frontend/parser.py
@@ -149,7 +149,18 @@ class MLIRTypeAdapter:
         )
 
     def adapt_block(self, block) -> List[Operation]:
-        return [self.adapt_op(op) for op in block.operations]
+        ops = []
+        block_args = list(block.arguments)
+        if block_args:
+            ops.append(Operation(
+                result=None,
+                op_type="region.bb0_args",
+                operands=[],
+                attributes={"names": [a.get_name() for a in block_args]},
+                result_type=None,
+            ))
+        ops.extend(self.adapt_op(op) for op in block.operations)
+        return ops
 
 
 # ---------------------------------------------------------------------------
@@ -167,6 +178,8 @@ MLIRTypeAdapter.install(
     "linalg.yield",
     "scf.yield",
     "scf.if",
+    "ktdp.yield_partial",
+    "ktdp.yield_reduced",
     # float binary
     "arith.addf", "arith.subf", "arith.mulf", "arith.divf", "arith.remf",
     # float unary
@@ -656,6 +669,54 @@ def _adapt_tensor_generate(mlir_op, attributes, result_type, operands):
         raise ValueError(f"tensor.generate: cannot parse result type {result_type!r}")
     attributes["shape"] = info["shape"]
     attributes["dtype"] = info["dtype"]
+
+
+@MLIRTypeAdapter.install("ktdp.inter_tile_produce")
+def _adapt_inter_tile_produce(mlir_op, attributes, result_type, operands):
+    """Extract producer_tiles_per_group, groups, and partial_tensor_types from result type.
+
+    result_type is "!ktdp.tile_future<T_p_1, ...>" — split the inner content to
+    produce partial_tensor_types, matching what the regex parser produces.
+    """
+    from ..parser_utils import split_top_level
+    attributes["producer_tiles_per_group"] = parse_affine_set(
+        str(mlir_op.attributes["producer_tiles_per_group"])
+    )
+    attributes["groups"] = parse_affine_set(
+        str(mlir_op.attributes["groups"])
+    )
+    # Parse "!ktdp.tile_future<T1, T2, ...>" → ("T1", "T2", ...)
+    m = re.match(r"!ktdp\.tile_future<(.+)>", result_type or "")
+    if not m:
+        raise ValueError(
+            f"ktdp.inter_tile_produce: cannot parse tile_future result type {result_type!r}"
+        )
+    inner = m.group(1).strip()
+    attributes["partial_tensor_types"] = tuple(
+        p.strip() for p in split_top_level(inner)
+    )
+
+
+@MLIRTypeAdapter.install("ktdp.inter_tile_reduce")
+def _adapt_inter_tile_reduce(mlir_op, attributes, result_type, operands):
+    """Extract consumer_tiles_per_group, groups, optional producer_dependency_per_consumer,
+    and _result_shape from the result type, matching the regex parser's output.
+    """
+    from ..parser_utils import parse_tensor_type
+    attributes["consumer_tiles_per_group"] = parse_affine_set(
+        str(mlir_op.attributes["consumer_tiles_per_group"])
+    )
+    attributes["groups"] = parse_affine_set(
+        str(mlir_op.attributes["groups"])
+    )
+    if "producer_dependency_per_consumer" in mlir_op.attributes:
+        attributes["producer_dependency_per_consumer"] = parse_affine_set(
+            str(mlir_op.attributes["producer_dependency_per_consumer"])
+        )
+    if result_type is not None:
+        parsed = parse_tensor_type(result_type)
+        if parsed is not None:
+            attributes["_result_shape"] = parsed["shape"]
 
 
 _DYNAMIC_SIZE = -(1 << 63)  # ShapedType::kDynamic in MLIR

--- a/ktir_cpu/mlir_frontend/parser.py
+++ b/ktir_cpu/mlir_frontend/parser.py
@@ -226,6 +226,12 @@ MLIRTypeAdapter.install(
 )(_no_attrs)
 
 
+@MLIRTypeAdapter.install("func.call")
+def _adapt_func_call(mlir_op, attributes, result_type, operands):
+    """Extract callee name from FlatSymbolRefAttr (e.g. '@name' → 'name')."""
+    attributes["callee"] = str(mlir_op.attributes["callee"]).lstrip("@")
+
+
 @MLIRTypeAdapter.install("scf.for")
 def _adapt_scf_for(mlir_op, attributes, result_type, operands):
     """Synthesize iter_var / iter_args from block arguments."""

--- a/ktir_cpu/parser.py
+++ b/ktir_cpu/parser.py
@@ -107,14 +107,23 @@ class KTIRParser(KTIRParserBase):
 
         # Find each func.func declaration and extract the body using
         # brace counting, which correctly skips the attributes { ... } block.
-        for match in re.finditer(r'func\.func\s+@(\w+)\s*\(([^)]*)\)', mlir_text):
+        # Collect all matches first so we can bound each function's search region.
+        all_func_matches = list(re.finditer(r'func\.func\s+@(\w+)\s*\(([^)]*)\)', mlir_text))
+        for idx, match in enumerate(all_func_matches):
             func_name = match.group(1)
             func_header_end = match.end()
+
+            # Limit search to text before the next func.func declaration so that
+            # _extract_brace_body cannot accidentally pick up a later function's body.
+            if idx + 1 < len(all_func_matches):
+                search_end = all_func_matches[idx + 1].start()
+            else:
+                search_end = len(mlir_text)
 
             # Extract the full header up to the body-opening brace.
             # There may be an attributes { ... } block before the body { ... }.
             # We skip brace-balanced blocks until we find the body.
-            func_body, body_end = self._extract_brace_body(mlir_text, func_header_end)
+            func_body, body_end = self._extract_brace_body(mlir_text[:search_end], func_header_end)
             if func_body is None:
                 continue
 
@@ -435,6 +444,9 @@ class KTIRParser(KTIRParserBase):
         # Match as op names (start of line or after `= `) to avoid false hits
         # on SSA names like `%sum_returned_val`.
         if re.match(r'(?:%\w+\s*=\s*)?(?:return\b|\w+\.yield\b)', text):
+            return True
+        # Void function-call return type: `-> ()`.
+        if re.search(r'->\s*\(\s*\)\s*$', text):
             return True
         # Type annotation: `: <type>` or `-> <type>` at end
         if self._TYPE_TERMINAL_RE.search(text):

--- a/ktir_cpu/parser_utils.py
+++ b/ktir_cpu/parser_utils.py
@@ -31,6 +31,21 @@ def find_ssa_names(text: str) -> list[str]:
 
 
 _OUTS_RE = re.compile(r'\bouts\s*\(([^)]+)\)')
+_BB0_RE = re.compile(r'\^bb0\s*\(([^)]*)\)')
+
+
+def extract_bb0_arg_names(op_text: str) -> list[str]:
+    """Extract block argument names from a ``^bb0(...)`` label in *op_text*.
+
+    Returns the list of SSA names (e.g. ``['%arg3', '%arg4']``) when the op's
+    ASM contains a region body with explicit block arguments, or an empty list
+    when no ``^bb0(...)`` label is present (e.g. scf.for, which carries its
+    block-arg names as op attributes instead).
+    """
+    m = _BB0_RE.search(op_text)
+    if not m:
+        return []
+    return find_ssa_names(m.group(1))
 
 
 def extract_outs_operands(op_text: str) -> list[str]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -281,6 +281,23 @@ EXAMPLE_PARAMS: dict[str, list[dict]] = {
         },
     ],
     # ---------------------------------------------------------------------------
+    # LX-fused softmax examples (multi-func via func.call and single-func)
+    # ---------------------------------------------------------------------------
+    "softmax": [
+        {
+            "path": "triton-ktir/softmax_lx_fused.ktir",
+            # Single func.func — 5 stages inlined, 2 HBM passes.
+            # Entry: @softmax(%X: index, %C: index), grid=[32].
+            "execute_kwargs": {},
+        },
+        {
+            "path": "triton-ktir/softmax_lx_fused_calls.ktir",
+            # Multi-func — 5 stage subfunctions called via top-level func.call.
+            # Entry: @softmax(%X: index, %Y: index), grid=[32].
+            "execute_kwargs": {},
+        },
+    ],
+    # ---------------------------------------------------------------------------
     # Cross-core communication examples
     # ---------------------------------------------------------------------------
     "ring_reduce": [

--- a/tests/mlir_frontend/test_parse_adapt.py
+++ b/tests/mlir_frontend/test_parse_adapt.py
@@ -13,6 +13,7 @@ import pytest
 
 from test_dialects_parse import (
     TestArithParsers as _TestArithParsers,
+    TestFuncParsers as _TestFuncParsers,
     TestLinalgParsers as _TestLinalgParsers,
     TestTensorParsers as _TestTensorParsers,
     TestKtdpParsers as _TestKtdpParsers,
@@ -59,6 +60,57 @@ module {{
             if op.op_type not in ("func.return", "return"):
                 return op
         raise RuntimeError(f"No target op found in:\n{module_text}")
+
+
+# ---------------------------------------------------------------------------
+# Func
+# ---------------------------------------------------------------------------
+
+class TestFuncAdapt(MLIRFrontendParseTestMixin, _TestFuncParsers):
+    """Func tests via MLIRFrontendParser.
+
+    func.call references a callee that must exist in the module for MLIR
+    verification to pass, so the single-op tests are overridden to embed a
+    callee declaration alongside @_test.  The multi-call test uses
+    KTIRInterpreter directly and is inherited unchanged.
+    """
+
+    def test_void_call_no_args(self):
+        module_text = """\
+module {
+  func.func @callee() attributes {grid = [1]} { return }
+  func.func @_test() attributes {grid = [1]} {
+    func.call @callee() : () -> ()
+    return
+  }
+}
+"""
+        ir_module = MLIRFrontendParser().parse_module(module_text)
+        calls = [o for o in ir_module.get_function("_test").operations
+                 if o.op_type == "func.call"]
+        op = calls[0]
+        self.assert_op_type(op, "func.call")
+        assert op.result is None
+        assert op.operands == []
+        self.assert_attribute(op, "callee", "callee")
+
+    def test_call_with_args(self):
+        module_text = """\
+module {
+  func.func @add(%x: index, %y: index) attributes {grid = [1]} { return }
+  func.func @_test(%x: index, %y: index) attributes {grid = [1]} {
+    func.call @add(%x, %y) : (index, index) -> ()
+    return
+  }
+}
+"""
+        ir_module = MLIRFrontendParser().parse_module(module_text)
+        calls = [o for o in ir_module.get_function("_test").operations
+                 if o.op_type == "func.call"]
+        op = calls[0]
+        self.assert_op_type(op, "func.call")
+        self.assert_attribute(op, "callee", "add")
+        self.assert_num_operands(op, 2)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/mlir_frontend/test_registry_consistency.py
+++ b/tests/mlir_frontend/test_registry_consistency.py
@@ -57,17 +57,6 @@ FRONTEND_UNSUPPORTED = {
     "ktdp.coreid": "non-spec op (not in the ktdp dialect). Reconcile to the "
                    "real core-identity form or remove. See issue #88.",
 
-    # Real spec ops missing a frontend adapter handler — pending
-    # ktir-mlir-frontend#23 (inter-tile communication ops).
-    "ktdp.inter_tile_produce": "🧪 experimental op; no frontend adapter yet. "
-                               "Blocked on ktir-mlir-frontend#23.",
-    "ktdp.inter_tile_reduce": "🧪 experimental op; no frontend adapter yet. "
-                              "Blocked on ktir-mlir-frontend#23.",
-    "ktdp.yield_partial": "🧪 experimental terminator; no frontend adapter yet. "
-                          "Blocked on ktir-mlir-frontend#23.",
-    "ktdp.yield_reduced": "🧪 experimental terminator; no frontend adapter yet. "
-                          "Blocked on ktir-mlir-frontend#23.",
-
     # Real spec op missing only a frontend adapter handler (distinct from the
     # non-spec ops above).
     "ktdp.construct_distributed_memory_view": "real ktdp dialect op; no frontend "

--- a/tests/test_dialects_exec.py
+++ b/tests/test_dialects_exec.py
@@ -1514,6 +1514,179 @@ class TestScfFunc:
         assert result == 42, f"expected 42, got {result!r}"
 
 # ---------------------------------------------------------------------------
+# func dialect — func.call end-to-end execution
+# ---------------------------------------------------------------------------
+
+def _run_ktir(ktir_text, func_name="main", **kwargs):
+    from ktir_cpu import KTIRInterpreter
+    interp = KTIRInterpreter()
+    interp.load(ktir_text)
+    return interp.execute_function(func_name, **kwargs)
+
+
+class TestFunc:
+    """func.call: callee execution, arg passing, scope isolation, LX persistence."""
+
+    def test_call_passes_args_to_callee(self):
+        # func.call binds caller SSA values to callee arg names
+        ktir = """
+#id1    = affine_map<(d0) -> (d0)>
+#full64 = affine_set<(d0) : (d0 >= 0, -d0 + 63 >= 0)>
+module @m {
+  func.func @copy(%src: index, %dst: index) attributes {grid = [1]} {
+    %c0 = arith.constant 0 : index
+    %sv = ktdp.construct_memory_view %src, sizes: [64], strides: [1]
+            {memory_space = #ktdp.spyre_memory_space<HBM>} : memref<64xf32>
+    %st = ktdp.construct_access_tile %sv[%c0]
+            {access_tile_set = #full64,
+             access_tile_order = #id1} : memref<64xf32> -> !ktdp.access_tile<64xindex>
+    %t  = ktdp.load %st : <64xindex> -> tensor<64xf32>
+    %dv = ktdp.construct_memory_view %dst, sizes: [64], strides: [1]
+            {memory_space = #ktdp.spyre_memory_space<HBM>} : memref<64xf32>
+    %dt = ktdp.construct_access_tile %dv[%c0]
+            {access_tile_set = #full64,
+             access_tile_order = #id1} : memref<64xf32> -> !ktdp.access_tile<64xindex>
+    ktdp.store %t, %dt : tensor<64xf32>, <64xindex>
+    return
+  }
+  func.func @main(%A: index, %B: index) attributes {grid = [1]} {
+    func.call @copy(%A, %B) : (index, index) -> ()
+    return
+  }
+}
+"""
+        rng = np.random.default_rng(1)
+        A = rng.standard_normal(64).astype(np.float32)
+        B = np.zeros(64, dtype=np.float32)
+        result = _run_ktir(ktir, func_name="main", A=A, B=B)
+        np.testing.assert_allclose(result["B"], A, atol=1e-6)
+
+    def test_caller_ssa_survives_call(self):
+        # SSA values bound before func.call remain accessible after it returns
+        ktir = """
+#id1    = affine_map<(d0) -> (d0)>
+#full64 = affine_set<(d0) : (d0 >= 0, -d0 + 63 >= 0)>
+module @m {
+  func.func @noop() attributes {grid = [1]} { return }
+  func.func @main(%X: index, %Y: index) attributes {grid = [1]} {
+    %c0 = arith.constant 0 : index
+    %xv = ktdp.construct_memory_view %X, sizes: [64], strides: [1]
+            {memory_space = #ktdp.spyre_memory_space<HBM>} : memref<64xf32>
+    %xt = ktdp.construct_access_tile %xv[%c0]
+            {access_tile_set = #full64,
+             access_tile_order = #id1} : memref<64xf32> -> !ktdp.access_tile<64xindex>
+    %x  = ktdp.load %xt : <64xindex> -> tensor<64xf32>
+    func.call @noop() : () -> ()
+    %yv = ktdp.construct_memory_view %Y, sizes: [64], strides: [1]
+            {memory_space = #ktdp.spyre_memory_space<HBM>} : memref<64xf32>
+    %yt = ktdp.construct_access_tile %yv[%c0]
+            {access_tile_set = #full64,
+             access_tile_order = #id1} : memref<64xf32> -> !ktdp.access_tile<64xindex>
+    ktdp.store %x, %yt : tensor<64xf32>, <64xindex>
+    return
+  }
+}
+"""
+        rng = np.random.default_rng(0)
+        X = rng.standard_normal(64).astype(np.float32)
+        Y = np.zeros(64, dtype=np.float32)
+        result = _run_ktir(ktir, func_name="main", X=X, Y=Y)
+        np.testing.assert_allclose(result["Y"], X, atol=1e-6)
+
+    def test_sequential_calls_accumulate(self):
+        # Five func.call @add_one ops each increment the buffer by 1.0
+        ktir = """
+#id1  = affine_map<(d0) -> (d0)>
+#full4 = affine_set<(d0) : (d0 >= 0, -d0 + 3 >= 0)>
+module @m {
+  func.func @add_one(%buf: index) attributes {grid = [1]} {
+    %c0 = arith.constant 0 : index
+    %bv = ktdp.construct_memory_view %buf, sizes: [4], strides: [1]
+            {memory_space = #ktdp.spyre_memory_space<HBM>} : memref<4xf32>
+    %bt = ktdp.construct_access_tile %bv[%c0]
+            {access_tile_set = #full4,
+             access_tile_order = #id1} : memref<4xf32> -> !ktdp.access_tile<4xindex>
+    %t  = ktdp.load %bt : <4xindex> -> tensor<4xf32>
+    %c1 = arith.constant 1.0 : f32
+    %e  = tensor.empty() : tensor<4xf32>
+    %o  = linalg.fill ins(%c1 : f32) outs(%e : tensor<4xf32>) -> tensor<4xf32>
+    %r  = arith.addf %t, %o : tensor<4xf32>
+    %bt2 = ktdp.construct_access_tile %bv[%c0]
+             {access_tile_set = #full4,
+              access_tile_order = #id1} : memref<4xf32> -> !ktdp.access_tile<4xindex>
+    ktdp.store %r, %bt2 : tensor<4xf32>, <4xindex>
+    return
+  }
+  func.func @main(%B: index) attributes {grid = [1]} {
+    func.call @add_one(%B) : (index) -> ()
+    func.call @add_one(%B) : (index) -> ()
+    func.call @add_one(%B) : (index) -> ()
+    func.call @add_one(%B) : (index) -> ()
+    func.call @add_one(%B) : (index) -> ()
+    return
+  }
+}
+"""
+        B = np.zeros(4, dtype=np.float32)
+        result = _run_ktir(ktir, func_name="main", B=B)
+        np.testing.assert_allclose(result["B"], np.full(4, 5.0, dtype=np.float32), atol=1e-6)
+
+    def test_lx_state_persists_across_calls(self):
+        # Data written to LX via ktdp.store in one callee is readable in the next
+        ktir = """
+#id3   = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+#tile4 = affine_set<(d0, d1, d2) : (d0 >= 0, -d0 + 0 >= 0,
+                                    d1 >= 0, -d1 + 0 >= 0,
+                                    d2 >= 0, -d2 + 3 >= 0)>
+module @m {
+  func.func @write_lx(%src: index, %lx: index) attributes {grid = [1]} {
+    %c0 = arith.constant 0 : index
+    %sv = ktdp.construct_memory_view %src, sizes: [1, 1, 4], strides: [4, 4, 1]
+            {memory_space = #ktdp.spyre_memory_space<HBM>} : memref<1x1x4xf32>
+    %st = ktdp.construct_access_tile %sv[%c0, %c0, %c0]
+            {access_tile_set = #tile4,
+             access_tile_order = #id3} : memref<1x1x4xf32> -> !ktdp.access_tile<1x1x4xindex>
+    %t  = ktdp.load %st : <1x1x4xindex> -> tensor<1x1x4xf32>
+    %lv = ktdp.construct_memory_view %lx, sizes: [1, 1, 4], strides: [4, 4, 1]
+            {memory_space = #ktdp.spyre_memory_space<LX>} : memref<1x1x4xf32>
+    %lt = ktdp.construct_access_tile %lv[%c0, %c0, %c0]
+            {access_tile_set = #tile4,
+             access_tile_order = #id3} : memref<1x1x4xf32> -> !ktdp.access_tile<1x1x4xindex>
+    ktdp.store %t, %lt : tensor<1x1x4xf32>, <1x1x4xindex>
+    return
+  }
+  func.func @read_lx(%lx: index, %dst: index) attributes {grid = [1]} {
+    %c0 = arith.constant 0 : index
+    %lv = ktdp.construct_memory_view %lx, sizes: [1, 1, 4], strides: [4, 4, 1]
+            {memory_space = #ktdp.spyre_memory_space<LX>} : memref<1x1x4xf32>
+    %lt = ktdp.construct_access_tile %lv[%c0, %c0, %c0]
+            {access_tile_set = #tile4,
+             access_tile_order = #id3} : memref<1x1x4xf32> -> !ktdp.access_tile<1x1x4xindex>
+    %t  = ktdp.load %lt : <1x1x4xindex> -> tensor<1x1x4xf32>
+    %dv = ktdp.construct_memory_view %dst, sizes: [1, 1, 4], strides: [4, 4, 1]
+            {memory_space = #ktdp.spyre_memory_space<HBM>} : memref<1x1x4xf32>
+    %dt = ktdp.construct_access_tile %dv[%c0, %c0, %c0]
+            {access_tile_set = #tile4,
+             access_tile_order = #id3} : memref<1x1x4xf32> -> !ktdp.access_tile<1x1x4xindex>
+    ktdp.store %t, %dt : tensor<1x1x4xf32>, <1x1x4xindex>
+    return
+  }
+  func.func @main(%X: index, %Y: index) attributes {grid = [1]} {
+    %lx_addr = arith.constant 524288 : index
+    func.call @write_lx(%X, %lx_addr) : (index, index) -> ()
+    func.call @read_lx(%lx_addr, %Y)  : (index, index) -> ()
+    return
+  }
+}
+"""
+        rng = np.random.default_rng(7)
+        X = rng.standard_normal((1, 1, 4)).astype(np.float32)
+        Y = np.zeros((1, 1, 4), dtype=np.float32)
+        result = _run_ktir(ktir, func_name="main", X=X, Y=Y)
+        np.testing.assert_allclose(result["Y"], X, atol=1e-6)
+
+
+# ---------------------------------------------------------------------------
 # ktdp dialect parsers
 # ---------------------------------------------------------------------------
 

--- a/tests/test_dialects_parse.py
+++ b/tests/test_dialects_parse.py
@@ -1152,6 +1152,55 @@ class TestScfParsers(ParseTestMixin):
 
 
 # ---------------------------------------------------------------------------
+# func dialect parsers
+# ---------------------------------------------------------------------------
+
+class TestFuncParsers(ParseTestMixin):
+    """func.call parser: void and value-returning forms, arg binding, multi-call."""
+
+    def test_void_call_no_args(self):
+        # func.call @f() : () -> () — no result, no operands
+        op = self._parse("func.call @callee() : () -> ()", args={})
+        self.assert_op_type(op, "func.call")
+        assert op.result is None
+        assert op.operands == []
+        self.assert_attribute(op, "callee", "callee")
+
+    def test_call_with_args(self):
+        # func.call with two index args records both operands
+        op = self._parse(
+            "func.call @add(%x, %y) : (index, index) -> ()",
+            args={"%x": "index", "%y": "index"},
+        )
+        self.assert_op_type(op, "func.call")
+        self.assert_attribute(op, "callee", "add")
+        self.assert_num_operands(op, 2)
+        self.assert_operand_names(op, "%x", "%y")
+
+    def test_multiple_sequential_calls_parsed_separately(self):
+        # Consecutive void func.call lines each produce a distinct op.
+        ktir = """
+module @m {
+  func.func @a() attributes {grid = [1]} { return }
+  func.func @b() attributes {grid = [1]} { return }
+  func.func @main() attributes {grid = [1]} {
+    func.call @a() : () -> ()
+    func.call @b() : () -> ()
+    return
+  }
+}
+"""
+        from ktir_cpu import KTIRInterpreter
+        interp = KTIRInterpreter()
+        interp.load(ktir)
+        ops = interp.module.get_function("main").operations
+        calls = [o for o in ops if o.op_type == "func.call"]
+        assert len(calls) == 2
+        assert calls[0].attributes["callee"] == "a"
+        assert calls[1].attributes["callee"] == "b"
+
+
+# ---------------------------------------------------------------------------
 # math dialect — all ops parse through the generic fallback parser
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION

## Summary

cc: @tnakaike @Prasanth-Chatarasi 

- **`func.call` execution** (`ktir_cpu/dialects/func_ops.py`): callee runs in a
  pushed scope with swapped `_use_counts`; LX scratchpad writes survive scope
  pop so data passed between stages via LX persists across call boundaries.
- **Dialect separation**: `func.return` / `func.call` handlers moved out of
  `scf_ops.py` into a dedicated `func_ops.py`; registered in
  `dialects/__init__.py`.
- **MLIR frontend** (`mlir_frontend/parser.py`):
  `MLIRTypeAdapter.install("func.call")` handler extracts callee name from
  `FlatSymbolRefAttr`. Closes the registry-consistency gap that would surface in
  `test_registry_consistency` once `mlir_ktdp` is available.
- **Examples** (`examples/triton-ktir/`): two LX-fused softmax variants —
  `softmax_lx_fused.ktir` (single func, 5 stages inlined) and
  `softmax_lx_fused_calls.ktir` (6 funcs, `@softmax` calls 5 stage subfunctions
  via top-level `func.call`). Both achieve identical latency (2 HBM passes,
  ~14 466 cycles).
- **Tests**: `TestFuncParsers` in `test_dialects_parse.py`, `TestFunc` in
  `test_dialects_exec.py`, `TestFuncAdapt` in `test_parse_adapt.py`.

## Constraint

`func.call` is only supported at the **top level** of a function body — not
inside `scf.for` / `scf.if` regions. This matches current usage and avoids
re-entrant scope/LX issues that haven't been designed for.

## Test plan

- [ ] `uv run pytest tests/ -v` — 1059 passed (adapt tests skip without `mlir_ktdp`)
- [ ] `softmax_lx_fused.ktir` and `softmax_lx_fused_calls.ktir` both run via
      `test_examples`; max softmax error < 1e-4, row sums 0.999–1.001


