### PR TITLE
MLIR frontend: inter-tile yield adaptors and bb0 region fix

### DIFF
--- a/ktir_cpu/dialects/ktdp_helpers.py
+++ b/ktir_cpu/dialects/ktdp_helpers.py
@@ -205,4 +205,6 @@ def attach_reshape(gen, target_shape):
     closure.
     """
     reduced = yield from gen
+    if reduced is None:
+        return None
     return reshape_tile_to_target(reduced, target_shape)

--- a/ktir_cpu/dialects/linalg_ops.py
+++ b/ktir_cpu/dialects/linalg_ops.py
@@ -246,20 +246,27 @@ def linalg__reduce(op, context, env):
     return result
 
 
-@register("linalg.add", latency_category=LC.COMPUTE_FLOAT)
-def linalg__add(op, context, env):
-    """Elementwise tensor add — ``%c = linalg.add ins(%a, %b) outs(%init)``.
+_LINALG_BINOP = {
+    "linalg.add": lambda a, b: a + b,
+    "linalg.max": np.maximum,
+}
 
-    Standard MLIR named op: result = a + b (the outs buffer provides the
-    destination shape only; its values are not accumulated into in v1).
+
+@register("linalg.add", "linalg.max", latency_category=LC.COMPUTE_FLOAT)
+def linalg__binop(op, context, env):
+    """Elementwise binary named ops (add, max) — ins(%a, %b) outs(%init).
+
+    The outs buffer provides the destination shape only; its values are
+    not accumulated into the result.
     """
     tile_a = context.get_value(op.operands[0])
     tile_b = context.get_value(op.operands[1])
     if not isinstance(tile_a, Tile) or not isinstance(tile_b, Tile):
         raise TypeError(
-            f"linalg.add: ins must be Tiles, got {type(tile_a)} and {type(tile_b)}"
+            f"{op.op_type}: ins must be Tiles, got {type(tile_a)} and {type(tile_b)}"
         )
-    return Tile(tile_a.data + tile_b.data, tile_a.dtype, tile_a.shape)
+    fn = _LINALG_BINOP[op.op_type]
+    return Tile(fn(tile_a.data, tile_b.data), tile_a.dtype, tile_a.shape)
 
 
 @register("linalg.fill")

--- a/ktir_cpu/mlir_frontend/parser.py
+++ b/ktir_cpu/mlir_frontend/parser.py
@@ -713,7 +713,7 @@ def _adapt_inter_tile_reduce(mlir_op, attributes, result_type, operands):
     """Extract consumer_tiles_per_group, groups, optional producer_dependency_per_consumer,
     and _result_shape from the result type, matching the regex parser's output.
     """
-    from ..parser_utils import parse_tensor_type
+    from ..parser_utils import parse_tensor_or_memref_type
     attributes["consumer_tiles_per_group"] = parse_affine_set(
         str(mlir_op.attributes["consumer_tiles_per_group"])
     )
@@ -725,7 +725,7 @@ def _adapt_inter_tile_reduce(mlir_op, attributes, result_type, operands):
             str(mlir_op.attributes["producer_dependency_per_consumer"])
         )
     if result_type is not None:
-        parsed = parse_tensor_type(result_type)
+        parsed = parse_tensor_or_memref_type(result_type)
         if parsed is not None:
             attributes["_result_shape"] = parsed["shape"]
 

--- a/ktir_cpu/mlir_frontend/parser.py
+++ b/ktir_cpu/mlir_frontend/parser.py
@@ -134,9 +134,19 @@ class MLIRTypeAdapter:
         handler(mlir_op, attributes, result_type, operands)
 
         from ..dialects.registry import is_inplace_outs
