### PR TITLE
[latency] Surface cross-core communication view in latency_demo.ipynb

### DIFF
--- a/notebooks/latency_demo.ipynb
+++ b/notebooks/latency_demo.ipynb
@@ -662,6 +662,32 @@
   },
   {
    "cell_type": "markdown",
+   "source": "## 7. Cross-core communication (comm) view\n\nEvery kernel above is embarrassingly parallel, so the `comm` column reads `0`. Communication *is* costed by\nthe model (`ktdp.inter_tile_reduce` → `comm_cycles`, folded into `total_cycles`; `bottleneck` recognises\n`comm`) — it just isn't exercised or surfaced here.\n\nThis section loads the in-repo cross-core all-reduce examples (`examples/ktir/ring_reduce*.mlir`) and surfaces\ncommunication: a per-core `compute / memory / comm` breakdown, plus the **critical-path core**'s\n`comm_fraction`, `comm_time`, and `comm_bytes`. Metrics are taken on the critical core (`max(total_cycles)`)\n— the wall-clock core `kernel_time` comes from — so this is *exposed communication* (PyTorch **HTA** framing):\ncomm on a non-critical core is hidden behind that core's own work and adds no wall time.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "source": "_KTIR = _REPO / \"examples\" / \"ktir\"\n\ndef run_comm_kernel(path, func, num_cores=4, n_cols=128, in_ptr=0, out_ptr=512, **run_kwargs):\n    \"\"\"Load an inter-tile reduce example, seed its HBM inputs, run it, return the LatencyReport.\n\n    ``in_ptr`` / ``out_ptr`` are f16 element indices (base_ptr convention); ``hbm.write`` takes\n    stick indices, so divide by elements-per-stick (64). ``out_ptr`` must be stick-aligned.\n    \"\"\"\n    interp = KTIRInterpreter(latency_config=hw, trace_latency=True)\n    interp.load(str(path))\n    rng = np.random.default_rng(42)\n    rows = rng.uniform(1.0, 2.0, size=(num_cores, n_cols)).astype(np.float16)\n    eps = 64  # f16 elements per 128-byte stick\n    _orig = interp._prepare_execution\n    def _seed(grid_shape):\n        _orig(grid_shape)\n        interp.memory.hbm.write(in_ptr // eps, rows.flatten())\n        interp.memory.hbm.write(out_ptr // eps, np.zeros(n_cols, dtype=np.float16))\n    interp._prepare_execution = _seed\n    interp.execute_function(func, in_ptr=in_ptr, out_ptr=out_ptr, **run_kwargs)\n    return interp.get_latency_report()\n\ndef comm_metrics(report):\n    \"\"\"Communication metrics on the critical-path core (exposed comm).\"\"\"\n    crit = max(report.per_core_summary(), key=lambda r: r[\"total_cycles\"])\n    total = crit[\"total_cycles\"]\n    breakdown = ({k: crit[f\"{k}_cycles\"] / total for k in (\"compute\", \"memory\", \"comm\")}\n                 if total else {})\n    return {\n        \"critical_core\": crit[\"core_id\"],\n        \"bottleneck\": report.bottleneck,\n        \"comm_fraction\": crit[\"comm_cycles\"] / total if total else 0.0,   # exposed comm share\n        \"comm_time_us\": crit[\"comm_cycles\"] / (hw.clock_ghz * 1e3),        # same conversion as kernel_time_us\n        \"comm_bytes\": report.counters[crit[\"core_id\"]].comm_bytes,         # per-core ring bytes\n        \"temporal_breakdown\": breakdown,                                    # 3 ratios, sum = 1\n    }\n\ndef print_comm_table(report):\n    \"\"\"Critical-core comm metrics + per-core compute/memory/comm table.\"\"\"\n    m = comm_metrics(report)\n    print(f\"critical core={m['critical_core']}  bottleneck={m['bottleneck']}  \"\n          f\"comm_fraction={m['comm_fraction']*100:.2f}%  \"\n          f\"comm_time={m['comm_time_us']*1e3:.3f} ns  \"\n          f\"comm_bytes={m['comm_bytes']} (per-core)\")\n    hdr = f\"{'core':>4}  {'compute':>10}  {'memory':>10}  {'comm':>10}  {'total':>10}  {'comm%':>6}\"\n    print(hdr); print(\"-\" * len(hdr))\n    for r in report.per_core_summary():\n        t = r[\"total_cycles\"]\n        print(f\"{r['core_id']:>4}  {r['compute_cycles']:>10.3f}  {r['memory_cycles']:>10.3f}  \"\n              f\"{r['comm_cycles']:>10.3f}  {t:>10.3f}  {r['comm_cycles']/t*100:>5.2f}%\")\n\ndef plot_comm_breakdown(report, title):\n    \"\"\"Per-core stacked bar of compute / memory / comm cycles, with value labels.\"\"\"\n    pcs = report.per_core_summary()\n    cores = [r[\"core_id\"] for r in pcs]\n    m = comm_metrics(report)\n    fig, ax = plt.subplots(figsize=(7, 4))\n    bottom = np.zeros(len(cores))\n    for name, color in [(\"compute\", \"#5B8FF9\"), (\"memory\", \"#F6BD16\"), (\"comm\", \"#E8684A\")]:\n        vals = np.array([r[f\"{name}_cycles\"] for r in pcs])\n        ax.bar(cores, vals, bottom=bottom, label=name, color=color, width=0.6, edgecolor=\"white\")\n        for x, v, b in zip(cores, vals, bottom):\n            if v > 0.05:\n                ax.text(x, b + v / 2, f\"{v:.2f}\", ha=\"center\", va=\"center\",\n                        fontsize=8, color=\"white\" if name != \"memory\" else \"#333\")\n        bottom += vals\n    ax.set_xlabel(\"core\"); ax.set_ylabel(\"cycles\"); ax.set_xticks(cores)\n    ax.set_title(f\"{title}\\ncritical core={m['critical_core']} · bottleneck={m['bottleneck']} · \"\n                 f\"comm_fraction={m['comm_fraction']*100:.2f}% · comm_time={m['comm_time_us']*1e3:.3f} ns\",\n                 fontsize=9)\n    ax.legend(frameon=False, ncol=3, loc=\"upper right\")\n    for s in (\"top\", \"right\"):\n        ax.spines[s].set_visible(False)\n    plt.tight_layout(); plt.show()",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "source": "# ring_reduce — single-ring all-reduce (one top-level comm)\nrr = run_comm_kernel(_KTIR / \"ring_reduce.mlir\", \"ring_reduce\")\nprint_comm_table(rr)\nplot_comm_breakdown(rr, \"ring_reduce — per-core compute/memory/comm\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "source": "# ring_reduce_inner_loop — same all-reduce inside scf.for (comm scales with iterations)\nrril = run_comm_kernel(_KTIR / \"ring_reduce_inner_loop.mlir\", \"ring_reduce_inner_loop\", n_iters=3)\nprint_comm_table(rril)\nplot_comm_breakdown(rril, \"ring_reduce_inner_loop (n_iters=3) — per-core compute/memory/comm\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "## Summary\n",


### PR DESCRIPTION
Spyre's chip has many cores; some kernels need cores to exchange and combine partial results over the on-chip ring interconnect (a "cross-core reduce"). That exchange costs time, but the latency tool could never show it. This change surfaces it.

**What.** Add a cross-core **communication view** to `latency_demo.ipynb` — a per-core compute/memory/comm breakdown plus, on the critical (wall-clock) core, `comm_fraction` / `comm_time` / `comm_bytes`.

**Why.** The latency model already costs communication (folded into `total_cycles`), but the notebook never showed it — so *"how much latency does a cross-core reduce add, and is comm ever the bottleneck?"* was unanswerable.

Driven on the in-repo `examples/ktir/ring_reduce*.mlir` all-reduce kernels, the comm segment now shows as a distinct, non-zero slice (e.g. `ring_reduce`: comm = 0.85% of the critical core, memory-bound). **Rendered charts + tables in the comment below.**

**Before → after**
- Before: the `comm` column prints integer cycles (sub-cycle comm rounds to `0`), and no communicating kernel is even loaded — comm is effectively invisible.
- After: a stacked-bar breakdown + critical-core comm metrics, computed in-cell from the existing `LatencyReport`.

**Metrics** (all on the critical-path core = `max(total_cycles)`)

| metric | formula |
|---|---|
| `comm_fraction` | `comm_cycles / total_cycles` |
| `comm_time` | `comm_cycles / (clock_ghz · 1e3)` (µs) |
| temporal breakdown | `{compute, memory, comm}_cycles / total_cycles` |
| `comm_bytes` | per-core ring bytes (Σ over that core's hops) |

`total_cycles = compute + memory + comm`; `comm_cycles = comm_bytes / ring_bytes_per_cycle` (already modelled).

**Scope.** Notebook-only; no `ktir_cpu` change; surfacing only. Part of #126 (report-API promotion and a composite cross-core kernel are follow-ups).
