### PR TITLE
Issue 77, Phase 1, ffn_swiglu MLIR example added

### DIFF
--- a/examples/ktir/ffn_swiglu.mlir
+++ b/examples/ktir/ffn_swiglu.mlir
@@ -1,0 +1,116 @@
+// FFN-SwiGLU: Feedforward network with SwiGLU activation
+// 
+// Algorithm:
+//   gate = x @ W_gate
+//   up = x @ W_up
+//   silu = gate * sigmoid(gate)  where sigmoid(x) = 1 / (1 + exp(-x))
+//   fused = silu * up
+//   out = fused @ W_down
+//   result = x + out  (residual connection)
+//
+// Dimensions (Phase 1 - minimal):
+//   seq = 1, d_model = 64, d_ffn = 128
+//   All operations single-core, no tiling
+
+module {
+  func.func @ffn_swiglu(
+      %x_ptr: index,      // input [1, 64]
+      %w_gate_ptr: index, // gate weights [64, 128]
+      %w_up_ptr: index,   // up weights [64, 128]
+      %w_down_ptr: index, // down weights [128, 64]
+      %out_ptr: index     // output [1, 64]
+  ) attributes {grid = [1, 1]} {
+    
+    %c0 = arith.constant 0 : index
+    
+    // Create memory views
+    %x_view = ktdp.construct_memory_view %x_ptr, sizes: [1, 64], strides: [64, 1] {
+      coordinate_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 0 >= 0, d1 >= 0, -d1 + 63 >= 0)>,
+      memory_space = #ktdp.spyre_memory_space<HBM>
+    } : memref<1x64xf16>
+    
+    %w_gate_view = ktdp.construct_memory_view %w_gate_ptr, sizes: [64, 128], strides: [128, 1] {
+      coordinate_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 63 >= 0, d1 >= 0, -d1 + 127 >= 0)>,
+      memory_space = #ktdp.spyre_memory_space<HBM>
+    } : memref<64x128xf16>
+    
+    %w_up_view = ktdp.construct_memory_view %w_up_ptr, sizes: [64, 128], strides: [128, 1] {
+      coordinate_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 63 >= 0, d1 >= 0, -d1 + 127 >= 0)>,
+      memory_space = #ktdp.spyre_memory_space<HBM>
+    } : memref<64x128xf16>
+    
+    %w_down_view = ktdp.construct_memory_view %w_down_ptr, sizes: [128, 64], strides: [64, 1] {
+      coordinate_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 127 >= 0, d1 >= 0, -d1 + 63 >= 0)>,
+      memory_space = #ktdp.spyre_memory_space<HBM>
+    } : memref<128x64xf16>
+    
+    %out_view = ktdp.construct_memory_view %out_ptr, sizes: [1, 64], strides: [64, 1] {
+      coordinate_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 0 >= 0, d1 >= 0, -d1 + 63 >= 0)>,
+      memory_space = #ktdp.spyre_memory_space<HBM>
+    } : memref<1x64xf16>
+    
+    // Load input x
+    %x_acc = ktdp.construct_access_tile %x_view[%c0, %c0] {
+      access_tile_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 0 >= 0, d1 >= 0, -d1 + 63 >= 0)>,
+      access_tile_order = affine_map<(d0, d1) -> (d0, d1)>
+    } : memref<1x64xf16> -> !ktdp.access_tile<1x64xindex>
+    %x = ktdp.load %x_acc : !ktdp.access_tile<1x64xindex> -> tensor<1x64xf16>
+    
+    // Gate projection: gate = x @ W_gate  [1,64] @ [64,128] -> [1,128]
+    %w_gate_acc = ktdp.construct_access_tile %w_gate_view[%c0, %c0] {
+      access_tile_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 63 >= 0, d1 >= 0, -d1 + 127 >= 0)>,
+      access_tile_order = affine_map<(d0, d1) -> (d0, d1)>
+    } : memref<64x128xf16> -> !ktdp.access_tile<64x128xindex>
+    %w_gate = ktdp.load %w_gate_acc : !ktdp.access_tile<64x128xindex> -> tensor<64x128xf16>
+    
+    %gate_init = tensor.empty() : tensor<1x128xf16>
+    %gate = linalg.matmul ins(%x, %w_gate : tensor<1x64xf16>, tensor<64x128xf16>)
+                          outs(%gate_init : tensor<1x128xf16>) -> tensor<1x128xf16>
+    
+    // Up projection: up = x @ W_up  [1,64] @ [64,128] -> [1,128]
+    %w_up_acc = ktdp.construct_access_tile %w_up_view[%c0, %c0] {
+      access_tile_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 63 >= 0, d1 >= 0, -d1 + 127 >= 0)>,
+      access_tile_order = affine_map<(d0, d1) -> (d0, d1)>
+    } : memref<64x128xf16> -> !ktdp.access_tile<64x128xindex>
+    %w_up = ktdp.load %w_up_acc : !ktdp.access_tile<64x128xindex> -> tensor<64x128xf16>
+    
+    %up_init = tensor.empty() : tensor<1x128xf16>
+    %up = linalg.matmul ins(%x, %w_up : tensor<1x64xf16>, tensor<64x128xf16>)
+                        outs(%up_init : tensor<1x128xf16>) -> tensor<1x128xf16>
+    
+    // SiLU activation: silu(gate) = gate * sigmoid(gate)
+    // sigmoid(x) = 1 / (1 + exp(-x))
+    %neg_gate = arith.negf %gate : tensor<1x128xf16>
+    %exp_neg_gate = math.exp %neg_gate : tensor<1x128xf16>
+    %one = arith.constant dense<1.0> : tensor<1x128xf16>
+    %one_plus_exp = arith.addf %one, %exp_neg_gate : tensor<1x128xf16>
+    %sigmoid = arith.divf %one, %one_plus_exp : tensor<1x128xf16>
+    %silu = arith.mulf %gate, %sigmoid : tensor<1x128xf16>
+    
+    // Gated fusion: fused = silu * up
+    %fused = arith.mulf %silu, %up : tensor<1x128xf16>
+    
+    // Down projection: out_partial = fused @ W_down  [1,128] @ [128,64] -> [1,64]
+    %w_down_acc = ktdp.construct_access_tile %w_down_view[%c0, %c0] {
+      access_tile_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 127 >= 0, d1 >= 0, -d1 + 63 >= 0)>,
+      access_tile_order = affine_map<(d0, d1) -> (d0, d1)>
+    } : memref<128x64xf16> -> !ktdp.access_tile<128x64xindex>
+    %w_down = ktdp.load %w_down_acc : !ktdp.access_tile<128x64xindex> -> tensor<128x64xf16>
+    
+    %out_partial_init = tensor.empty() : tensor<1x64xf16>
+    %out_partial = linalg.matmul ins(%fused, %w_down : tensor<1x128xf16>, tensor<128x64xf16>)
+                                 outs(%out_partial_init : tensor<1x64xf16>) -> tensor<1x64xf16>
+    
+    // Residual connection: result = x + out_partial
+    %result = arith.addf %x, %out_partial : tensor<1x64xf16>
+    
+    // Store result
+    %out_acc = ktdp.construct_access_tile %out_view[%c0, %c0] {
+      access_tile_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 0 >= 0, d1 >= 0, -d1 + 63 >= 0)>,
+      access_tile_order = affine_map<(d0, d1) -> (d0, d1)>
+    } : memref<1x64xf16> -> !ktdp.access_tile<1x64xindex>
+    ktdp.store %result, %out_acc : tensor<1x64xf16>, !ktdp.access_tile<1x64xindex>
+    
+    return
+  }
+}

