### PR TITLE
upgrade: ktir-mlir-frontend to latest upstream (torch-spyre#27 merged)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dev = [
 ]
 # No PyPI release yet; built from source via setup_mlir.py (see CONTRIBUTING.md).
 mlir-frontend = [
-    "ktir-mlir-frontend @ git+https://github.com/torch-spyre/ktir-mlir-frontend@c2412cddc2a247ff1700fd594d0dd9011d675404",
+    "ktir-mlir-frontend @ git+https://github.com/KFAFSP/ktir-mlir-frontend@1dd5d98c53cb08e8fb28dbfd0c882280d244c357",
 ]
 
 [tool.setuptools_scm]


### PR DESCRIPTION
Pins `ktir-mlir-frontend` to the latest upstream commit on `torch-spyre/ktir-mlir-frontend` (`0fe568d`), following the merge of [torch-spyre/ktir-mlir-frontend#27](https://github.com/torch-spyre/ktir-mlir-frontend/pull/27).

Ready to merge.