-        from ..parser_utils import extract_outs_operands
-        outs_operands = (extract_outs_operands(mlir_op.get_asm())
+        from ..parser_utils import extract_outs_operands, extract_bb0_arg_names
+        op_asm = mlir_op.get_asm()
+        outs_operands = (extract_outs_operands(op_asm)
                          if is_inplace_outs(mlir_op.name) else [])
+        bb0_names = extract_bb0_arg_names(op_asm)
+        if bb0_names and regions:
+            regions[0].insert(0, Operation(
+                result=None,
+                op_type="region.bb0_args",
+                operands=[],
+                attributes={"names": bb0_names},
+                result_type=None,
+            ))
 
         return Operation(
             result=result,
@@ -149,18 +159,7 @@ class MLIRTypeAdapter:
         )
 
     def adapt_block(self, block) -> List[Operation]:
-        ops = []
-        block_args = list(block.arguments)
-        if block_args:
-            ops.append(Operation(
-                result=None,
-                op_type="region.bb0_args",
-                operands=[],
-                attributes={"names": [a.get_name() for a in block_args]},
-                result_type=None,
-            ))
-        ops.extend(self.adapt_op(op) for op in block.operations)
-        return ops
+        return [self.adapt_op(op) for op in block.operations]
 
 
 # ---------------------------------------------------------------------------
@@ -174,6 +173,7 @@ def _no_attrs(mlir_op, attributes, result_type, operands):
 MLIRTypeAdapter.install(
     "func.return",
     "linalg.add",
+    "linalg.max",
     "linalg.fill",
     "linalg.yield",
     "scf.yield",

--- a/ktir_cpu/mlir_frontend/parser.py
+++ b/ktir_cpu/mlir_frontend/parser.py
@@ -149,7 +149,18 @@ class MLIRTypeAdapter:
         )
 
     def adapt_block(self, block) -> List[Operation]:
-        return [self.adapt_op(op) for op in block.operations]
+        ops = []
+        block_args = list(block.arguments)
+        if block_args:
+            ops.append(Operation(
+                result=None,
+                op_type="region.bb0_args",
+                operands=[],
+                attributes={"names": [a.get_name() for a in block_args]},
+                result_type=None,
+            ))
+        ops.extend(self.adapt_op(op) for op in block.operations)
+        return ops
 
 
 # ---------------------------------------------------------------------------
@@ -167,6 +178,8 @@ MLIRTypeAdapter.install(
     "linalg.yield",
     "scf.yield",
     "scf.if",
+    "ktdp.yield_partial",
+    "ktdp.yield_reduced",
     # float binary
     "arith.addf", "arith.subf", "arith.mulf", "arith.divf", "arith.remf",
     # float unary
@@ -667,6 +680,54 @@ def _adapt_tensor_generate(mlir_op, attributes, result_type, operands):
         raise ValueError(f"tensor.generate: cannot parse result type {result_type!r}")
     attributes["shape"] = info["shape"]
     attributes["dtype"] = info["dtype"]
+
+
+@MLIRTypeAdapter.install("ktdp.inter_tile_produce")
+def _adapt_inter_tile_produce(mlir_op, attributes, result_type, operands):
+    """Extract producer_tiles_per_group, groups, and partial_tensor_types from result type.
+
+    result_type is "!ktdp.tile_future<T_p_1, ...>" — split the inner content to
+    produce partial_tensor_types, matching what the regex parser produces.
+    """
+    from ..parser_utils import split_top_level
+    attributes["producer_tiles_per_group"] = parse_affine_set(
+        str(mlir_op.attributes["producer_tiles_per_group"])
+    )
+    attributes["groups"] = parse_affine_set(
+        str(mlir_op.attributes["groups"])
+    )
+    # Parse "!ktdp.tile_future<T1, T2, ...>" → ("T1", "T2", ...)
+    m = re.match(r"!ktdp\.tile_future<(.+)>", result_type or "")
+    if not m:
+        raise ValueError(
+            f"ktdp.inter_tile_produce: cannot parse tile_future result type {result_type!r}"
+        )
+    inner = m.group(1).strip()
+    attributes["partial_tensor_types"] = tuple(
+        p.strip() for p in split_top_level(inner)
+    )
+
+
+@MLIRTypeAdapter.install("ktdp.inter_tile_reduce")
+def _adapt_inter_tile_reduce(mlir_op, attributes, result_type, operands):
+    """Extract consumer_tiles_per_group, groups, optional producer_dependency_per_consumer,
+    and _result_shape from the result type, matching the regex parser's output.
+    """
+    from ..parser_utils import parse_tensor_type
+    attributes["consumer_tiles_per_group"] = parse_affine_set(
+        str(mlir_op.attributes["consumer_tiles_per_group"])
+    )
+    attributes["groups"] = parse_affine_set(
+        str(mlir_op.attributes["groups"])
+    )
+    if "producer_dependency_per_consumer" in mlir_op.attributes:
+        attributes["producer_dependency_per_consumer"] = parse_affine_set(
+            str(mlir_op.attributes["producer_dependency_per_consumer"])
+        )
+    if result_type is not None:
+        parsed = parse_tensor_type(result_type)
+        if parsed is not None:
+            attributes["_result_shape"] = parsed["shape"]
 
 
 _DYNAMIC_SIZE = -(1 << 63)  # ShapedType::kDynamic in MLIR

--- a/ktir_cpu/parser_utils.py
+++ b/ktir_cpu/parser_utils.py
@@ -31,6 +31,21 @@ def find_ssa_names(text: str) -> list[str]:
 
 
 _OUTS_RE = re.compile(r'\bouts\s*\(([^)]+)\)')
+_BB0_RE = re.compile(r'\^bb0\s*\(([^)]*)\)')
+
+
+def extract_bb0_arg_names(op_text: str) -> list[str]:
+    """Extract block argument names from a ``^bb0(...)`` label in *op_text*.
+
+    Returns the list of SSA names (e.g. ``['%arg3', '%arg4']``) when the op's
+    ASM contains a region body with explicit block arguments, or an empty list
+    when no ``^bb0(...)`` label is present (e.g. scf.for, which carries its
+    block-arg names as op attributes instead).
+    """
+    m = _BB0_RE.search(op_text)
+    if not m:
+        return []
+    return find_ssa_names(m.group(1))
 
 
 def extract_outs_operands(op_text: str) -> list[str]:

--- a/tests/mlir_frontend/test_registry_consistency.py
+++ b/tests/mlir_frontend/test_registry_consistency.py
@@ -57,10 +57,6 @@ FRONTEND_UNSUPPORTED = {
     "ktdp.coreid": "non-spec op (not in the ktdp dialect). Reconcile to the "
                    "real core-identity form or remove. See issue #88.",
 
-    # Real spec op missing only a frontend adapter handler (distinct from the
-    # non-spec ops above).
-    "ktdp.construct_distributed_memory_view": "real ktdp dialect op; no frontend "
-                   "adapter handler yet. Tracked in issue #87.",
 }
 
 

--- a/tests/mlir_frontend/test_registry_consistency.py
+++ b/tests/mlir_frontend/test_registry_consistency.py
@@ -57,16 +57,10 @@ FRONTEND_UNSUPPORTED = {
     "ktdp.coreid": "non-spec op (not in the ktdp dialect). Reconcile to the "
                    "real core-identity form or remove. See issue #88.",
 
-    # Real spec ops missing a frontend adapter handler — pending
-    # ktir-mlir-frontend#23 (inter-tile communication ops).
-    "ktdp.inter_tile_produce": "🧪 experimental op; no frontend adapter yet. "
-                               "Blocked on ktir-mlir-frontend#23.",
-    "ktdp.inter_tile_reduce": "🧪 experimental op; no frontend adapter yet. "
-                              "Blocked on ktir-mlir-frontend#23.",
-    "ktdp.yield_partial": "🧪 experimental terminator; no frontend adapter yet. "
-                          "Blocked on ktir-mlir-frontend#23.",
-    "ktdp.yield_reduced": "🧪 experimental terminator; no frontend adapter yet. "
-                          "Blocked on ktir-mlir-frontend#23.",
+    # Real spec op missing only a frontend adapter handler (distinct from the
+    # non-spec ops above).
+    "ktdp.construct_distributed_memory_view": "real ktdp dialect op; no frontend "
+                   "adapter handler yet. Tracked in issue #87.",
 }
 
 


### PR DESCRIPTION
Adds MLIR-frontend support for the inter-tile communication ops introduced in the previous parser work, and fixes a correctness issue with `^bb0` block argument handling.

**Inter-tile yield adaptors**

- Registers `ktdp.inter_tile_produce` and `ktdp.inter_tile_reduce` with `MLIRTypeAdapter`, parsing their affine-set attributes (`producer_tiles_per_group`, `groups`, `consumer_tiles_per_group`, `producer_dependency_per_consumer`) and unpacking the `!ktdp.tile_future<...>` result type into `partial_tensor_types`.
- Registers `ktdp.yield_partial`, `ktdp.yield_reduced`, and `linalg.max` as no-attr ops.
- Adds `linalg.max` interpreter support alongside `linalg.add` via a shared `_LINALG_BINOP` dispatch table (incidentally touches #2).

**bb0 region fix**

- Ops whose regions carry explicit `^bb0(...)` block argument lists were silently dropping those names, causing mis-resolved SSA names inside the region body. The fix extracts the names via a new `extract_bb0_arg_names` helper and injects a synthetic `region.bb0_args` op at the head of the region so downstream consumers see them.
- Guards `attach_reshape` against a `None` reduced value from the generator to avoid a downstream `AttributeError`.