--- a/examples/ktir/ffn_swiglu_4core.mlir
+++ b/examples/ktir/ffn_swiglu_4core.mlir
@@ -1,0 +1,181 @@
+// FFN-SwiGLU: 4-core distributed hidden-dimension sharding with ring all-reduce.
+//
+// Algorithm per core pid in [0, 3]:
+//   ffn_start = pid * 256
+//   gate_local = x @ W_gate[:, ffn_start:ffn_start+256]
+//   up_local = x @ W_up[:, ffn_start:ffn_start+256]
+//   silu_local = gate_local * sigmoid(gate_local)
+//   fused_local = silu_local * up_local
+//   out_partial_local = fused_local @ W_down[ffn_start:ffn_start+256, :]
+//   out = all_reduce_sum(out_partial_local)
+//   result = x + out
+//   core 0 stores result
+//
+// Dimensions:
+//   seq = 4, d_model = 256, d_ffn = 1024, grid = [4]
+//   Shard width = 256 hidden units/core
+//
+// Layout and stick granularity:
+//   x        : [4, 256]
+//   W_gate   : [256, 1024], row-major strides [1024, 1]
+//   W_up     : [256, 1024], row-major strides [1024, 1]
+//   W_down   : [1024, 256], row-major strides [256, 1]
+//   out      : [4, 256]
+//
+// With f16, one stick = 64 elements.  The 256-wide FFN shard width preserves
+// stick granularity for all three weight matrices.
+
+#x_set         = affine_set<(d0, d1) : (d0 >= 0, -d0 + 3 >= 0, d1 >= 0, -d1 + 255 >= 0)>
+#gate_full_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 255 >= 0, d1 >= 0, -d1 + 1023 >= 0)>
+#gate_shard_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 255 >= 0, d1 >= 0, -d1 + 255 >= 0)>
+#down_full_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 1023 >= 0, d1 >= 0, -d1 + 255 >= 0)>
+#partial_set   = affine_set<(d0, d1) : (d0 >= 0, -d0 + 3 >= 0, d1 >= 0, -d1 + 255 >= 0)>
+#flat_1024_set = affine_set<(d0) : (d0 >= 0, -d0 + 1023 >= 0)>
+#identity_2d   = affine_map<(d0, d1) -> (d0, d1)>
+#identity_1d   = affine_map<(d0) -> (d0)>
+#all_tiles     = affine_set<(i)[g] : (i - 4*g >= 0, -i + 4*g + 3 >= 0)>
+#one_group     = affine_set<(g) : (g == 0)>
+
+module {
+  func.func @ffn_swiglu_4core(
+      %x_ptr: index,
+      %w_gate_ptr: index,
+      %w_up_ptr: index,
+      %w_down_ptr: index,
+      %out_ptr: index
+  ) attributes {grid = [4]} {
+    %c0 = arith.constant 0 : index
+    %c256 = arith.constant 256 : index
+    %c1024 = arith.constant 1024 : index
+
+    %pid = ktdp.get_compute_tile_id : index
+    %ffn_start = arith.muli %pid, %c256 : index
+
+    // Base element offsets for this core's weight shards.
+    %gate_base = arith.addi %w_gate_ptr, %ffn_start : index
+    %up_base = arith.addi %w_up_ptr, %ffn_start : index
+    %down_row_offset = arith.muli %ffn_start, %c256 : index
+    %down_base = arith.addi %w_down_ptr, %down_row_offset : index
+
+    // Replicated input and final output views.
+    %x_view = ktdp.construct_memory_view %x_ptr, sizes: [4, 256], strides: [256, 1] {
+      coordinate_set = #x_set,
+      memory_space = #ktdp.spyre_memory_space<HBM>
+    } : memref<4x256xf16>
+
+    %out_view = ktdp.construct_memory_view %out_ptr, sizes: [4, 256], strides: [256, 1] {
+      coordinate_set = #x_set,
+      memory_space = #ktdp.spyre_memory_space<HBM>
+    } : memref<4x256xf16>
+
+    // Local FFN-dimension shards for this core.
+    %w_gate_view = ktdp.construct_memory_view %gate_base, sizes: [256, 256], strides: [1024, 1] {
+      coordinate_set = #gate_shard_set,
+      memory_space = #ktdp.spyre_memory_space<HBM>
+    } : memref<256x256xf16>
+
+    %w_up_view = ktdp.construct_memory_view %up_base, sizes: [256, 256], strides: [1024, 1] {
+      coordinate_set = #gate_shard_set,
+      memory_space = #ktdp.spyre_memory_space<HBM>
+    } : memref<256x256xf16>
+
+    %w_down_view = ktdp.construct_memory_view %down_base, sizes: [256, 256], strides: [256, 1] {
+      coordinate_set = #gate_shard_set,
+      memory_space = #ktdp.spyre_memory_space<HBM>
+    } : memref<256x256xf16>
+
+    // Step 1: load full replicated x.
+    %x_acc = ktdp.construct_access_tile %x_view[%c0, %c0] {
+      access_tile_set = #x_set,
+      access_tile_order = #identity_2d
+    } : memref<4x256xf16> -> !ktdp.access_tile<4x256xindex>
+    %x = ktdp.load %x_acc : !ktdp.access_tile<4x256xindex> -> tensor<4x256xf16>
+
+    // Steps 2-3: load local W_gate and W_up shards.
+    %w_gate_acc = ktdp.construct_access_tile %w_gate_view[%c0, %c0] {
+      access_tile_set = #gate_shard_set,
+      access_tile_order = #identity_2d
+    } : memref<256x256xf16> -> !ktdp.access_tile<256x256xindex>
+    %w_gate = ktdp.load %w_gate_acc : !ktdp.access_tile<256x256xindex> -> tensor<256x256xf16>
+
+    %w_up_acc = ktdp.construct_access_tile %w_up_view[%c0, %c0] {
+      access_tile_set = #gate_shard_set,
+      access_tile_order = #identity_2d
+    } : memref<256x256xf16> -> !ktdp.access_tile<256x256xindex>
+    %w_up = ktdp.load %w_up_acc : !ktdp.access_tile<256x256xindex> -> tensor<256x256xf16>
+
+    // Steps 4-5: local gate and up projections.
+    %gate_init = tensor.empty() : tensor<4x256xf16>
+    %gate = linalg.matmul ins(%x, %w_gate : tensor<4x256xf16>, tensor<256x256xf16>)
+                          outs(%gate_init : tensor<4x256xf16>) -> tensor<4x256xf16>
+
+    %up_init = tensor.empty() : tensor<4x256xf16>
+    %up = linalg.matmul ins(%x, %w_up : tensor<4x256xf16>, tensor<256x256xf16>)
+                        outs(%up_init : tensor<4x256xf16>) -> tensor<4x256xf16>
+
+    // Step 6: local SwiGLU activation and fusion.
+    %neg_gate = arith.negf %gate : tensor<4x256xf16>
+    %exp_neg_gate = math.exp %neg_gate : tensor<4x256xf16>
+    %one = arith.constant dense<1.0> : tensor<4x256xf16>
+    %one_plus_exp = arith.addf %one, %exp_neg_gate : tensor<4x256xf16>
+    %sigmoid = arith.divf %one, %one_plus_exp : tensor<4x256xf16>
+    %silu = arith.mulf %gate, %sigmoid : tensor<4x256xf16>
+    %fused = arith.mulf %silu, %up : tensor<4x256xf16>
+
+    // Step 7: load local W_down shard and compute local output partial.
+    %w_down_acc = ktdp.construct_access_tile %w_down_view[%c0, %c0] {
+      access_tile_set = #gate_shard_set,
+      access_tile_order = #identity_2d
+    } : memref<256x256xf16> -> !ktdp.access_tile<256x256xindex>
+    %w_down = ktdp.load %w_down_acc : !ktdp.access_tile<256x256xindex> -> tensor<256x256xf16>
+
+    %out_partial_init = tensor.empty() : tensor<4x256xf16>
+    %out_partial = linalg.matmul ins(%fused, %w_down : tensor<4x256xf16>, tensor<256x256xf16>)
+                                 outs(%out_partial_init : tensor<4x256xf16>) -> tensor<4x256xf16>
+
+    %out_partial_flat = tensor.collapse_shape %out_partial [[0, 1]] : tensor<4x256xf16> into tensor<1024xf16>
+
+    // Step 8: all-reduce the local output partial across all 4 cores.
+    %fut = ktdp.inter_tile_produce
+        producer_tiles_per_group = #all_tiles,
+        groups                   = #one_group
+        : tensor<1024xf16> -> !ktdp.tile_future<tensor<1024xf16>>
+    {
+      ^bb0(%gid: index):
+        ktdp.yield_partial %out_partial_flat : tensor<1024xf16>
+    }
+
+    %c_zero = arith.constant 0.0 : f16
+    %id_init = tensor.empty() : tensor<1024xf16>
+    %add_id = linalg.fill ins(%c_zero : f16) outs(%id_init : tensor<1024xf16>) -> tensor<1024xf16>
+
+    %out_reduced_flat = ktdp.inter_tile_reduce(%fut)
+        consumer_tiles_per_group = #all_tiles,
+        groups                   = #one_group,
+        identity(%add_id : tensor<1024xf16>)
+        : !ktdp.tile_future<tensor<1024xf16>> -> tensor<1024xf16>
+    {
+      ^bb0(%lhs: tensor<1024xf16>, %rhs: tensor<1024xf16>):
+        %init = tensor.empty() : tensor<1024xf16>
+        %sum = linalg.add ins(%lhs, %rhs : tensor<1024xf16>, tensor<1024xf16>)
+                          outs(%init : tensor<1024xf16>) -> tensor<1024xf16>
+        ktdp.yield_reduced %sum : tensor<1024xf16>
+    }
+
+    %out_reduced = tensor.expand_shape %out_reduced_flat [[0, 1]] output_shape [4, 256]
+                     : tensor<1024xf16> into tensor<4x256xf16>
+
+    // Step 9: residual add; only core 0 stores the final result.
+    %result = arith.addf %x, %out_reduced : tensor<4x256xf16>
+    %is_writer = arith.cmpi eq, %pid, %c0 : index
+    scf.if %is_writer {
+      %out_acc = ktdp.construct_access_tile %out_view[%c0, %c0] {
+        access_tile_set = #x_set,
+        access_tile_order = #identity_2d
+      } : memref<4x256xf16> -> !ktdp.access_tile<4x256xindex>
+      ktdp.store %result, %out_acc : tensor<4x256xf16>, !ktdp.access_tile<4x256xindex>
+    }
+
+    return
+  }
+}

--- a/examples/ktir/ffn_swiglu_4core.mlir
+++ b/examples/ktir/ffn_swiglu_4core.mlir
@@ -1,6 +1,7 @@
-// FFN-SwiGLU: 4-core distributed hidden-dimension sharding with ring all-reduce.
+// FFN-SwiGLU: 4-core distributed hidden-dimension sharding with all-reduce.
 //
-// Algorithm per core pid in [0, 3]:
+// === Algorithm per core pid in [0, 3] ===
+//
 //   ffn_start = pid * 256
 //   gate_local = x @ W_gate[:, ffn_start:ffn_start+256]
 //   up_local = x @ W_up[:, ffn_start:ffn_start+256]
@@ -11,30 +12,93 @@
 //   result = x + out
 //   core 0 stores result
 //
