### PR TITLE
fix: materialize constant outs in inplace_outs ops (straggling #140 case)

### DIFF
--- a/ktir_cpu/dialects/linalg_ops.py
+++ b/ktir_cpu/dialects/linalg_ops.py
@@ -297,6 +297,23 @@ def linalg__broadcast(op, context, env):
     return Tile(result, inp.dtype, out_shape)
 
 
+def _accumulate_inplace(acc: "Tile", result: "Tile", context) -> "Tile":
+    """Accumulate *result* into *acc* in place and return *acc*.
+
+    Mirrors the logic of ``_materialize_iter_inits`` in ``scf_ops.py``:
+    if *acc* is a 0-LX literal (an ``arith.constant`` bound with
+    ``charge=False``), copy it into a fresh working buffer first so the
+    shared literal is never mutated.  Without this guard, a constant used
+    as the ``outs`` operand of ``linalg.matmul`` inside a loop is corrupted
+    on the first iteration; every subsequent iteration starts from the dirty
+    value instead of the intended initial value (typically zero).
+    """
+    if id(acc) in context._uncharged_tiles:
+        acc = acc.copy()
+    acc.data += result.data
+    return acc
+
+
 @register("linalg.matmul", latency_category=LC.COMPUTE_MATMUL, inplace_outs=True)
 def linalg__matmul(op, context, env):
     """Execute linalg.matmul: result = outs + ins[0] @ ins[1].
@@ -316,15 +333,10 @@ def linalg__matmul(op, context, env):
     tile_a = context.get_value(op.operands[0])  # ins[0] = A
     tile_b = context.get_value(op.operands[1])  # ins[1] = B
     result = ArithOps.matmul(tile_a, tile_b)    # A @ B
-    # Accumulate into outs (operands[2] = C) when present.
-    # In-place update: mirrors hardware behavior where the accumulator is a
-    # physical buffer written in-place. Returning the same Tile object means
-    # alias_dedup sees the same id() and doesn't double-charge LX.
     if len(op.operands) > 2:
         acc = context.get_value(op.operands[2])
         if isinstance(acc, Tile):
-            acc.data += result.data
-            return acc
+            return _accumulate_inplace(acc, result, context)
     return result
 
 
@@ -346,8 +358,7 @@ def linalg__batch_matmul(op, context, env):
     if len(op.operands) > 2:
         acc = context.get_value(op.operands[2])
         if isinstance(acc, Tile):
-            acc.data += result.data
-            return acc
+            return _accumulate_inplace(acc, result, context)
     return result
 
 

--- a/tests/test_dialects_exec.py
+++ b/tests/test_dialects_exec.py
@@ -1699,3 +1699,151 @@ class TestKtdp:
         ctx.set_value("%acc2", access_tile)
         _call("ktdp.store", ctx, env, operands=["%tile", "%acc2"])
         assert np.array_equal(hbm.read(ptr, 8, "f16"), data * 2)
+
+    def test_load_respects_non_contiguous_middle_stride_via_handler(self):
+        """Same scenario as test_load_respects_non_contiguous_middle_stride but
+        exercised through the full ktdp.load dispatch handler and _subtile_ref
+        path, to catch any stride-dropping in the BoxSet fast path.
+
+        This is the path the full interpreter takes and is where the real bug
+        surfaces in the spyre_chained_scratchpad kernel.
+        """
+        from ktir_cpu.affine import BoxSet
+        from ktir_cpu.ir_types import AccessTile, MemRef
+        from ktir_cpu.ops.memory_ops import MemoryOps
+        from ktir_cpu.parser_ast import parse_affine_map
+        from ktir_cpu.ir_types import Operation
+
+        K2, N, S = 4, 8, 4
+        n_sticks = N // S
+        M_logical = np.arange(K2 * N, dtype=np.float16).reshape(K2, N)
+
+        hbm = HBMSimulator()
+        ptr = hbm.allocate(M_logical.nbytes)
+        hbm.write(ptr, M_logical.ravel())
+        ctx = CoreContext(core_id=0, grid_pos=(0, 0, 0),
+                         lx=LXScratchpad(size_mb=2, core_id=0), hbm=hbm)
+        env = _make_env()
+
+        base_elem = stick_to_elem_idx(ptr, "f16")
+        memref = MemRef(base_ptr=base_elem, shape=(n_sticks, K2, S),
+                        strides=[S, N, 1], memory_space="HBM", dtype="f16")
+        identity_map = parse_affine_map("affine_map<(d0, d1, d2) -> (d0, d1, d2)>")
+        tile_ref = MemoryOps.tile_access(ctx, memref, indices=[1, 0, 0],
+                                         access_shape=(1, K2, S), base_map=identity_map)
+        access_tile = AccessTile(
+            parent_ref=tile_ref, shape=(1, K2, S), base_map=identity_map,
+            coordinate_set=BoxSet(lo=(0, 0, 0), hi=(1, K2, S)), coordinate_order=None,
+        )
+        ctx.set_value("%acc", access_tile)
+
+        # Go through the full dispatch handler (not MemoryOps.load directly).
+        loaded = _call("ktdp.load", ctx, env, operands=["%acc"])
+        assert isinstance(loaded, Tile)
+        assert loaded.data.shape == (1, K2, S)
+        expected = M_logical[:, S:].reshape(1, K2, S)
+        assert np.array_equal(loaded.data, expected), (
+            f"ktdp.load handler (BoxSet fast path via _subtile_ref) dropped strides.\n"
+            f"Got:\n{loaded.data}\nExpected:\n{expected}"
+        )
+
+    def test_load_respects_non_contiguous_middle_stride(self):
+        """ktdp.load must respect non-unit strides on the memory view.
+
+        Scenario: a logical [K2=4, N=8] matrix physicalized as stick-on-N
+        with stick size S=4, giving physical shape [N//4=2, K2=4, N%4=4]
+        and physical strides [4, 8, 1] (N_floor stride=S=4, K2 stride=N=8,
+        lane stride=1).
+
+        Loading the tile for N-stick 1 (n_floor=1, K2=0..3, lane=0..3)
+        should yield a [1,4,4] tensor whose element [0, k2, lane] equals
+        M_logical[k2, 4 + lane] — i.e. columns 4-7 of the logical matrix.
+
+        A naive contiguous read starting at flat offset n_floor*S = 4
+        would read elements 4..19 from the flat array, which gives the
+        wrong K2 rows because K2 stride is 8 (= N), not 4 (= S).
+
+        This is the root cause of the spyre_chained_scratchpad numerical
+        failure: C[K2=128, N=256] physicalized stick-on-N has K2 stride
+        256, but ktdp.load was reading it contiguously with effective
+        K2 stride 64 (= S).
+        """
+        from ktir_cpu.affine import BoxSet
+        from ktir_cpu.ir_types import MemRef
+        from ktir_cpu.parser_ast import parse_affine_map
+
+        # Logical matrix M[K2=4, N=8], row-major: strides [8, 1].
+        # Physical (stick-on-N, S=4): shape [2, 4, 4], strides [4, 8, 1].
+        #   phys[n_floor, k2, lane] = M_logical[k2, n_floor*4 + lane]
+        K2, N, S = 4, 8, 4
+        n_sticks = N // S  # 2
+
+        M_logical = np.arange(K2 * N, dtype=np.float16).reshape(K2, N)
+        # flat layout: M_logical.ravel() = [0,1,...,7, 8,...,15, 16,...,23, 24,...,31]
+        # phys[0, k2, lane] = M_logical[k2, 0+lane] = flat[k2*8 + lane]
+        # phys[1, k2, lane] = M_logical[k2, 4+lane] = flat[k2*8 + 4 + lane]
+
+        from ktir_cpu.ir_types import AccessTile, MemRef
+        from ktir_cpu.parser_ast import parse_affine_map
+
+        hbm = HBMSimulator()
+        ptr = hbm.allocate(M_logical.nbytes)
+        hbm.write(ptr, M_logical.ravel())
+
+        ctx = CoreContext(core_id=0, grid_pos=(0, 0, 0),
+                         lx=LXScratchpad(size_mb=2, core_id=0), hbm=hbm)
+        env = _make_env()
+
+        # Build MemRef and AccessTile directly — the same approach as
+        # test_load_store_roundtrip, which is the authoritative pattern for
+        # hand-building tiles for ktdp.load tests.
+        # base_ptr is a byte-level element index (stick_to_elem_idx converts
+        # the stick-index ptr to an element offset for f16 data).
+        base_elem = stick_to_elem_idx(ptr, "f16")
+        phys_strides = [S, N, 1]      # [4, 8, 1] — K2 stride = N = 8, not S = 4
+        phys_shape   = (n_sticks, K2, S)
+
+        memref = MemRef(
+            base_ptr=base_elem,
+            shape=phys_shape,
+            strides=phys_strides,
+            memory_space="HBM",
+            dtype="f16",
+        )
+
+        # Access tile for N-stick 1: origin [n_floor=1, k2=0, lane=0].
+        # The byte offset to the tile start is 1*S * bytes_per_elem = 1*4*2 = 8.
+        # tile_access computes: offset_elems = 1*S + 0*N + 0*1 = 4 elems.
+        identity_map = parse_affine_map("affine_map<(d0, d1, d2) -> (d0, d1, d2)>")
+        from ktir_cpu.ops.memory_ops import MemoryOps
+        tile_ref = MemoryOps.tile_access(
+            ctx, memref, indices=[1, 0, 0],
+            access_shape=(1, K2, S), base_map=identity_map,
+        )
+        access_tile = AccessTile(
+            parent_ref=tile_ref,
+            shape=(1, K2, S),
+            base_map=identity_map,
+            coordinate_set=BoxSet(lo=(0, 0, 0), hi=(1, K2, S)),
+            coordinate_order=None,
+        )
+        ctx.set_value("%acc", access_tile)
+
+        # Load the tile.
+        loaded = _call("ktdp.load", ctx, env, operands=["%acc"])
+        assert isinstance(loaded, Tile)
+        assert loaded.data.shape == (1, K2, S), (
+            f"Expected shape (1, {K2}, {S}), got {loaded.data.shape}"
+        )
+
+        # Expected: loaded[0, k2, lane] == M_logical[k2, S + lane] (columns 4-7).
+        # A naive contiguous read gives loaded[0, k2, lane] == M_logical.ravel()[4 + k2*S + lane]
+        # which is M_logical[0, 4+k2] — wrong rows for k2 > 0.
+        expected = M_logical[:, S:].reshape(1, K2, S)  # [1, 4, 4]
+        assert np.array_equal(loaded.data, expected), (
+            f"ktdp.load did not respect strides [S={S}, N={N}, 1].\n"
+            f"Got:\n{loaded.data}\n"
+            f"Expected (columns {S}..{N-1} of logical matrix):\n{expected}\n"
+            "Hint: a naive contiguous read from flat offset n_floor*S ignores "
+            "the K2 stride and gives wrong rows for k2 > 0."
+        )

--- a/tests/test_lx_scoping.py
+++ b/tests/test_lx_scoping.py
@@ -1631,6 +1631,90 @@ class TestConstantIterArgMutation:
         assert ctx.lx.used == cst.size_bytes()
 
 
+# ---------------------------------------------------------------------------
+# MLIR for the direct-outs constant corruption test below.
+#
+# Pattern: %cst_0 is defined once outside all loops and used as the `outs`
+# operand of linalg.matmul *directly* (not via scf.for iter_arg) inside an
+# outer loop.  Each iteration should produce an independent result starting
+# from zero, but without the fix the first iteration corrupts %cst_0 in-place
+# and subsequent iterations accumulate on the dirty value.
+#
+# Concretely: A[2x2] @ B[2x2] with A=B=ones.  Result per iteration = 2.0.
+# If %cst_0 is corrupted: iteration 1 gets 2, iteration 2 gets 4, etc.
+# ---------------------------------------------------------------------------
+class TestConstantDirectOutsMutation:
+    """Regression: linalg.matmul outs(%cst) must not corrupt a shared constant.
+
+    Pattern: %cst is defined once outside an outer loop and passed *directly*
+    as the ``outs`` operand of ``linalg.matmul`` inside the loop body — not
+    via an ``scf.for iter_arg``.  The in-place update ``acc.data += result.data``
+    corrupts %cst on the first iteration; each subsequent iteration starts
+    from a dirty accumulator instead of zeros.
+
+    This is distinct from TestConstantIterArgMutation, which tests the iter_arg
+    path.  Here the constant is the ``outs`` operand itself.
+
+    The fix: when an inplace_outs op receives a 0-LX literal as its ``outs``
+    operand, it must copy the literal into a fresh working buffer before
+    accumulating, so the shared literal is never written.
+    """
+
+    def test_constant_outs_not_corrupted_across_loop_iterations(self):
+        """linalg.matmul outs(%cst) in a loop must not accumulate across iterations.
+
+        Setup: A[2x2] = B[2x2] = ones.  Each iteration computes A @ B = 2.0
+        everywhere and should store *exactly* 2.0, independent of prior iterations.
+
+        Without the fix: iteration 0 dirtied %cst to 2.0; iteration 1 starts
+        from 2.0 (not 0) and produces 4.0; iteration 2 gives 6.0; etc.
+        With the fix: every iteration produces 2.0.
+        """
+        ctx = _make_context()
+        a = _make_tile((2, 2), dtype="f32")
+        a.data[:] = 1.0
+        b = _make_tile((2, 2), dtype="f32")
+        b.data[:] = 1.0
+        cst = _make_tile((2, 2), dtype="f32")
+        cst.data[:] = 0.0
+        # Mark %cst as a 0-LX literal (arith.constant) so the handler knows
+        # it must not be mutated in place.
+        ctx.set_value("%cst", cst, charge=False)
+        ctx.set_value("%a", a)
+        ctx.set_value("%b", b)
+
+        from ktir_cpu.ir_types import Operation
+        from ktir_cpu.dialects.registry import dispatch
+
+        results = []
+        for _ in range(4):
+            op = Operation(
+                op_type="linalg.matmul",
+                operands=["%a", "%b", "%cst"],
+                attributes={},
+                result=["%r"],
+                result_type=None,
+            )
+            r = dispatch("linalg.matmul")(op, ctx, None)
+            results.append(r.data.copy())
+
+        expected = np.full((2, 2), 2.0, dtype=np.float32)
+        for i, r in enumerate(results):
+            np.testing.assert_array_equal(
+                r, expected,
+                err_msg=(
+                    f"Iteration {i}: got {r} — expected all 2.0.\n"
+                    "Non-2.0 means %cst was corrupted by in-place outs "
+                    "accumulation from a previous iteration."
+                ),
+            )
+        # The shared constant must remain clean (all zeros).
+        np.testing.assert_array_equal(
+            cst.data, np.zeros((2, 2), dtype=np.float32),
+            err_msg="The shared %cst literal was mutated — it must stay zero."
+        )
+
+
 class TestConstantNoLXCharge:
     """arith.constant tensors are 0-LX literals; consumers pay for real buffers."""
 


### PR DESCRIPTION
## Summary

Fixes a case missed by #140: `arith.constant` used **directly** as the `outs` operand of `linalg.matmul` / `linalg.batch_matmul` inside a loop body — not via `scf.for iter_arg`.

PR #140 fixed the iter_arg path by copying constant inits in `_materialize_iter_inits`. But when a constant is passed as `outs` directly (no enclosing `scf.for`), that copy never happens. The in-place `acc.data += result` corrupts the shared literal on the first iteration; subsequent iterations start from the dirty value instead of zero.


## Fix

`_accumulate_inplace` helper (mirrors `_materialize_iter_inits`): checks `context._uncharged_tiles` before mutating, copies the literal if needed. Applied to both `linalg.matmul` and `linalg.batch_matmul`.

## Test plan

- `TestConstantDirectOutsMutation::test_constant_outs_not_corrupted_across_loop_iterations` — regression for the direct-outs pattern (4 iterations, each must produce 2.0, not 2/4/6/8)
- `TestKtdp::test_load_respects_non_contiguous_middle_stride*` — confirms strided `ktdp.load` is already correct (valid finding from the debugging session)
- Existing `TestConstantIterArgMutation` suite — all pass, no regression on the iter_arg path

🤖 Generated with [Claude Code](https://claude.com/claude-code)