-// Dimensions:
+// === Distributed view pattern ===
+//
+// Weight tensors are too large for one core.  We shard them across 4 cores
+// using ktdp.construct_distributed_memory_view, which works in 3 steps:
+//
+// 1. Declare partition views — one construct_memory_view per shard, each
+//    carrying a coordinate_set that maps it to a region of the global tensor.
+//    For W_gate [256, 1024] column-sharded into 4:
+//
+//      partition 0: coordinate_set covers cols [0, 255]     → base = w_gate_ptr
+//      partition 1: coordinate_set covers cols [256, 511]   → base = w_gate_ptr + 256
+//      partition 2: coordinate_set covers cols [512, 767]   → base = w_gate_ptr + 512
+//      partition 3: coordinate_set covers cols [768, 1023]  → base = w_gate_ptr + 768
+//
+//    Each partition is [256, 256] with strides [1024, 1] (a strided subview
+//    of the contiguous row-major [256, 1024] matrix in HBM).
+//
+// 2. Compose into a global view — construct_distributed_memory_view wraps
+//    the 4 partition MemRefs into a single logical memref<256x1024xf16>.
+//    No data is moved or allocated; the op is purely declarative.
+//
+// 3. Access via pid-positioned tile — each core creates an access tile at
+//    [0, pid*256] on the global view.  The runtime intersects the access
+//    region with each partition's coordinate_set, finds exactly one match,
+//    and loads from that partition's physical memory.
+//
+// This separates layout declaration (where data lives) from access logic
+// (which coordinates each core needs), making the sharding strategy explicit
+// and verifiable from the coordinate_set attributes alone.
+//
+// W_down [1024, 256] is row-sharded instead: partition k covers rows
+// [k*256, (k+1)*256-1], and each core accesses at [pid*256, 0].
+//
+// === Dimensions ===
+//
 //   seq = 4, d_model = 256, d_ffn = 1024, grid = [4]
 //   Shard width = 256 hidden units/core
 //
-// Layout and stick granularity:
-//   x        : [4, 256]
-//   W_gate   : [256, 1024], row-major strides [1024, 1]
-//   W_up     : [256, 1024], row-major strides [1024, 1]
-//   W_down   : [1024, 256], row-major strides [256, 1]
-//   out      : [4, 256]
+// === Layout and stick granularity ===
 //
-// With f16, one stick = 64 elements.  The 256-wide FFN shard width preserves
+//   x        : [4, 256]   — replicated, all cores read the same input
+//   W_gate   : [256, 1024], strides [1024, 1], column-sharded into 4×[256,256]
+//   W_up     : [256, 1024], strides [1024, 1], column-sharded into 4×[256,256]
+//   W_down   : [1024, 256], strides [256, 1],  row-sharded into 4×[256,256]
+//   out      : [4, 256]   — only core 0 writes the final result
+//
+// With f16, one stick = 64 elements.  The 256-wide shard width preserves
 // stick granularity for all three weight matrices.
+//
+// === Note on repetition ===
+//
+// The per-partition construct_memory_view declarations below repeat 4× for
+// each weight matrix.  This is the expected lowered form: MLIR's static SSA
+// design requires each partition to be a distinct named value, and the
+// variadic construct_distributed_memory_view op takes them all as explicit
+// operands — there is no loop construct that can build a variadic operand
+// list dynamically.
+//
+// In practice, this MLIR is not hand-authored at scale.  A frontend
+// (e.g. ktir-mlir-frontend or a kernel-gen Python script) emits it from a
+// compact high-level description like:
+//   distribute(W_gate, axis=1, num_shards=4, shard_width=256)
+// The repetitive partition declarations are generated, not written.
+// See: https://gist.github.com/kiszk/f575757845d8a637c81ec26735b39643
+// for a kernel-gen script that parameterizes tiling, core count, and fusion.
 
-#x_set         = affine_set<(d0, d1) : (d0 >= 0, -d0 + 3 >= 0, d1 >= 0, -d1 + 255 >= 0)>
-#gate_full_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 255 >= 0, d1 >= 0, -d1 + 1023 >= 0)>
-#gate_shard_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 255 >= 0, d1 >= 0, -d1 + 255 >= 0)>
-#down_full_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 1023 >= 0, d1 >= 0, -d1 + 255 >= 0)>
-#partial_set   = affine_set<(d0, d1) : (d0 >= 0, -d0 + 3 >= 0, d1 >= 0, -d1 + 255 >= 0)>
-#flat_1024_set = affine_set<(d0) : (d0 >= 0, -d0 + 1023 >= 0)>
-#identity_2d   = affine_map<(d0, d1) -> (d0, d1)>
-#identity_1d   = affine_map<(d0) -> (d0)>
-#all_tiles     = affine_set<(i)[g] : (i - 4*g >= 0, -i + 4*g + 3 >= 0)>
-#one_group     = affine_set<(g) : (g == 0)>
+// x and output coordinate set: [4, 256]
+#x_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 3 >= 0, d1 >= 0, -d1 + 255 >= 0)>
+
+// Access tile shape for each core's 256x256 shard (relative to access origin)
+#shard_set = affine_set<(d0, d1) : (d0 >= 0, -d0 + 255 >= 0, d1 >= 0, -d1 + 255 >= 0)>
+
+// W_gate / W_up column-shard coordinate sets (global coords)
+#gate_col_0 = affine_set<(d0, d1) : (d0 >= 0, -d0 + 255 >= 0, d1 >= 0, -d1 + 255 >= 0)>
+#gate_col_1 = affine_set<(d0, d1) : (d0 >= 0, -d0 + 255 >= 0, d1 - 256 >= 0, -d1 + 511 >= 0)>
+#gate_col_2 = affine_set<(d0, d1) : (d0 >= 0, -d0 + 255 >= 0, d1 - 512 >= 0, -d1 + 767 >= 0)>
+#gate_col_3 = affine_set<(d0, d1) : (d0 >= 0, -d0 + 255 >= 0, d1 - 768 >= 0, -d1 + 1023 >= 0)>
+
+// W_down row-shard coordinate sets (global coords)
+#down_row_0 = affine_set<(d0, d1) : (d0 >= 0, -d0 + 255 >= 0, d1 >= 0, -d1 + 255 >= 0)>
+#down_row_1 = affine_set<(d0, d1) : (d0 - 256 >= 0, -d0 + 511 >= 0, d1 >= 0, -d1 + 255 >= 0)>
+#down_row_2 = affine_set<(d0, d1) : (d0 - 512 >= 0, -d0 + 767 >= 0, d1 >= 0, -d1 + 255 >= 0)>
+#down_row_3 = affine_set<(d0, d1) : (d0 - 768 >= 0, -d0 + 1023 >= 0, d1 >= 0, -d1 + 255 >= 0)>
+
+#identity_2d = affine_map<(d0, d1) -> (d0, d1)>
+#all_tiles   = affine_set<(i)[g] : (i - 4*g >= 0, -i + 4*g + 3 >= 0)>
+#one_group   = affine_set<(g) : (g == 0)>
 
 module {
   func.func @ffn_swiglu_4core(
@@ -46,18 +110,17 @@ module {
   ) attributes {grid = [4]} {
     %c0 = arith.constant 0 : index
     %c256 = arith.constant 256 : index
-    %c1024 = arith.constant 1024 : index
+    %c512 = arith.constant 512 : index
+    %c768 = arith.constant 768 : index
+    %c65536 = arith.constant 65536 : index
+    %c131072 = arith.constant 131072 : index
+    %c196608 = arith.constant 196608 : index
 
     %pid = ktdp.get_compute_tile_id : index
     %ffn_start = arith.muli %pid, %c256 : index
 
-    // Base element offsets for this core's weight shards.
-    %gate_base = arith.addi %w_gate_ptr, %ffn_start : index
-    %up_base = arith.addi %w_up_ptr, %ffn_start : index
-    %down_row_offset = arith.muli %ffn_start, %c256 : index
-    %down_base = arith.addi %w_down_ptr, %down_row_offset : index
+    // ---- Replicated input and output views ----
 
-    // Replicated input and final output views.
     %x_view = ktdp.construct_memory_view %x_ptr, sizes: [4, 256], strides: [256, 1] {
       coordinate_set = #x_set,
       memory_space = #ktdp.spyre_memory_space<HBM>
@@ -68,43 +131,111 @@ module {
       memory_space = #ktdp.spyre_memory_space<HBM>
     } : memref<4x256xf16>
 
-    // Local FFN-dimension shards for this core.
-    %w_gate_view = ktdp.construct_memory_view %gate_base, sizes: [256, 256], strides: [1024, 1] {
-      coordinate_set = #gate_shard_set,
+    // ---- W_gate [256, 1024] distributed view: 4 column shards ----
+
+    %gate_p1_base = arith.addi %w_gate_ptr, %c256 : index
+    %gate_p2_base = arith.addi %w_gate_ptr, %c512 : index
+    %gate_p3_base = arith.addi %w_gate_ptr, %c768 : index
+
+    %gate_p0 = ktdp.construct_memory_view %w_gate_ptr, sizes: [256, 256], strides: [1024, 1] {
+      coordinate_set = #gate_col_0,
+      memory_space = #ktdp.spyre_memory_space<HBM>
+    } : memref<256x256xf16>
+    %gate_p1 = ktdp.construct_memory_view %gate_p1_base, sizes: [256, 256], strides: [1024, 1] {
+      coordinate_set = #gate_col_1,
+      memory_space = #ktdp.spyre_memory_space<HBM>
+    } : memref<256x256xf16>
+    %gate_p2 = ktdp.construct_memory_view %gate_p2_base, sizes: [256, 256], strides: [1024, 1] {
+      coordinate_set = #gate_col_2,
+      memory_space = #ktdp.spyre_memory_space<HBM>
+    } : memref<256x256xf16>
+    %gate_p3 = ktdp.construct_memory_view %gate_p3_base, sizes: [256, 256], strides: [1024, 1] {
+      coordinate_set = #gate_col_3,
       memory_space = #ktdp.spyre_memory_space<HBM>
     } : memref<256x256xf16>
 
-    %w_up_view = ktdp.construct_memory_view %up_base, sizes: [256, 256], strides: [1024, 1] {
-      coordinate_set = #gate_shard_set,
+    %w_gate_dist = ktdp.construct_distributed_memory_view
+        (%gate_p0, %gate_p1, %gate_p2, %gate_p3 : memref<256x256xf16>, memref<256x256xf16>, memref<256x256xf16>, memref<256x256xf16>)
+        : memref<256x1024xf16>
+
+    // ---- W_up [256, 1024] distributed view: 4 column shards ----
+
+    %up_p1_base = arith.addi %w_up_ptr, %c256 : index
+    %up_p2_base = arith.addi %w_up_ptr, %c512 : index
+    %up_p3_base = arith.addi %w_up_ptr, %c768 : index
+
+    %up_p0 = ktdp.construct_memory_view %w_up_ptr, sizes: [256, 256], strides: [1024, 1] {
+      coordinate_set = #gate_col_0,
+      memory_space = #ktdp.spyre_memory_space<HBM>
+    } : memref<256x256xf16>
+    %up_p1 = ktdp.construct_memory_view %up_p1_base, sizes: [256, 256], strides: [1024, 1] {
+      coordinate_set = #gate_col_1,
+      memory_space = #ktdp.spyre_memory_space<HBM>
+    } : memref<256x256xf16>
+    %up_p2 = ktdp.construct_memory_view %up_p2_base, sizes: [256, 256], strides: [1024, 1] {
+      coordinate_set = #gate_col_2,
+      memory_space = #ktdp.spyre_memory_space<HBM>
+    } : memref<256x256xf16>
+    %up_p3 = ktdp.construct_memory_view %up_p3_base, sizes: [256, 256], strides: [1024, 1] {
+      coordinate_set = #gate_col_3,
       memory_space = #ktdp.spyre_memory_space<HBM>
     } : memref<256x256xf16>
 
-    %w_down_view = ktdp.construct_memory_view %down_base, sizes: [256, 256], strides: [256, 1] {
-      coordinate_set = #gate_shard_set,
+    %w_up_dist = ktdp.construct_distributed_memory_view
+        (%up_p0, %up_p1, %up_p2, %up_p3 : memref<256x256xf16>, memref<256x256xf16>, memref<256x256xf16>, memref<256x256xf16>)
+        : memref<256x1024xf16>
+
+    // ---- W_down [1024, 256] distributed view: 4 row shards ----
+
+    %down_p1_base = arith.addi %w_down_ptr, %c65536 : index
+    %down_p2_base = arith.addi %w_down_ptr, %c131072 : index
+    %down_p3_base = arith.addi %w_down_ptr, %c196608 : index
+
+    %down_p0 = ktdp.construct_memory_view %w_down_ptr, sizes: [256, 256], strides: [256, 1] {
+      coordinate_set = #down_row_0,
+      memory_space = #ktdp.spyre_memory_space<HBM>
+    } : memref<256x256xf16>
+    %down_p1 = ktdp.construct_memory_view %down_p1_base, sizes: [256, 256], strides: [256, 1] {
+      coordinate_set = #down_row_1,
+      memory_space = #ktdp.spyre_memory_space<HBM>
+    } : memref<256x256xf16>
+    %down_p2 = ktdp.construct_memory_view %down_p2_base, sizes: [256, 256], strides: [256, 1] {
+      coordinate_set = #down_row_2,
+      memory_space = #ktdp.spyre_memory_space<HBM>
+    } : memref<256x256xf16>
+    %down_p3 = ktdp.construct_memory_view %down_p3_base, sizes: [256, 256], strides: [256, 1] {
+      coordinate_set = #down_row_3,
       memory_space = #ktdp.spyre_memory_space<HBM>
     } : memref<256x256xf16>
 
-    // Step 1: load full replicated x.
+    %w_down_dist = ktdp.construct_distributed_memory_view
+        (%down_p0, %down_p1, %down_p2, %down_p3 : memref<256x256xf16>, memref<256x256xf16>, memref<256x256xf16>, memref<256x256xf16>)
+        : memref<1024x256xf16>
+
+    // ---- Step 1: load replicated x ----
+
     %x_acc = ktdp.construct_access_tile %x_view[%c0, %c0] {
       access_tile_set = #x_set,
       access_tile_order = #identity_2d
     } : memref<4x256xf16> -> !ktdp.access_tile<4x256xindex>
     %x = ktdp.load %x_acc : !ktdp.access_tile<4x256xindex> -> tensor<4x256xf16>
 
-    // Steps 2-3: load local W_gate and W_up shards.
-    %w_gate_acc = ktdp.construct_access_tile %w_gate_view[%c0, %c0] {
-      access_tile_set = #gate_shard_set,
+    // ---- Steps 2-3: load local W_gate and W_up shards via distributed view ----
+
+    %w_gate_acc = ktdp.construct_access_tile %w_gate_dist[%c0, %ffn_start] {
+      access_tile_set = #shard_set,
       access_tile_order = #identity_2d
-    } : memref<256x256xf16> -> !ktdp.access_tile<256x256xindex>
+    } : memref<256x1024xf16> -> !ktdp.access_tile<256x256xindex>
     %w_gate = ktdp.load %w_gate_acc : !ktdp.access_tile<256x256xindex> -> tensor<256x256xf16>
 
-    %w_up_acc = ktdp.construct_access_tile %w_up_view[%c0, %c0] {
-      access_tile_set = #gate_shard_set,
+    %w_up_acc = ktdp.construct_access_tile %w_up_dist[%c0, %ffn_start] {
+      access_tile_set = #shard_set,
       access_tile_order = #identity_2d
-    } : memref<256x256xf16> -> !ktdp.access_tile<256x256xindex>
+    } : memref<256x1024xf16> -> !ktdp.access_tile<256x256xindex>
     %w_up = ktdp.load %w_up_acc : !ktdp.access_tile<256x256xindex> -> tensor<256x256xf16>
 
-    // Steps 4-5: local gate and up projections.
+    // ---- Steps 4-5: local gate and up projections ----
+
     %gate_init = tensor.empty() : tensor<4x256xf16>
     %gate = linalg.matmul ins(%x, %w_gate : tensor<4x256xf16>, tensor<256x256xf16>)
                           outs(%gate_init : tensor<4x256xf16>) -> tensor<4x256xf16>
@@ -113,7 +244,8 @@ module {
     %up = linalg.matmul ins(%x, %w_up : tensor<4x256xf16>, tensor<256x256xf16>)
                         outs(%up_init : tensor<4x256xf16>) -> tensor<4x256xf16>
 
-    // Step 6: local SwiGLU activation and fusion.
+    // ---- Step 6: SwiGLU activation and fusion ----
+
     %neg_gate = arith.negf %gate : tensor<4x256xf16>
     %exp_neg_gate = math.exp %neg_gate : tensor<4x256xf16>
     %one = arith.constant dense<1.0> : tensor<4x256xf16>
@@ -122,11 +254,12 @@ module {
     %silu = arith.mulf %gate, %sigmoid : tensor<4x256xf16>
     %fused = arith.mulf %silu, %up : tensor<4x256xf16>
 
-    // Step 7: load local W_down shard and compute local output partial.
-    %w_down_acc = ktdp.construct_access_tile %w_down_view[%c0, %c0] {
-      access_tile_set = #gate_shard_set,
+    // ---- Step 7: load local W_down shard and compute partial output ----
+
+    %w_down_acc = ktdp.construct_access_tile %w_down_dist[%ffn_start, %c0] {
+      access_tile_set = #shard_set,
       access_tile_order = #identity_2d
-    } : memref<256x256xf16> -> !ktdp.access_tile<256x256xindex>
+    } : memref<1024x256xf16> -> !ktdp.access_tile<256x256xindex>
     %w_down = ktdp.load %w_down_acc : !ktdp.access_tile<256x256xindex> -> tensor<256x256xf16>
 
     %out_partial_init = tensor.empty() : tensor<4x256xf16>
@@ -135,7 +268,8 @@ module {
 
     %out_partial_flat = tensor.collapse_shape %out_partial [[0, 1]] : tensor<4x256xf16> into tensor<1024xf16>
 
-    // Step 8: all-reduce the local output partial across all 4 cores.
+    // ---- Step 8: all-reduce partial outputs across 4 cores ----
+
     %fut = ktdp.inter_tile_produce
         producer_tiles_per_group = #all_tiles,
         groups                   = #one_group
@@ -165,7 +299,17 @@ module {
     %out_reduced = tensor.expand_shape %out_reduced_flat [[0, 1]] output_shape [4, 256]
                      : tensor<1024xf16> into tensor<4x256xf16>
 
-    // Step 9: residual add; only core 0 stores the final result.
+    // ---- Step 9: residual add and store ----
+    // After all-reduce, every core holds the full output.  Two strategies:
+    //   (a) All-reduce → 1 core stores (used here): simple, sufficient for
+    //       small outputs.  Cores 1-3 discard their identical result.
+    //   (b) Reduce-scatter → each core stores its slice: more bandwidth-
+    //       efficient for large outputs (e.g. seq=2048, d_model=4096) since
+    //       each core writes only 1/N of the result with no redundant traffic.
+    // We use (a) because the output is small ([4, 256]) and because
+    // inter_tile_reduce_scatter is not yet implemented — it depends on
+    // upstream ktir-mlir-frontend PR #23 (unmerged).
+
     %result = arith.addf %x, %out_reduced : tensor<4x256xf16>
     %is_writer = arith.cmpi eq, %pid, %c0 : index
     scf.if %is_writer {

--- a/ktir_cpu/latency.py
+++ b/ktir_cpu/latency.py
@@ -28,7 +28,9 @@ from enum import StrEnum
 from typing import Any, Dict, List, Optional, Tuple
 import numpy as np
 
-from .ir_types import AccessTile, IndirectAccessTile, MemRef, Tile, TileRef
+from .ir_types import (
+    AccessTile, DistributedTileRef, IndirectAccessTile, MemRef, Tile, TileRef,
+)
 from .dtypes import bytes_per_elem
 from .memory import HBMSimulator
 
@@ -312,6 +314,8 @@ class LatencyTracker:
             if isinstance(v, TileRef):
                 return v.memref.memory_space
             if isinstance(v, AccessTile):
+                if isinstance(v.parent_ref, DistributedTileRef):
+                    return v.parent_ref.partitions[0].memref.memory_space
                 return v.parent_ref.memref.memory_space
             if isinstance(v, IndirectAccessTile):
                 all_lx = (v.parent_ref.memory_space == "LX" and

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -327,6 +327,24 @@ EXAMPLE_PARAMS: dict[str, list[dict]] = {
             "group_size": 4,
         },
     ],
+    # ---------------------------------------------------------------------------
+    # FFN-SwiGLU example (Issue #77)
+    # ---------------------------------------------------------------------------
+    "ffn_swiglu": [
+        {
+            "path": "ktir/ffn_swiglu.mlir",
+            # Single-core FFN-SwiGLU with minimal dimensions:
+            # seq=1, d_model=64, d_ffn=128
+            # Tests the complete SwiGLU feedforward network:
+            #   gate = x @ W_gate, up = x @ W_up
+            #   silu = gate * sigmoid(gate)
+            #   fused = silu * up
+            #   out = fused @ W_down
+            #   result = x + out (residual)
+            # grid = [1, 1] → single core
+            "execute_kwargs": {},
+        },
+    ],
 }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -345,6 +345,32 @@ EXAMPLE_PARAMS: dict[str, list[dict]] = {
             "execute_kwargs": {},
         },
     ],
+    "ffn_swiglu_4core": [
+        {
+            "path": "ktir/ffn_swiglu_4core.mlir",
+            # 4-core distributed FFN-SwiGLU with hidden-dimension sharding.
+            # Global dimensions: seq=4, d_model=256, d_ffn=1024, grid=[4].
+            # x is replicated, each core owns a 256-wide FFN shard of W_gate/W_up
+            # and a 256-row shard of W_down, computes a local [4,256] partial,
+            # all-reduces it, adds the residual, and only core 0 writes back.
+            # HBM element-index layout (f16, 1 stick = 64 f16):
+            #   elems [0..1023]        → x        [4,256]
+            #   elems [1024..263167]   → W_gate   [256,1024]
+            #   elems [263168..525311] → W_up     [256,1024]
+            #   elems [525312..787455] → W_down   [1024,256]
+            #   elems [787456..788479] → out      [4,256]
+            "execute_kwargs": {
+                "x_ptr": 0,
+                "w_gate_ptr": 1024,
+                "w_up_ptr": 263168,
+                "w_down_ptr": 525312,
+                "out_ptr": 787456,
+            },
+            "seq": 4,
+            "d_model": 256,
+            "d_ffn": 1024,
+        },
+    ],
 }
 
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -801,6 +801,10 @@ class TestFFNSwiGLU4CoreExecution:
     dimension, compute local output partials, all-reduce them with
     ``ktdp.inter_tile_produce`` + ``ktdp.inter_tile_reduce``, then add the
     residual and have only core 0 write the final [4,256] result to HBM.
+
+    Does not use InterpreterTestMixin because multi-core execution requires
+    explicit HBM seeding via _prepare_execution — the single-core kwarg-based
+    interface does not support replicated/sharded memory layouts.
     """
 
     @staticmethod
@@ -872,10 +876,66 @@ class TestFFNSwiGLU4CoreExecution:
         assert result.shape == expected.shape, f"Shape mismatch: {result.shape} vs {expected.shape}"
         assert not np.any(np.isnan(result)), "output contains NaN"
         assert not np.any(np.isinf(result)), "output contains Inf"
+        # Looser than single-core (5e-2) because f16 overflow in exp() during
+        # SiLU causes a handful of outliers in 4-core accumulated outputs.
         np.testing.assert_allclose(
             result,
             expected,
-            rtol=2.5e-1,
-            atol=1e1,
+            rtol=1.5e-1,
+            atol=2.0,
             err_msg="Distributed FFN-SwiGLU output does not match NumPy reference",
         )
+
+    @pytest.mark.parametrize("path,func_name,entry", get_test_params("ffn_swiglu_4core"))
+    def test_ffn_swiglu_4core_zero_input(self, path, func_name, entry):
+        """Zero input should produce zero output: verifies all-reduce identity is correct."""
+        meta = parse_example(path, func_name)
+        import math
+        num_cores = math.prod(meta.grid)
+        assert num_cores == 4
+
+        seq = entry["seq"]
+        d_model = entry["d_model"]
+        d_ffn = entry["d_ffn"]
+        x_ptr = entry["execute_kwargs"]["x_ptr"]
+        w_gate_ptr = entry["execute_kwargs"]["w_gate_ptr"]
+        w_up_ptr = entry["execute_kwargs"]["w_up_ptr"]
+        w_down_ptr = entry["execute_kwargs"]["w_down_ptr"]
+        out_ptr = entry["execute_kwargs"]["out_ptr"]
+
+        x = np.zeros((seq, d_model), dtype=np.float16)
+        rng = np.random.default_rng(271828)
+        w_gate = rng.standard_normal((d_model, d_ffn)).astype(np.float16)
+        w_up = rng.standard_normal((d_model, d_ffn)).astype(np.float16)
+        w_down = rng.standard_normal((d_ffn, d_model)).astype(np.float16)
+        out = np.zeros((seq, d_model), dtype=np.float16)
+
+        interp = KTIRInterpreter()
+        interp.load(path)
+
+        STICK_BYTES = 128
+        F16_BYTES = 2
+        elems_per_stick = STICK_BYTES // F16_BYTES
+        x_stick = x_ptr // elems_per_stick
+        w_gate_stick = w_gate_ptr // elems_per_stick
+        w_up_stick = w_up_ptr // elems_per_stick
+        w_down_stick = w_down_ptr // elems_per_stick
+        out_stick = out_ptr // elems_per_stick
+
+        _orig = interp._prepare_execution
+
+        def _prepare_and_seed(grid_shape):
+            _orig(grid_shape)
+            interp.memory.hbm.write(x_stick, x.flatten())
+            interp.memory.hbm.write(w_gate_stick, w_gate.flatten())
+            interp.memory.hbm.write(w_up_stick, w_up.flatten())
+            interp.memory.hbm.write(w_down_stick, w_down.flatten())
+            interp.memory.hbm.write(out_stick, out.flatten())
+
+        interp._prepare_execution = _prepare_and_seed
+        interp.execute_function(func_name, **entry["execute_kwargs"])
+
+        result = interp.memory.hbm.read(out_stick, seq * d_model, "f16").reshape(seq, d_model)
+        expected = np.zeros((seq, d_model), dtype=np.float16)
+
+        np.testing.assert_allclose(result, expected, rtol=1e-3, atol=1e-3)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -792,3 +792,90 @@ class TestFFNSwiGLUExecution(InterpreterTestMixin):
         assert not np.any(np.isnan(result)), "output contains NaN"
         assert not np.any(np.isinf(result)), "output contains Inf"
         np.testing.assert_allclose(result, expected, rtol=1e-2, atol=1e-2)
+
+
+class TestFFNSwiGLU4CoreExecution:
+    """End-to-end execution of ffn_swiglu_4core.mlir.
+
+    This is the distributed Phase 2 variant: 4 cores shard the FFN hidden
+    dimension, compute local output partials, all-reduce them with
+    ``ktdp.inter_tile_produce`` + ``ktdp.inter_tile_reduce``, then add the
+    residual and have only core 0 write the final [4,256] result to HBM.
+    """
+
+    @staticmethod
+    def _ffn_reference(x, w_gate, w_up, w_down):
+        x_f32 = x.astype(np.float32)
+        w_gate_f32 = w_gate.astype(np.float32)
+        w_up_f32 = w_up.astype(np.float32)
+        w_down_f32 = w_down.astype(np.float32)
+
+        gate = x_f32 @ w_gate_f32
+        up = x_f32 @ w_up_f32
+        sigmoid = 1.0 / (1.0 + np.exp(-gate))
+        silu = gate * sigmoid
+        fused = silu * up
+        out_partial = fused @ w_down_f32
+        return (x_f32 + out_partial).astype(np.float16)
+
+    @pytest.mark.parametrize("path,func_name,entry", get_test_params("ffn_swiglu_4core"))
+    def test_ffn_swiglu_4core_distributed(self, path, func_name, entry):
+        meta = parse_example(path, func_name)
+        import math
+        num_cores = math.prod(meta.grid)
+        assert num_cores == 4
+
+        seq = entry["seq"]
+        d_model = entry["d_model"]
+        d_ffn = entry["d_ffn"]
+        x_ptr = entry["execute_kwargs"]["x_ptr"]
+        w_gate_ptr = entry["execute_kwargs"]["w_gate_ptr"]
+        w_up_ptr = entry["execute_kwargs"]["w_up_ptr"]
+        w_down_ptr = entry["execute_kwargs"]["w_down_ptr"]
+        out_ptr = entry["execute_kwargs"]["out_ptr"]
+
+        rng = np.random.default_rng(314159)
+        x = rng.standard_normal((seq, d_model)).astype(np.float16)
+        w_gate = rng.standard_normal((d_model, d_ffn)).astype(np.float16)
+        w_up = rng.standard_normal((d_model, d_ffn)).astype(np.float16)
+        w_down = rng.standard_normal((d_ffn, d_model)).astype(np.float16)
+        out = np.zeros((seq, d_model), dtype=np.float16)
+
+        interp = KTIRInterpreter()
+        interp.load(path)
+
+        STICK_BYTES = 128
+        F16_BYTES = 2
+        elems_per_stick = STICK_BYTES // F16_BYTES  # 64
+        x_stick = x_ptr // elems_per_stick
+        w_gate_stick = w_gate_ptr // elems_per_stick
+        w_up_stick = w_up_ptr // elems_per_stick
+        w_down_stick = w_down_ptr // elems_per_stick
+        out_stick = out_ptr // elems_per_stick
+
+        _orig = interp._prepare_execution
+
+        def _prepare_and_seed(grid_shape):
+            _orig(grid_shape)
+            interp.memory.hbm.write(x_stick, x.flatten())
+            interp.memory.hbm.write(w_gate_stick, w_gate.flatten())
+            interp.memory.hbm.write(w_up_stick, w_up.flatten())
+            interp.memory.hbm.write(w_down_stick, w_down.flatten())
+            interp.memory.hbm.write(out_stick, out.flatten())
+
+        interp._prepare_execution = _prepare_and_seed
+        interp.execute_function(func_name, **entry["execute_kwargs"])
+
+        result = interp.memory.hbm.read(out_stick, seq * d_model, "f16").reshape(seq, d_model)
+        expected = self._ffn_reference(x, w_gate, w_up, w_down)
+
+        assert result.shape == expected.shape, f"Shape mismatch: {result.shape} vs {expected.shape}"
+        assert not np.any(np.isnan(result)), "output contains NaN"
+        assert not np.any(np.isinf(result)), "output contains Inf"
+        np.testing.assert_allclose(
+            result,
+            expected,
+            rtol=2.5e-1,
+            atol=1e1,
+            err_msg="Distributed FFN-SwiGLU output does not match NumPy reference",
+        )

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -637,3 +637,158 @@ class TestRingReduceInnerLoopExecution:
         expected = (rows.sum(axis=0) * n_iters).astype(np.float16)
         np.testing.assert_allclose(result, expected, rtol=1e-2,
                                    err_msg="Core 0 output does not match n_iters * sum of input rows")
+
+
+class TestFFNSwiGLUExecution(InterpreterTestMixin):
+    """End-to-end execution of ffn_swiglu.mlir.
+
+    Tests the SwiGLU feedforward network implementation:
+        gate = x @ W_gate
+        up = x @ W_up
+        silu = gate * sigmoid(gate)  where sigmoid(x) = 1 / (1 + exp(-x))
+        fused = silu * up
+        out = fused @ W_down
+        result = x + out  (residual connection)
+
+    Phase 1: Single-core, minimal dimensions (seq=1, d_model=64, d_ffn=128)
+    """
+
+    @staticmethod
+    def _ffn_shapes(interp, func_name):
+        sizes = interp.tensor_input_output_sizes(func_name)
+        x_ptr, w_gate_ptr, w_up_ptr, w_down_ptr, out_ptr = interp.arg_names(func_name)
+        seq, d_model = sizes[x_ptr]["shape"]
+        gate_rows, d_ffn = sizes[w_gate_ptr]["shape"]
+        up_rows, up_cols = sizes[w_up_ptr]["shape"]
+        down_rows, down_cols = sizes[w_down_ptr]["shape"]
+        out_seq, out_model = sizes[out_ptr]["shape"]
+
+        assert gate_rows == d_model
+        assert up_rows == d_model
+        assert up_cols == d_ffn
+        assert down_rows == d_ffn
+        assert down_cols == d_model
+        assert out_seq == seq
+        assert out_model == d_model
+
+        return (x_ptr, w_gate_ptr, w_up_ptr, w_down_ptr, out_ptr), (seq, d_model, d_ffn)
+
+    @staticmethod
+    def _ffn_reference(x, w_gate, w_up, w_down):
+        """NumPy reference for SwiGLU FFN using f32 intermediates."""
+        x_f32 = x.astype(np.float32)
+        w_gate_f32 = w_gate.astype(np.float32)
+        w_up_f32 = w_up.astype(np.float32)
+        w_down_f32 = w_down.astype(np.float32)
+
+        gate = x_f32 @ w_gate_f32
+        up = x_f32 @ w_up_f32
+        sigmoid = 1.0 / (1.0 + np.exp(-gate))
+        silu = gate * sigmoid
+        fused = silu * up
+        out_partial = fused @ w_down_f32
+        return (x_f32 + out_partial).astype(np.float16)
+
+    @pytest.mark.parametrize("path,func_name,entry", get_test_params("ffn_swiglu"))
+    def test_ffn_swiglu_single_core(self, path, func_name, entry):
+        """Run FFN-SwiGLU on 1 core, verify output matches NumPy reference."""
+        interp = self._make_interp()
+        interp.load(path)
+
+        (x_ptr, w_gate_ptr, w_up_ptr, w_down_ptr, out_ptr), (seq, d_model, d_ffn) = (
+            self._ffn_shapes(interp, func_name)
+        )
+
+        rng = np.random.default_rng(42)
+        x = rng.standard_normal((seq, d_model)).astype(np.float16)
+        w_gate = rng.standard_normal((d_model, d_ffn)).astype(np.float16)
+        w_up = rng.standard_normal((d_model, d_ffn)).astype(np.float16)
+        w_down = rng.standard_normal((d_ffn, d_model)).astype(np.float16)
+        output = np.zeros((seq, d_model), dtype=np.float16)
+
+        outputs = interp.execute_function(func_name, **{
+            x_ptr: x,
+            w_gate_ptr: w_gate,
+            w_up_ptr: w_up,
+            w_down_ptr: w_down,
+            out_ptr: output,
+        })
+
+        result = outputs[out_ptr]
+        expected = self._ffn_reference(x, w_gate, w_up, w_down)
+
+        assert result.shape == expected.shape, f"Shape mismatch: {result.shape} vs {expected.shape}"
+        assert not np.any(np.isnan(result)), "output contains NaN"
+        assert not np.any(np.isinf(result)), "output contains Inf"
+
+        # Relaxed tolerance due to f16 accumulation in 3 matmuls + element-wise ops.
+        np.testing.assert_allclose(
+            result,
+            expected,
+            rtol=5e-2,
+            atol=5e-2,
+            err_msg="FFN-SwiGLU output does not match NumPy reference",
+        )
+
+    @pytest.mark.parametrize("path,func_name,entry", get_test_params("ffn_swiglu"))
+    def test_ffn_swiglu_zero_input(self, path, func_name, entry):
+        """Zero input should produce zero output even with non-zero weights."""
+        interp = self._make_interp()
+        interp.load(path)
+
+        (x_ptr, w_gate_ptr, w_up_ptr, w_down_ptr, out_ptr), (seq, d_model, d_ffn) = (
+            self._ffn_shapes(interp, func_name)
+        )
+
+        x = np.zeros((seq, d_model), dtype=np.float16)
+
+        rng = np.random.default_rng(123)
+        w_gate = rng.standard_normal((d_model, d_ffn)).astype(np.float16)
+        w_up = rng.standard_normal((d_model, d_ffn)).astype(np.float16)
+        w_down = rng.standard_normal((d_ffn, d_model)).astype(np.float16)
+        output = np.zeros((seq, d_model), dtype=np.float16)
+
+        outputs = interp.execute_function(func_name, **{
+            x_ptr: x,
+            w_gate_ptr: w_gate,
+            w_up_ptr: w_up,
+            w_down_ptr: w_down,
+            out_ptr: output,
+        })
+
+        result = outputs[out_ptr]
+        expected = np.zeros((seq, d_model), dtype=np.float16)
+        np.testing.assert_allclose(result, expected, rtol=1e-3, atol=1e-3)
+
+    @pytest.mark.parametrize("path,func_name,entry", get_test_params("ffn_swiglu"))
+    def test_ffn_swiglu_small_weights_reference(self, path, func_name, entry):
+        """Small weights should stay finite and match the NumPy reference."""
+        interp = self._make_interp()
+        interp.load(path)
+
+        (x_ptr, w_gate_ptr, w_up_ptr, w_down_ptr, out_ptr), (seq, d_model, d_ffn) = (
+            self._ffn_shapes(interp, func_name)
+        )
+
+        rng = np.random.default_rng(456)
+        x = rng.standard_normal((seq, d_model)).astype(np.float16)
+
+        w_gate = (rng.standard_normal((d_model, d_ffn)) * 0.1).astype(np.float16)
+        w_up = (rng.standard_normal((d_model, d_ffn)) * 0.1).astype(np.float16)
+        w_down = (rng.standard_normal((d_ffn, d_model)) * 0.1).astype(np.float16)
+        output = np.zeros((seq, d_model), dtype=np.float16)
+
+        outputs = interp.execute_function(func_name, **{
+            x_ptr: x,
+            w_gate_ptr: w_gate,
+            w_up_ptr: w_up,
+            w_down_ptr: w_down,
+            out_ptr: output,
+        })
+
+        result = outputs[out_ptr]
+        expected = self._ffn_reference(x, w_gate, w_up, w_down)
+
+        assert not np.any(np.isnan(result)), "output contains NaN"
+        assert not np.any(np.isinf(result)), "output contains Inf"
+        np.testing.assert_allclose(result, expected, rtol=1e-2, atol=1e-2)

--- a/tests/test_latency.py
+++ b/tests/test_latency.py
@@ -2262,3 +2262,341 @@ class TestRingReduceMultiGroupLatency:
         assert store_cores == expected_writers, (
             f"expected writers {expected_writers}, got {store_cores}"
         )
+
+
+# ---------------------------------------------------------------------------
+# FFN-SwiGLU single-core latency
+# ---------------------------------------------------------------------------
+
+
+def _run_ffn_swiglu(path, func_name, entry, cfg, trace=False):
+    """Run single-core FFN-SwiGLU and return latency report.
+
+    Dimensions: seq=1, d_model=64, d_ffn=128.
+    Loads: x [1,64], W_gate [64,128], W_up [64,128], W_down [128,64].
+    Matmuls: gate [1,64]×[64,128], up [1,64]×[64,128], down [1,128]×[128,64].
+    """
+    interp = KTIRInterpreter(latency_config=cfg, trace_latency=trace)
+    interp.load(path)
+    sizes = interp.tensor_input_output_sizes(func_name)
+    rng = np.random.default_rng(42)
+
+    x = rng.standard_normal(tuple(sizes["x_ptr"]["shape"])).astype(np.float16)
+    w_gate = rng.standard_normal(tuple(sizes["w_gate_ptr"]["shape"])).astype(np.float16)
+    w_up = rng.standard_normal(tuple(sizes["w_up_ptr"]["shape"])).astype(np.float16)
+    w_down = rng.standard_normal(tuple(sizes["w_down_ptr"]["shape"])).astype(np.float16)
+    out = np.zeros(tuple(sizes["out_ptr"]["shape"]), dtype=np.float16)
+
+    interp.execute_function(
+        func_name,
+        x_ptr=x, w_gate_ptr=w_gate, w_up_ptr=w_up,
+        w_down_ptr=w_down, out_ptr=out,
+    )
+    return interp.get_latency_report()
+
+
+class TestFFNSwiGLULatency:
+    """Per-core latency for the single-core FFN-SwiGLU in
+    ``examples/ktir/ffn_swiglu.mlir``.
+
+    Kernel dimensions: seq=1, d_model=64, d_ffn=128.
+
+    HBM loads per core (only 1 core):
+      - x:      [1, 64]   = 128 bytes
+      - W_gate: [64, 128] = 16384 bytes
+      - W_up:   [64, 128] = 16384 bytes
+      - W_down: [128, 64] = 16384 bytes
+      - store:  [1, 64]   = 128 bytes
+      Total HBM: 49152 bytes load + 128 bytes store = 49408 bytes
+
+    Matmul FLOPs:
+      - gate:  2 × 1 × 128 × 64  = 16384 FLOPs
+      - up:    2 × 1 × 128 × 64  = 16384 FLOPs
+      - down:  2 × 1 × 64  × 128 = 16384 FLOPs
+      Total systolic FLOPs: 49152
+
+    SIMD elementwise ops (on [1, 128] tiles = 128 elements each):
+      - negf, exp, addf, divf, mulf (silu), mulf (fused) = 6 ops × 128 elems
+      Plus residual addf on [1, 64] = 64 elements
+      Total SIMD elements: 6 × 128 + 64 = 832
+      With exp as transcendental (4× penalty): 128 × 4 + 5 × 128 + 64 = 1216
+      effective element-cycles
+
+    With default HardwareConfig (1.0 TB/s, 32 cores, 1.5 GHz):
+      per-core HBM BW = 1e12 / 1.5e9 / 32 = 20.83 B/cycle
+      memory_cycles ≈ 49408 / 20.83 ≈ 2372
+      compute (systolic) ≈ 49152 / (2*64*64*64) ≈ 0.094 cycles
+      compute (simd) ≈ 1216 / 64 ≈ 19 cycles
+    → memory-dominated
+    """
+
+    @pytest.mark.parametrize("path,func_name,entry", get_test_params("ffn_swiglu"))
+    def test_memory_dominated(self, path, func_name, entry):
+        """FFN is memory-bound: weight loads dwarf the matmul/SIMD compute."""
+        cfg = HardwareConfig()
+        report = _run_ffn_swiglu(path, func_name, entry, cfg)
+        assert report.bottleneck == "memory"
+        core0 = report.counters[0]
+        assert core0.memory_cycles > core0.compute_cycles * 10
+
+    @pytest.mark.parametrize("path,func_name,entry", get_test_params("ffn_swiglu"))
+    def test_matmul_cycle_formula(self, path, func_name, entry):
+        """Each linalg.matmul trace entry matches 2*M*N*K / systolic throughput."""
+        cfg = HardwareConfig()
+        report = _run_ffn_swiglu(path, func_name, entry, cfg, trace=True)
+        core0 = report.counters[0]
+
+        matmul_entries = [e for e in core0.trace if e.op_type == "linalg.matmul"]
+        assert len(matmul_entries) == 3
+
+        # gate: [1,64]×[64,128] → M=1, N=128, K=64
+        # up:   [1,64]×[64,128] → M=1, N=128, K=64
+        # down: [1,128]×[128,64] → M=1, N=64, K=128
+        expected_flops = [
+            2.0 * 1 * 128 * 64,
+            2.0 * 1 * 128 * 64,
+            2.0 * 1 * 64 * 128,
+        ]
+        for entry_e, flops in zip(matmul_entries, expected_flops):
+            assert entry_e.cycles == pytest.approx(
+                flops / cfg.systolic_flops_per_cycle
+            )
+
+    @pytest.mark.parametrize("path,func_name,entry", get_test_params("ffn_swiglu"))
+    @pytest.mark.parametrize("hbm_bw", [0.5, 1.0, 2.0, 4.0])
+    def test_memory_scales_with_bandwidth(self, path, func_name, entry, hbm_bw):
+        """Memory cycles scale inversely with HBM bandwidth."""
+        baseline_cfg = HardwareConfig(hbm_bandwidth_tb_s=1.0)
+        scaled_cfg = HardwareConfig(hbm_bandwidth_tb_s=hbm_bw)
+
+        baseline = _run_ffn_swiglu(path, func_name, entry, baseline_cfg)
+        scaled = _run_ffn_swiglu(path, func_name, entry, scaled_cfg)
+
+        baseline_mem = baseline.counters[0].memory_cycles
+        scaled_mem = scaled.counters[0].memory_cycles
+
+        expected_ratio = 1.0 / hbm_bw
+        actual_ratio = scaled_mem / baseline_mem
+        assert actual_ratio == pytest.approx(expected_ratio, rel=1e-3)
+
+    @pytest.mark.parametrize("path,func_name,entry", get_test_params("ffn_swiglu"))
+    @pytest.mark.parametrize("systolic", [
+        2 * 32 * 32 * 32,
+        2 * 64 * 64 * 64,
+        2 * 128 * 128 * 128,
+    ])
+    def test_matmul_scales_with_systolic(self, path, func_name, entry, systolic):
+        """Matmul cycles scale inversely with systolic throughput."""
+        cfg = HardwareConfig(systolic_flops_per_cycle=systolic)
+        report = _run_ffn_swiglu(path, func_name, entry, cfg, trace=True)
+        core0 = report.counters[0]
+
+        matmul_entries = [e for e in core0.trace if e.op_type == "linalg.matmul"]
+        # All three matmuls have the same FLOP count: 2*1*128*64 = 16384
+        for entry_e in matmul_entries:
+            assert entry_e.cycles == pytest.approx(16384.0 / systolic)
+
+    @pytest.mark.parametrize("path,func_name,entry", get_test_params("ffn_swiglu"))
+    def test_transcendental_penalty(self, path, func_name, entry):
+        """math.exp incurs the transcendental_penalty multiplier."""
+        cfg = HardwareConfig()
+        report = _run_ffn_swiglu(path, func_name, entry, cfg, trace=True)
+        core0 = report.counters[0]
+
+        exp_entries = [e for e in core0.trace if e.op_type == "math.exp"]
+        assert len(exp_entries) == 1
+        # exp on [1, 128] = 128 elements, penalty = 4
+        expected = 128.0 / cfg.simd_elements_per_cycle * cfg.transcendental_penalty
+        assert exp_entries[0].cycles == pytest.approx(expected)
+
+
+# ---------------------------------------------------------------------------
+# FFN-SwiGLU 4-core distributed latency
+# ---------------------------------------------------------------------------
+
+
+def _run_ffn_swiglu_4core(path, func_name, entry, cfg, trace=False):
+    """Run 4-core distributed FFN-SwiGLU and return latency report.
+
+    Dimensions: seq=4, d_model=256, d_ffn=1024, grid=[4].
+    Uses _prepare_execution patching to seed HBM (same as the correctness
+    test in test_examples.py and the ring_reduce latency test above).
+    """
+    meta = parse_example(path, func_name)
+    num_cores = math.prod(meta.grid)
+
+    seq = entry["seq"]
+    d_model = entry["d_model"]
+    d_ffn = entry["d_ffn"]
+
+    rng = np.random.default_rng(42)
+    x = rng.standard_normal((seq, d_model)).astype(np.float16)
+    w_gate = rng.standard_normal((d_model, d_ffn)).astype(np.float16)
+    w_up = rng.standard_normal((d_model, d_ffn)).astype(np.float16)
+    w_down = rng.standard_normal((d_ffn, d_model)).astype(np.float16)
+
+    x_ptr = entry["execute_kwargs"]["x_ptr"]
+    w_gate_ptr = entry["execute_kwargs"]["w_gate_ptr"]
+    w_up_ptr = entry["execute_kwargs"]["w_up_ptr"]
+    w_down_ptr = entry["execute_kwargs"]["w_down_ptr"]
+    out_ptr = entry["execute_kwargs"]["out_ptr"]
+
+    _elems_per_stick = 64
+    x_stick = x_ptr // _elems_per_stick
+    w_gate_stick = w_gate_ptr // _elems_per_stick
+    w_up_stick = w_up_ptr // _elems_per_stick
+    w_down_stick = w_down_ptr // _elems_per_stick
+
+    interp = KTIRInterpreter(latency_config=cfg, trace_latency=trace)
+    interp.load(path)
+
+    _orig = interp._prepare_execution
+
+    def _prepare_and_seed(grid_shape):
+        _orig(grid_shape)
+        interp.memory.hbm.write(x_stick, x.flatten())
+        interp.memory.hbm.write(w_gate_stick, w_gate.flatten())
+        interp.memory.hbm.write(w_up_stick, w_up.flatten())
+        interp.memory.hbm.write(w_down_stick, w_down.flatten())
+
+    interp._prepare_execution = _prepare_and_seed
+    interp.execute_function(func_name, **entry["execute_kwargs"])
+    return interp.get_latency_report(), num_cores
+
+
+class TestFFNSwiGLU4CoreLatency:
+    """Per-core latency for the 4-core distributed FFN-SwiGLU in
+    ``examples/ktir/ffn_swiglu_4core.mlir``.
+
+    Kernel: seq=4, d_model=256, d_ffn=1024, grid=[4].
+    Each core owns a 256-wide shard of W_gate/W_up (column-sharded)
+    and a 256-row shard of W_down (row-sharded).
+
+    Per-core HBM loads:
+      - x:      [4, 256]  = 2048 bytes (replicated, all cores load)
+      - W_gate: [256, 256] = 131072 bytes (shard)
+      - W_up:   [256, 256] = 131072 bytes (shard)
+      - W_down: [256, 256] = 131072 bytes (shard)
+      Total load: 395264 bytes/core
+
+    Per-core HBM stores (core 0 only):
+      - out:    [4, 256]  = 2048 bytes
+
+    Per-core matmuls (each core):
+      - gate: [4,256]×[256,256] → 2×4×256×256 = 524288 FLOPs
+      - up:   [4,256]×[256,256] → 2×4×256×256 = 524288 FLOPs
+      - down: [4,256]×[256,256] → 2×4×256×256 = 524288 FLOPs
+      Total systolic: 1572864 FLOPs/core
+
+    Per-core elementwise (on [4, 256] = 1024 elements):
+      - negf, exp(×4 penalty), addf, divf, mulf, mulf = 6 ops
+      - residual addf on [4, 256]
+      SIMD cycles: (128×4 + 5×1024 + 1024) / 64 ≈ 102 cycles
+
+    Per-core comm (ring all-reduce of [1024] f16 partial = 2048 bytes):
+      - Ring: 4 cores, 3 rounds, 2048 bytes/round = 6144 bytes/core
+
+    With default HardwareConfig (1.0 TB/s, 32 cores, 1.5 GHz):
+      per-core HBM BW = 20.83 B/cycle
+      memory_cycles ≈ 395264 / 20.83 ≈ 18984 cycles
+      systolic_cycles ≈ 1572864 / 524288 ≈ 3 cycles
+      comm_cycles ≈ 6144 / 4000 ≈ 1.5 cycles
+    → memory-dominated
+    """
+
+    @pytest.mark.parametrize("path,func_name,entry", get_test_params("ffn_swiglu_4core"))
+    def test_memory_dominated(self, path, func_name, entry):
+        """4-core FFN is memory-bound: weight shard loads dominate."""
+        cfg = HardwareConfig()
+        report, _ = _run_ffn_swiglu_4core(path, func_name, entry, cfg)
+        assert report.bottleneck == "memory"
+        core0 = report.counters[0]
+        assert core0.memory_cycles > core0.compute_cycles
+
+    @pytest.mark.parametrize("path,func_name,entry", get_test_params("ffn_swiglu_4core"))
+    def test_per_core_compute_symmetric(self, path, func_name, entry):
+        """All 4 cores execute the same matmuls and SIMD ops: equal compute."""
+        cfg = HardwareConfig()
+        report, num_cores = _run_ffn_swiglu_4core(path, func_name, entry, cfg)
+        compute_cycles = [report.counters[c].compute_cycles for c in range(num_cores)]
+        for c in range(1, num_cores):
+            assert compute_cycles[c] == pytest.approx(compute_cycles[0])
+
+    @pytest.mark.parametrize("path,func_name,entry", get_test_params("ffn_swiglu_4core"))
+    def test_per_core_comm_symmetric(self, path, func_name, entry):
+        """All 4 cores participate equally in the all-reduce ring."""
+        cfg = HardwareConfig()
+        report, num_cores = _run_ffn_swiglu_4core(path, func_name, entry, cfg)
+        comm_cycles = [report.counters[c].comm_cycles for c in range(num_cores)]
+        for c in range(1, num_cores):
+            assert comm_cycles[c] == pytest.approx(comm_cycles[0])
+
+    @pytest.mark.parametrize("path,func_name,entry", get_test_params("ffn_swiglu_4core"))
+    def test_comm_bytes_formula(self, path, func_name, entry):
+        """Ring comm bytes = (N_ring - 1) × partial_bytes per core."""
+        cfg = HardwareConfig()
+        report, num_cores = _run_ffn_swiglu_4core(path, func_name, entry, cfg, trace=True)
+
+        # Partial is [1024] f16 = 2048 bytes; ring does N-1 = 3 rounds.
+        partial_bytes = entry["seq"] * entry["d_model"] * 2  # [4,256] → 1024 elems × 2B
+        expected_comm_bytes = (num_cores - 1) * partial_bytes
+        expected_comm_cycles = expected_comm_bytes / cfg.ring_bytes_per_cycle
+
+        for core_id in range(num_cores):
+            cc = report.counters[core_id]
+            assert cc.comm_bytes == expected_comm_bytes
+            assert cc.comm_cycles == pytest.approx(expected_comm_cycles)
+
+    @pytest.mark.parametrize("path,func_name,entry", get_test_params("ffn_swiglu_4core"))
+    def test_matmul_cycle_formula(self, path, func_name, entry):
+        """Each core runs 3 matmuls of [4,256]×[256,256]; verify cycle formula."""
+        cfg = HardwareConfig()
+        report, num_cores = _run_ffn_swiglu_4core(path, func_name, entry, cfg, trace=True)
+
+        # All three matmuls: M=4, N=256, K=256 → 2*4*256*256 = 524288 FLOPs each
+        expected_per_matmul = (2.0 * 4 * 256 * 256) / cfg.systolic_flops_per_cycle
+
+        for core_id in range(num_cores):
+            cc = report.counters[core_id]
+            matmul_entries = [e for e in cc.trace if e.op_type == "linalg.matmul"]
+            assert len(matmul_entries) == 3
+            for entry_e in matmul_entries:
+                assert entry_e.cycles == pytest.approx(expected_per_matmul)
+
+    @pytest.mark.parametrize("path,func_name,entry", get_test_params("ffn_swiglu_4core"))
+    def test_store_only_core_0(self, path, func_name, entry):
+        """Only core 0 writes back the final output."""
+        cfg = HardwareConfig()
+        report, num_cores = _run_ffn_swiglu_4core(path, func_name, entry, cfg, trace=True)
+
+        store_cores = [
+            cid for cid, cc in report.counters.items()
+            if any(t.op_type == "ktdp.store" for t in cc.trace)
+        ]
+        assert store_cores == [0]
+
+    @pytest.mark.parametrize("path,func_name,entry", get_test_params("ffn_swiglu_4core"))
+    def test_core0_heaviest(self, path, func_name, entry):
+        """Core 0 carries the extra store → highest total cycles."""
+        cfg = HardwareConfig()
+        report, num_cores = _run_ffn_swiglu_4core(path, func_name, entry, cfg)
+        per_core_total = {c: report.counters[c].total_cycles for c in range(num_cores)}
+        assert report.kernel_cycles == max(per_core_total.values())
+        assert per_core_total[0] >= max(per_core_total[c] for c in range(1, num_cores))
+
+    @pytest.mark.parametrize("path,func_name,entry", get_test_params("ffn_swiglu_4core"))
+    @pytest.mark.parametrize("hbm_bw", [0.5, 1.0, 2.0])
+    def test_memory_scales_with_bandwidth(self, path, func_name, entry, hbm_bw):
+        """Memory cycles scale inversely with HBM bandwidth."""
+        baseline_cfg = HardwareConfig(hbm_bandwidth_tb_s=1.0)
+        scaled_cfg = HardwareConfig(hbm_bandwidth_tb_s=hbm_bw)
+
+        baseline, _ = _run_ffn_swiglu_4core(path, func_name, entry, baseline_cfg)
+        scaled, _ = _run_ffn_swiglu_4core(path, func_name, entry, scaled_cfg)
+
+        baseline_mem = baseline.counters[0].memory_cycles
+        scaled_mem = scaled.counters[0].memory_cycles
+
+        expected_ratio = 1.0 / hbm_bw
+        actual_ratio = scaled_mem / baseline_mem
+        assert actual_ratio == pytest.approx(expected_ratio, rel=1e-3)


### PR DESCRIPTION
**Issues** partially addressing: #77 


1. **Gist:**  about creating MLIR example codes to drive the model coverage tests for the stage of the MLP (three feedforward layers with SwiGLU). 
2. **What's done** : Aded a mlir program for ffn_swiglu for 1-core, with batchsize=1. 
3. **Missing**: Not covering distributed variant running on 4 cores with correct all-reduce. 
1. **On going**: To add the distributed case in the same PR, may combine example code. 

```
// FFN-SwiGLU: Feedforward network with SwiGLU activation
// 
// Algorithm:
//   gate = x @ W_gate
//   up = x @ W_up
//   silu = gate * sigmoid(gate)  where sigmoid(x) = 1 / (1 + exp(-x))
//   fused = silu * up
//   out = fused @ W_down
//   result = x + out  (residual connection)
//
// Dimensions (Phase 1 - minimal):
//   seq = 1, d_model = 64, d_ffn = 128
//   All operations single-core, no tiling

```
