### PR TITLE
[latency] Chip-level roofline metrics + per-core rename

### DIFF
--- a/docs/latency.md
+++ b/docs/latency.md
@@ -258,18 +258,57 @@ GFLOP/s
 - **BW ceiling** (the slope): `peak_bw × AI`. When a kernel has low arithmetic intensity it cannot feed the compute units fast enough — performance is limited by memory bandwidth.
 - **Compute ceiling** (the flat top): `peak_gflops`. Once AI is high enough, the compute units are fully utilized.
 - **Ridge point**: `peak_gflops / peak_bw`. Left of it the kernel is memory-bound; right of it, compute-bound.
-- **Efficiency**: `achieved / ceiling` — how close the kernel gets to the roofline at its operating point.
+- **Efficiency**: `achieved / ceiling` — how close the kernel gets to the roofline at its operating point (reported per-core as `core_efficiency`).
 
-Access roofline metrics via `report.roofline()`:
+The roofline is split **by granularity into two methods**: `chip_roofline()` (the whole chip as one unit,
+plain NCU-style names) and `core_roofline()` (the critical-path core, `core_*` names). `roofline()` returns
+both merged into one flat dict for a single-call / back-compatible view.
 
 ```python
 report = interp.get_latency_report()
-rf = report.roofline()
-print(rf["arithmetic_intensity"])  # FLOP/B
-print(rf["efficiency"])            # 0..1
+
+# Chip-level (whole chip as one unit) — aggregates all cores; aggregate HBM roof
+chip = report.chip_roofline()
+print(chip["AI"])                     # FLOP/B — Σ FLOP / Σ HBM bytes over all cores
+print(chip["compute_throughput"])     # 0..1  — compute SOL
+print(chip["dram_throughput"])        # 0..1  — memory SOL
+print(chip["mean_core_active_frac"])  # 0..1  — time-based core occupancy
+print(chip["grid_coverage"])          # 0..1  — spatial dispatch coverage
+
+# Per-core (critical-path core)
+core = report.core_roofline()
+print(core["core_AI"])                # FLOP/B
+print(core["core_efficiency"])        # 0..1
+print(core["core_dominant_unit"])     # "systolic" | "simd"
+print(core["units"])                  # per-unit breakdown (systolic / simd)
+
+rf = report.roofline()                # chip + core merged (== {**core, **chip})
 ```
 
+The two methods **do not share inputs across granularity**: `chip_roofline()` aggregates every core's counters
+and reads the *aggregate* `hbm_bandwidth_tb_s` directly (never the per-core `÷ num_cores` figure), and picks
+its dominant unit chip-wide; `core_roofline()` uses the critical core and the per-core bandwidth. Only the
+wall-clock `elapsed` (the critical core's total cycles) is shared — it is when the whole chip finishes.
+
 > **Note:** The roofline model only covers compute and HBM bandwidth. Communication cycles (ring allgather/reduce) are not modelled. For comm-dominated kernels, `report.bottleneck` may report `"comm"` while the roofline classifies based on the compute-vs-HBM ratio alone. For `"compute"` or `"memory"` bottlenecks, the roofline bound always agrees with `bottleneck`.
+
+### Chip-level metrics
+
+The chip-level metrics treat the **whole chip as one unit** (the way Nsight Compute views a device), aggregating the existing per-core counters — no new inputs. HBM is one shared chip resource, so the memory roof is the **aggregate** `hbm_bandwidth_tb_s`, read directly (never the per-core `hbm_bandwidth_tb_s / num_cores` partition). Intra-chip ring / per-core partition / multicast are out of scope here. All the throughput/occupancy metrics are peak-based ratios in `[0, 1]`.
+
+`Σ FLOP` counts the **dominant unit's** FLOP (aggregated over cores), not both units summed: the systolic (`2·M·N·K`) and SIMD (per-element) FLOP are not comparable and the units' peaks differ by orders of magnitude, so summing them and dividing by one unit's peak would push `compute_throughput` above 1. Using the dominant unit's FLOP mirrors the per-core AI and keeps the chip point self-consistent (same numerator on both axes).
+
+| Metric | Formula | Meaning (Nsight analogue) |
+|---|---|---|
+| `AI` | `Σ FLOP / Σ HBM bytes` | roofline x-axis (Arithmetic Intensity); dominant-unit FLOP, HBM `dram_bytes` only, ring excluded |
+| `compute_throughput` | `Σ FLOP / elapsed / chip_peak` | compute SOL — fraction of chip compute peak (*Compute (SM) Throughput %*). `chip_peak = dominant-unit per-core peak × num_cores` |
+| `dram_throughput` | `Σ HBM bytes / (hbm_bw × elapsed)` | memory SOL — fraction of aggregate HBM bandwidth (*DRAM/Memory Throughput %*) |
+| `mean_core_active_frac` | `Σ core.total_cycles / (num_cores × elapsed_cycles)` | time-based core occupancy over all cores (*SM Active %*). Two deliberate differences: *active* = compute + memory + comm cycles, and `elapsed_cycles` is the critical core's total cycles (a wall-clock proxy) |
+| `grid_coverage` | `cores_active / num_cores` | **spatial** dispatch coverage — fraction of chip cores dispatched any work; not core busyness (so it is *not* the *SM Active %* — that role is `mean_core_active_frac`) |
+
+The `ridge_point` (`chip_peak / hbm_bw`) is identical at chip and per-core granularity: the dominant unit is decided **once, chip-wide** (from cycles summed over all cores) and shared by both granularities, and `num_cores` cancels within a unit. So the normalised roofline (throughput as a fraction of peak vs AI) is granularity-invariant — the notebook plots the chip point and the per-core point under one shared roof, each labelled by granularity.
+
+**Per-core rename.** The plain NCU names belong to the chip level, so the per-core headline fields carry a `core_` prefix: `core_AI`, `core_efficiency`, `core_dominant_unit` (semantics unchanged). The per-unit `units[...]` breakdown also exposes each unit's own chip-wide `compute_throughput`.
 
 ### Example: vector_add (memory-bound)
 

--- a/ktir_cpu/latency.py
+++ b/ktir_cpu/latency.py
@@ -485,192 +485,247 @@ class LatencyReport:
             })
         return summaries
 
-    def roofline(self) -> Dict[str, Any]:
-        """Compute per-unit roofline metrics for the critical-path core.
+    # ------------------------------------------------------------------
+    # Roofline — shared base, then chip / per-core fork
+    # ------------------------------------------------------------------
+    # Two compute units are modelled: systolic (``linalg.matmul``) and SIMD
+    # (float / transcendental / int). Their FLOPs are not comparable (matmul
+    # ``2*M*N*K`` vs SIMD per-element) and their peaks differ by orders of
+    # magnitude, so every roofline reports the *dominant* unit — the one that
+    # consumed the most cycles (the bottleneck). Cycles, not FLOPs, pick it.
 
-        Two compute units are modelled (systolic for matmul, SIMD for everything
-        else).  The dominant unit — whichever consumed the most compute cycles —
-        sets the headline.  The chart shows one roof::
+    def _roofline_common(self) -> Dict[str, Any]:
+        """Granularity-agnostic quantities shared by :meth:`chip_roofline` and
+        :meth:`core_roofline`, gathered in one place so neither method
+        re-derives them (each call builds this dict once; :meth:`roofline`,
+        which calls both, builds it twice — negligible for report sizes).
 
-            GFLOP/s
-              ^
-              |         peak (dominant unit)
-              |        .----------------------------  compute ceiling
-              |       /
-              |      /    * kernel dot
-              |     /
-              |    /
-              |   /  BW ceiling = peak_bw × AI
-              |  /
-              | /
-              +-----------------------------------> AI (FLOP/B)
-                       ^
-                  ridge point
+        Nothing here mixes granularity: hardware peak rates, the wall-clock
+        elapsed (= the critical core's total cycles, i.e. when the whole chip
+        finishes), and core counts.
 
+        The **dominant unit is decided here, once**, from cycles summed over
+        ALL cores, and both :meth:`chip_roofline` and :meth:`core_roofline`
+        consume that single value — they never re-derive it, so the two can
+        never disagree. Dominant is a workload property (every core runs the
+        same op mix in data-parallel execution), not a per-core one, so the
+        chip-wide aggregate is the right — and only — place to decide it.
 
-
-        - **systolic**: ``linalg.matmul`` ops, peak = ``systolic_flops_per_cycle × clock``
-        - **simd**: all other compute ops (float, transcendental, int),
-          peak = ``simd_elements_per_cycle × clock``
-
-        The **dominant unit** is whichever consumed the most compute cycles in
-        the kernel trace — the real bottleneck.  FLOPs are not comparable across
-        units (matmul ``2*M*N*K`` vs SIMD per-element), so cycles, not FLOPs,
-        identify the busy unit.  The summary ``arithmetic_intensity`` and
-        ``efficiency`` are reported for the dominant unit.
-
-        For each unit, ``achieved_gflops`` is ``unit_flops / total_wall_time``
-        (not unit_flops / unit_cycles) so the achieved rate reflects true
-        end-to-end throughput including memory stalls.
-
-        .. note:: The roofline covers compute and HBM bandwidth only.
-           Communication cycles (ring allgather/reduce) are not modelled.
-
-        Returns a dict with:
-            arithmetic_intensity: the dominant unit's per-unit AI
-                (``dominant_unit FLOPs / total bytes``, FLOP/B).
-            peak_bw_gb_s: Per-core HBM bandwidth in GB/s.
-            dominant_unit: ``"systolic"`` or ``"simd"`` (most compute cycles).
-            efficiency: achieved / ceiling for the dominant unit (0..1).
-            cores_active: number of cores that consumed any cycle (nonzero
-                total_cycles). A core left idle by an oversized grid produces a
-                counter entry but spends zero cycles, so it is excluded and an
-                under-filled grid does not inflate coverage. A core busy only
-                on communication still counts as active — dispatched is not the
-                same as doing useful compute.
-            num_cores: chip-wide hardware core count from ``HardwareConfig``.
-            grid_coverage: ``cores_active / num_cores`` — fraction of chip
-                cores dispatched any work. Spatial dispatch coverage, not how
-                busy each core is (a core running a single cycle counts fully),
-                so it is NOT Nsight's time-based "SM Active %"; pair with
-                chip_throughput / efficiency to read actual utilization.
-            units: per-unit dict, each with:
-                achieved_gflops, ceiling_gflops, ridge_point, efficiency,
-                arithmetic_intensity (this unit's own FLOPs / total bytes),
-                peak_gflops, chip_peak_gflops, chip_throughput.
-
-        Per-unit chip-level fields (peak-based, Nsight SOL analogue):
-            peak_gflops: per-core flat hardware peak (independent of AI).
-            chip_peak_gflops: ``peak_gflops × num_cores`` — chip-wide flat
-                peak. Distinct from ``ceiling_gflops`` which is the
-                roofline ceiling at this kernel's AI.
-            chip_throughput: ``sum(core FLOPs over all cores) / elapsed
-                / (peak × num_cores)`` — Nsight "Compute (SM) Throughput %"
-                analogue. The numerator is the actual total FLOPs summed
-                across every core over the elapsed (wall) time, so idle and
-                lighter cores correctly pull the figure down — the same way
-                Nsight aggregates per-SM counters across all SMs over elapsed
-                cycles. This is exact under any work distribution, including
-                split-K and uneven tiling, where extrapolating the critical
-                core's rate to all cores would overstate utilization.
-
-                Distinct from ``efficiency`` (per-active-core, ceiling-based)
-                and from ``grid_coverage`` (dispatched-core fraction):
-                chip_throughput is peak-based and chip-wide. The three
-                coincide only when work is evenly distributed and the kernel
-                is compute-bound at its flat peak.
+        ``peak_bw_core`` (per-core HBM) feeds the per-core roofline only;
+        ``hbm_bw_chip`` (aggregate HBM, read directly) feeds the chip roofline
+        only — the two never cross, so chip is never fed a ``÷ num_cores``
+        bandwidth.
         """
-        if not self.counters:
-            return {}
         critical = max(self.counters.values(), key=lambda c: c.total_cycles)
-
         clock = self.config.clock_ghz * 1e9
-        elapsed_s = critical.total_cycles / clock
-        peak_bw = self.config.hbm_bytes_per_cycle_per_core * clock
-
-        # Count cores that consumed any cycle, not every grid core that produced
-        # a counter entry: an oversized grid leaves some cores with zero loop
-        # iterations (0 cycles), and those must not inflate utilization. Use
-        # total_cycles (compute+memory+comm) so memory-only kernels with 0 FLOPs
-        # (e.g. embedding gather) still count their active cores. A comm-only
-        # core also counts as active here (dispatched, not necessarily computing).
-        cores_active = sum(1 for c in self.counters.values() if c.total_cycles > 0)
-        num_cores = self.config.num_cores
-        grid_coverage = cores_active / num_cores if num_cores > 0 else 0.0
-
-        # Per-unit hardware ceilings (hardware constants, not kernel-derived).
-        unit_ceilings = {
-            "systolic": self.config.systolic_flops_per_cycle * clock,
-            "simd": self.config.simd_elements_per_cycle * clock,
-        }
-
-        # Which LatencyCategory strings belong to each unit.
         _LC = LatencyCategory
         unit_categories = {
             "systolic": {str(_LC.COMPUTE_MATMUL)},
-            "simd": {str(_LC.COMPUTE_FLOAT), str(_LC.COMPUTE_TRANSCENDENTAL), str(_LC.COMPUTE_INT)},
+            "simd": {str(_LC.COMPUTE_FLOAT),
+                     str(_LC.COMPUTE_TRANSCENDENTAL),
+                     str(_LC.COMPUTE_INT)},
+        }
+        # Chip-wide cycles per category (Σ over all cores) → the single
+        # dominant-unit decision, shared by both granularities.
+        chip_cycles_by_cat: Dict[str, float] = {}
+        for c in self.counters.values():
+            for cat, cyc in c.cycles_by_category.items():
+                chip_cycles_by_cat[cat] = chip_cycles_by_cat.get(cat, 0.0) + cyc
+        return {
+            "critical": critical,
+            "clock": clock,
+            "elapsed_cycles": critical.total_cycles,          # wall clock
+            "elapsed_s": critical.total_cycles / clock if clock > 0 else 0.0,
+            "num_cores": self.config.num_cores,
+            # Cores that consumed any cycle — an oversized grid leaves some
+            # cores at 0 cycles; those must not inflate coverage. total_cycles
+            # (compute+memory+comm) so memory-only cores still count.
+            "cores_active": sum(1 for c in self.counters.values()
+                                if c.total_cycles > 0),
+            # Per-core hardware peak FLOP-rate per compute unit (hardware consts).
+            "unit_ceilings": {
+                "systolic": self.config.systolic_flops_per_cycle * clock,
+                "simd": self.config.simd_elements_per_cycle * clock,
+            },
+            "unit_categories": unit_categories,
+            # Single dominant unit (bottleneck), chip-wide, shared by both forks.
+            "dominant_unit": self._dominant_unit(chip_cycles_by_cat,
+                                                 unit_categories),
+            # Per-core HBM bandwidth (bytes/s) — CORE roofline only.
+            "peak_bw_core": self.config.hbm_bytes_per_cycle_per_core * clock,
+            # Aggregate chip HBM bandwidth (bytes/s), read directly — CHIP only.
+            # NOT the per-core hbm_bytes_per_cycle_per_core (= this / num_cores).
+            "hbm_bw_chip": self.config.hbm_bandwidth_tb_s * 1e12,
         }
 
+    @staticmethod
+    def _dominant_unit(cycles_by_category: Dict[str, float],
+                       unit_categories: Dict[str, Any]) -> str:
+        """Bottleneck unit = the one with the most cycles. Called once, from
+        :meth:`_roofline_common`, on cycles summed over all cores (dominant is
+        a chip-wide workload property). FLOPs are not comparable across units,
+        so cycles — not FLOPs — pick the bottleneck. Falls back to ``"simd"``
+        when no compute ran (every category zero).
+        """
+        totals = {
+            unit: sum(cycles_by_category.get(cat, 0.0) for cat in cats)
+            for unit, cats in unit_categories.items()
+        }
+        if not any(totals.values()):
+            return "simd"
+        return max(totals, key=totals.get)
+
+    def chip_roofline(self) -> Dict[str, Any]:
+        """Chip (device) level roofline — the whole chip as ONE unit (NCU
+        device view).
+
+        Aggregates the existing per-core counters over ALL cores; no new
+        inputs, and no per-core (critical-core) quantity except the wall-clock
+        elapsed. FLOPs are the dominant unit's, summed over all cores; the
+        dominant unit is chosen chip-wide (Σ cycles over all cores), never from
+        the critical core. The HBM roof is the aggregate bandwidth read
+        directly, never per-core ``÷ num_cores``.
+
+        Returns:
+            AI: ``Σ FLOP / Σ HBM bytes`` over all cores — roofline x-axis (FLOP/B).
+            compute_throughput: ``Σ FLOP / elapsed / chip_peak`` — compute SOL
+                (Nsight "Compute (SM) Throughput %"); ``chip_peak`` = dominant
+                unit's per-core peak × ``num_cores``.
+            dram_throughput: ``Σ HBM bytes / (hbm_bw × elapsed)`` — memory SOL
+                (Nsight "DRAM Throughput %"); ``hbm_bw`` the aggregate bandwidth.
+            mean_core_active_frac: ``Σ core.total_cycles / (num_cores ×
+                elapsed_cycles)`` — time-based core occupancy over all cores
+                (Nsight "SM Active %" analogue; active = compute+memory+comm).
+            grid_coverage: ``cores_active / num_cores`` — spatial dispatch coverage.
+            ridge: ``chip_peak / hbm_bw`` (== per-core ridge — same dominant
+                unit for both, num_cores cancels).
+            dominant_unit, num_cores, cores_active.
+        """
+        if not self.counters:
+            return {}
+        k = self._roofline_common()
+        # Single dominant unit, decided chip-wide in _roofline_common.
+        dom = k["dominant_unit"]
+        dom_cats = k["unit_categories"][dom]
+
+        chip_flops = sum(c.flops_by_category.get(cat, 0.0)
+                         for c in self.counters.values() for cat in dom_cats)
+        chip_dram_bytes = sum(c.dram_bytes for c in self.counters.values())
+        chip_cycles = sum(c.total_cycles for c in self.counters.values())
+
+        elapsed_s = k["elapsed_s"]
+        elapsed_cycles = k["elapsed_cycles"]
+        num_cores = k["num_cores"]
+        chip_peak = k["unit_ceilings"][dom] * num_cores
+        hbm_bw = k["hbm_bw_chip"]
+
+        return {
+            "AI": (chip_flops / chip_dram_bytes
+                   if chip_dram_bytes > 0 else float("inf")),
+            "compute_throughput": (chip_flops / elapsed_s / chip_peak
+                                   if elapsed_s > 0 and chip_peak > 0 else 0.0),
+            "dram_throughput": (chip_dram_bytes / (hbm_bw * elapsed_s)
+                                if elapsed_s > 0 and hbm_bw > 0 else 0.0),
+            "mean_core_active_frac": (
+                chip_cycles / (num_cores * elapsed_cycles)
+                if num_cores > 0 and elapsed_cycles > 0 else 0.0),
+            "grid_coverage": (k["cores_active"] / num_cores
+                              if num_cores > 0 else 0.0),
+            "ridge": chip_peak / hbm_bw if hbm_bw > 0 else float("inf"),
+            "dominant_unit": dom,
+            "num_cores": num_cores,
+            "cores_active": k["cores_active"],
+        }
+
+    def core_roofline(self) -> Dict[str, Any]:
+        """Per-core roofline — the critical-path core only.
+
+        For each compute unit, ``achieved_gflops`` is ``unit_flops /
+        total_wall_time`` (not unit_flops / unit_cycles) so it reflects true
+        end-to-end throughput including memory stalls. The dominant unit sets
+        the ``core_*`` headline. HBM bandwidth here is the per-core figure.
+
+        .. note:: Covers compute and HBM bandwidth only. Communication cycles
+           (ring allgather/reduce) are not modelled.
+
+        Returns:
+            core_AI: dominant unit's FLOPs / HBM ``dram_bytes`` on the critical
+                core (FLOP/B; comm/ring bytes excluded).
+            core_efficiency: achieved / ceiling for the dominant unit (0..1).
+            core_dominant_unit: ``"systolic"`` or ``"simd"`` (most cycles).
+            peak_bw_gb_s: per-core HBM bandwidth (GB/s).
+            ridge: dominant unit's ridge point (peak / peak_bw_core; == chip
+                ridge — same dominant unit, num_cores cancels).
+            units: per-unit dict, each with achieved_gflops, ceiling_gflops,
+                ridge_point, efficiency, arithmetic_intensity, peak_gflops,
+                chip_peak_gflops, compute_throughput.
+        """
+        if not self.counters:
+            return {}
+        k = self._roofline_common()
+        critical = k["critical"]
+        elapsed_s = k["elapsed_s"]
+        peak_bw = k["peak_bw_core"]
+        num_cores = k["num_cores"]
+        cats_of = k["unit_categories"]
+
         units: Dict[str, Any] = {}
-        for unit_name, peak in unit_ceilings.items():
-            cats = unit_categories[unit_name]
+        for unit_name, peak in k["unit_ceilings"].items():
+            cats = cats_of[unit_name]
             flops = sum(critical.flops_by_category.get(c, 0.0) for c in cats)
             achieved = flops / elapsed_s if elapsed_s > 0 else 0.0
-            # Per-unit arithmetic intensity: this unit's own FLOPs over the kernel's
-            # DRAM bytes (NCU convention — numerator split per pipeline, denominator
-            # the shared byte traffic). The denominator is dram_bytes: the HBM
-            # bandwidth ceiling governs HBM traffic only, so comm/ring bytes (a
-            # different interconnect) are excluded — otherwise a comm kernel's
-            # byte-rate could exceed HBM peak and put the point above the roof. Each
-            # unit gets its own ceiling, so the other unit's FLOPs don't inflate it.
+            # Per-unit AI: this unit's FLOPs over HBM dram_bytes (comm/ring
+            # excluded — the HBM ceiling governs HBM traffic only).
             unit_ai = (flops / critical.dram_bytes
-                       if critical.dram_bytes > 0 else float('inf'))
-            # Roofline ceiling at this unit's own AI.
+                       if critical.dram_bytes > 0 else float("inf"))
             ceiling = min(peak, peak_bw * unit_ai)
-            # Cores are homogeneous: every core shares the same clock and
-            # compute rates from HardwareConfig, so the chip peak is
-            # peak * num_cores, which equals summing identical per-core peaks.
-            # Heterogeneity lives on other axes (per functional unit, captured
-            # separately in unit_ceilings; per precision/generation, captured by
-            # the config values), never core-to-core.
+            # Per-unit chip-wide throughput (shipped #120 metric, renamed from
+            # chip_throughput): real per-core FLOP sum over elapsed, vs the
+            # unit's chip peak. Lighter/idle cores correctly pull it down.
             chip_peak = peak * num_cores
-            # Chip throughput uses the actual FLOPs summed across every core,
-            # not the critical core's rate extrapolated to all cores. Under
-            # uneven tiling the lighter cores do fewer FLOPs in the same wall
-            # time; extrapolating `achieved * cores_active` would count them as
-            # if they matched the critical core and overstate utilization. The
-            # real per-core sum over the same elapsed time gives the true
-            # chip-wide figure, matching Nsight's SM Throughput (per-SM counters
-            # aggregated across all SMs over elapsed cycles).
             chip_flops = sum(c.flops_by_category.get(cat, 0.0)
                              for c in self.counters.values() for cat in cats)
-            chip_achieved = chip_flops / elapsed_s if elapsed_s > 0 else 0.0
-            chip_throughput = chip_achieved / chip_peak if chip_peak > 0 else 0.0
+            compute_throughput = (chip_flops / elapsed_s / chip_peak
+                                  if elapsed_s > 0 and chip_peak > 0 else 0.0)
             units[unit_name] = {
                 "achieved_gflops": achieved / 1e9,
                 "ceiling_gflops": ceiling / 1e9,
-                "ridge_point": peak / peak_bw,
+                "ridge_point": peak / peak_bw if peak_bw > 0 else float("inf"),
                 "efficiency": achieved / ceiling if ceiling > 0 else 0.0,
                 "arithmetic_intensity": unit_ai,
                 "peak_gflops": peak / 1e9,
                 "chip_peak_gflops": chip_peak / 1e9,
-                "chip_throughput": chip_throughput,
+                "compute_throughput": compute_throughput,
             }
 
-        # Dominant unit = the unit that consumed the most compute cycles — the
-        # real bottleneck. Per-category cycles are already attributed to each
-        # unit upstream (LatencyTracker._estimate); read that conclusion rather
-        # than re-deriving from FLOPs, which are not comparable across units
-        # (matmul 2*M*N*K vs SIMD per-element). Fall back to "simd" when no
-        # compute ran at all (every category zero → both flops and cycles zero).
-        dominant = max(
-            unit_ceilings,
-            key=lambda u: sum(critical.cycles_by_category.get(c, 0.0)
-                              for c in unit_categories[u]),
-        )
-        if all(units[u]["achieved_gflops"] == 0.0 for u in units):
-            dominant = "simd"
+        # Same single dominant unit as chip_roofline (decided chip-wide in
+        # _roofline_common) so the two granularities never disagree.
+        dom = k["dominant_unit"]
 
         return {
-            "arithmetic_intensity": units[dominant]["arithmetic_intensity"],
+            "core_AI": units[dom]["arithmetic_intensity"],
+            "core_efficiency": units[dom]["efficiency"],
+            "core_dominant_unit": dom,
             "peak_bw_gb_s": peak_bw / 1e9,
-            "dominant_unit": dominant,
-            "efficiency": units[dominant]["efficiency"],
-            "cores_active": cores_active,
-            "num_cores": num_cores,
-            "grid_coverage": grid_coverage,
+            "ridge": units[dom]["ridge_point"],
             "units": units,
         }
+
+    def roofline(self) -> Dict[str, Any]:
+        """Combined roofline = chip-level + per-core, merged into one flat dict.
+
+        Prefer the granularity-specific methods for clarity:
+        :meth:`chip_roofline` (whole chip as one unit) and :meth:`core_roofline`
+        (critical-path core). This merges both for a single-call combined view.
+        The two key sets are disjoint — chip uses plain NCU names
+        (``AI``, ``compute_throughput``, …), per-core uses ``core_*`` / ``units``
+        / ``peak_bw_gb_s`` — except ``ridge``, which is identical at both
+        granularities: the dominant unit is decided once (chip-wide) and shared,
+        and ``num_cores`` cancels within a unit.
+        """
+        if not self.counters:
+            return {}
+        return {**self.core_roofline(), **self.chip_roofline()}
 
     def summary_dict(self) -> Dict[str, Any]:
         """Return summary as a dictionary."""
@@ -704,57 +759,64 @@ class LatencyReport:
             )
         lines.append("=" * 60)
 
-        # Roofline section — only if there are flops or bytes
+        # Roofline section — two clearly-separated blocks (chip, then per-core),
+        # each sourced from its own method. Only if there are flops or bytes.
         critical = max(self.counters.values(), key=lambda c: c.total_cycles)
         if critical.total_flops > 0 or critical.total_bytes > 0:
-            rf = self.roofline()
-            lines.append("")
-            lines.append("Roofline Analysis (critical-path core)")
-            lines.append("-" * 60)
-            ai = rf["arithmetic_intensity"]
-            # AI == inf means dram_bytes == 0 (no HBM). Split by total_bytes, not by
+            chip = self.chip_roofline()
+            core = self.core_roofline()
+
+            # AI == inf means no HBM bytes moved. Split by total_bytes, not by
             # naming a transport, so a comm-only kernel (or a future non-HBM
             # interconnect) reads "no HBM traffic" instead of the misleading "no
             # memory traffic" — it did move bytes, just not over HBM.
-            if ai != float('inf'):
-                ai_str = f"{ai:.2f} FLOP/B"
-            elif critical.total_bytes > 0:
-                ai_str = "inf (no HBM traffic)"
-            else:
-                ai_str = "inf (no memory traffic)"
-            dom_unit = rf["units"][rf["dominant_unit"]]
-            lines.append(f"  Arithmetic intensity : {ai_str}")
-            lines.append(f"  Peak bandwidth       : {rf['peak_bw_gb_s']:.2f} GB/s")
-            lines.append(f"  Dominant unit        : {rf['dominant_unit']}")
+            def _fmt_ai(ai: float) -> str:
+                if ai != float('inf'):
+                    return f"{ai:.2f} FLOP/B"
+                if critical.total_bytes > 0:
+                    return "inf (no HBM traffic)"
+                return "inf (no memory traffic)"
+
+            # --- CHIP-LEVEL block (whole chip as one unit) ---
+            lines.append("")
+            lines.append("Roofline: CHIP-LEVEL  (whole chip as one unit)")
+            lines.append("-" * 60)
+            lines.append(f"  AI                    : {_fmt_ai(chip['AI'])}")
+            lines.append(f"  compute_throughput    : {chip['compute_throughput']:.1%}")
+            lines.append(f"  dram_throughput       : {chip['dram_throughput']:.1%}")
+            lines.append(f"  mean_core_active_frac : {chip['mean_core_active_frac']:.1%}")
             lines.append(
-                f"  Grid coverage        : {rf['cores_active']}/{rf['num_cores']}  "
-                f"(grid_coverage {rf['grid_coverage']:.1%})"
+                f"  grid_coverage         : {chip['cores_active']}/{chip['num_cores']}  "
+                f"({chip['grid_coverage']:.1%})"
             )
-            lines.append(
-                f"  Efficiency           : {rf['efficiency']:.1%}  "
-                f"(per-active core, achieved/ceiling)"
-            )
-            lines.append(
-                f"  Chip throughput      : {dom_unit['chip_throughput']:.1%}  "
-                f"(chip-wide, achieved/peak with idle cores)"
-            )
+            lines.append(f"  dominant_unit         : {chip['dominant_unit']}")
+
+            # --- PER-CORE block (critical-path core) ---
+            dom = core["core_dominant_unit"]
+            lines.append("")
+            lines.append("Roofline: PER-CORE  (critical-path core)")
+            lines.append("-" * 60)
+            lines.append(f"  core_AI               : {_fmt_ai(core['core_AI'])}")
+            lines.append(f"  core_efficiency       : {core['core_efficiency']:.1%}")
+            lines.append(f"  core_dominant_unit    : {dom}")
+            lines.append(f"  peak_bw (per-core)    : {core['peak_bw_gb_s']:.2f} GB/s")
             lines.append("")
             lines.append(
                 f"  {'Unit':>10}  {'Achieved':>12}  {'Ceiling':>12}  "
-                f"{'Ridge':>10}  {'Eff':>7}  {'ChipThru':>9}"
+                f"{'Ridge':>10}  {'Eff':>7}  {'CompThru':>9}"
             )
             lines.append(
                 f"  {'-'*10}  {'-'*12}  {'-'*12}  {'-'*10}  {'-'*7}  {'-'*9}"
             )
-            for unit_name, u in rf["units"].items():
-                marker = " *" if unit_name == rf["dominant_unit"] else "  "
+            for unit_name, u in core["units"].items():
+                marker = " *" if unit_name == dom else "  "
                 lines.append(
                     f"{marker} {unit_name:>10}  "
                     f"{u['achieved_gflops']:>10.2f} G  "
                     f"{u['ceiling_gflops']:>10.2f} G  "
                     f"{u['ridge_point']:>8.1f} F/B  "
                     f"{u['efficiency']:>6.1%}  "
-                    f"{u['chip_throughput']:>8.2%}"
+                    f"{u['compute_throughput']:>8.2%}"
                 )
             lines.append("=" * 60)
 

--- a/notebooks/latency_demo.ipynb
+++ b/notebooks/latency_demo.ipynb
@@ -41,10 +41,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T23:39:24.280908Z",
-     "iopub.status.busy": "2026-06-16T23:39:24.280802Z",
-     "iopub.status.idle": "2026-06-16T23:39:24.345864Z",
-     "shell.execute_reply": "2026-06-16T23:39:24.345040Z"
+     "iopub.execute_input": "2026-07-07T15:18:27.302596Z",
+     "iopub.status.busy": "2026-07-07T15:18:27.302325Z",
+     "iopub.status.idle": "2026-07-07T15:18:27.367948Z",
+     "shell.execute_reply": "2026-07-07T15:18:27.367441Z"
     }
    },
    "outputs": [],
@@ -67,92 +67,67 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T23:39:24.348305Z",
-     "iopub.status.busy": "2026-06-16T23:39:24.348160Z",
-     "iopub.status.idle": "2026-06-16T23:39:24.586752Z",
-     "shell.execute_reply": "2026-06-16T23:39:24.586096Z"
+     "iopub.execute_input": "2026-07-07T15:18:27.369921Z",
+     "iopub.status.busy": "2026-07-07T15:18:27.369793Z",
+     "iopub.status.idle": "2026-07-07T15:18:27.702823Z",
+     "shell.execute_reply": "2026-07-07T15:18:27.702363Z"
     }
    },
    "outputs": [],
    "source": [
     "import matplotlib.pyplot as plt\n",
     "\n",
-    "def plot_roofline(hw: HardwareConfig, kernels: list[tuple[str, object]], title: str = \"Roofline\") -> None:\n",
-    "    \"\"\"One subplot per dominant unit (stacked vertically); x-axis zoomed to kernel region.\"\"\"\n",
-    "    clock   = hw.clock_ghz * 1e9\n",
-    "    peak_bw = hw.hbm_bytes_per_cycle_per_core * clock / 1e9  # GB/s per-core\n",
-    "\n",
-    "    unit_peaks = {\n",
-    "        \"systolic\": hw.systolic_flops_per_cycle * clock / 1e9,\n",
-    "        \"simd\":     hw.simd_elements_per_cycle  * clock / 1e9,\n",
-    "    }\n",
-    "\n",
-    "    rfs = [(name, rep.roofline()) for name, rep in kernels]\n",
+    "def plot_roofline(hw: HardwareConfig, kernels: list[tuple[str, object]],\n",
+    "                  granularity: str, title: str | None = None) -> None:\n",
+    "    \"\"\"Roofline for ONE granularity, on its own figure (chip and per-core are\n",
+    "    never mixed). Pulls report.chip_roofline() or report.core_roofline().\n",
+    "    y is normalised (throughput as fraction of peak, in [0,1]); roof =\n",
+    "    min(1, AI/ridge) with ridge read from the report; one subplot per dominant unit.\"\"\"\n",
+    "    assert granularity in (\"chip\", \"core\")\n",
+    "    rfs = [(name, rep.chip_roofline() if granularity == \"chip\" else rep.core_roofline())\n",
+    "           for name, rep in kernels]\n",
+    "    dom_key = \"dominant_unit\" if granularity == \"chip\" else \"core_dominant_unit\"\n",
+    "    ai_key  = \"AI\" if granularity == \"chip\" else \"core_AI\"\n",
     "\n",
     "    from collections import defaultdict\n",
     "    groups: dict[str, list] = defaultdict(list)\n",
     "    for name, rf in rfs:\n",
-    "        groups[rf[\"dominant_unit\"]].append((name, rf))\n",
+    "        groups[rf[dom_key]].append((name, rf))\n",
     "\n",
     "    n_panels = len(groups)\n",
     "    fig, axes = plt.subplots(n_panels, 1, figsize=(7, 4 * n_panels), squeeze=False)\n",
-    "    fig.suptitle(title, fontsize=12)\n",
-    "\n",
+    "    fig.suptitle(title or f\"Roofline — {granularity}-level\", fontsize=12)\n",
     "    colors = plt.rcParams[\"axes.prop_cycle\"].by_key()[\"color\"]\n",
     "\n",
     "    for row, (unit, kgroup) in enumerate(groups.items()):\n",
     "        ax = axes[row][0]\n",
-    "        peak_gflops = unit_peaks[unit]\n",
-    "        ridge       = peak_gflops / peak_bw\n",
-    "\n",
-    "        ais       = [rf[\"arithmetic_intensity\"] for _, rf in kgroup]\n",
-    "        achieveds = [rf[\"units\"][unit][\"achieved_gflops\"] for _, rf in kgroup]\n",
-    "        max_ai    = max(ais)\n",
-    "\n",
-    "        if ridge <= max_ai * 3:\n",
-    "            ai_max = ridge * 1.3\n",
-    "            show_ridge_in_plot = True\n",
-    "        else:\n",
-    "            ai_max = max_ai * 2.5\n",
-    "            show_ridge_in_plot = False\n",
+    "        ridge = kgroup[0][1][\"ridge\"]          # granularity-invariant; from the report\n",
+    "        xs = [rf[ai_key] for _, rf in kgroup]\n",
+    "        finite = [x for x in xs if x != float(\"inf\")]\n",
+    "        ai_max = max([ridge] + finite) * 1.3\n",
     "\n",
     "        ai_range = np.linspace(0, ai_max, 400)\n",
-    "        roof     = np.minimum(peak_bw * ai_range, peak_gflops)\n",
-    "\n",
-    "        ax.plot(ai_range, roof, color=\"gray\", linewidth=2, label=\"Roofline\")\n",
-    "\n",
-    "        if show_ridge_in_plot:\n",
-    "            ax.axvline(ridge, color=\"gray\", linestyle=\"--\", linewidth=1, alpha=0.6)\n",
-    "            ax.text(ridge * 1.02, peak_gflops * 0.5,\n",
-    "                    f\"ridge={ridge:.1f} F/B\", color=\"gray\", fontsize=8, va=\"center\")\n",
-    "        else:\n",
-    "            ax.axhline(peak_gflops, color=\"gray\", linestyle=\"--\", linewidth=1, alpha=0.5)\n",
-    "            ax.annotate(\n",
-    "                f\"ridge={ridge:.0f} F/B →\",\n",
-    "                xy=(ai_max, peak_bw * ai_max),\n",
-    "                xytext=(ai_max * 0.82, (peak_bw * ai_max) * 1.22),\n",
-    "                fontsize=8, color=\"gray\",\n",
-    "                arrowprops=dict(arrowstyle=\"->\", color=\"gray\", lw=1),\n",
-    "            )\n",
+    "        roof = np.minimum(ai_range / ridge, 1.0)\n",
+    "        ax.plot(ai_range, roof, color=\"gray\", linewidth=2, label=\"Roofline (norm)\")\n",
+    "        ax.axvline(ridge, color=\"gray\", linestyle=\"--\", linewidth=1, alpha=0.6)\n",
+    "        ax.text(ridge * 1.02, 0.5, f\"ridge={ridge:.1f} F/B\", color=\"gray\", fontsize=8, va=\"center\")\n",
     "\n",
     "        for i, (name, rf) in enumerate(kgroup):\n",
-    "            u        = rf[\"units\"][unit]\n",
-    "            achieved = u[\"achieved_gflops\"]\n",
-    "            ceiling  = u[\"ceiling_gflops\"]\n",
-    "            eff      = u[\"efficiency\"]\n",
-    "            ai       = rf[\"arithmetic_intensity\"]\n",
-    "            c        = colors[i % len(colors)]\n",
+    "            c = colors[i % len(colors)]\n",
+    "            if granularity == \"chip\":\n",
+    "                x, y = rf[\"AI\"], rf[\"compute_throughput\"]\n",
+    "            else:\n",
+    "                u = rf[\"units\"][unit]\n",
+    "                x = rf[\"core_AI\"]\n",
+    "                y = u[\"achieved_gflops\"] / u[\"peak_gflops\"] if u[\"peak_gflops\"] else 0.0\n",
+    "            if x != float(\"inf\"):\n",
+    "                ax.scatter(x, y, s=100, zorder=5, color=c, edgecolor=\"black\", linewidth=0.5,\n",
+    "                           label=f\"{name} (AI={x:.2f}, {y:.0%})\")\n",
     "\n",
-    "            ax.scatter(ai, achieved, s=90, zorder=5, color=c,\n",
-    "                       label=f\"{name}  (AI={ai:.2f} F/B, {achieved:.1f} GFLOP/s, eff={eff:.0%})\")\n",
-    "            ax.plot([ai, ai], [achieved, min(ceiling, (peak_bw * ai_max) * 1.5)],\n",
-    "                    color=c, lw=1, linestyle=\"dotted\")\n",
-    "\n",
-    "        y_top = (peak_bw * ai_max * 1.3) if not show_ridge_in_plot else peak_gflops * 1.15\n",
     "        ax.set_xlim(left=0, right=ai_max)\n",
-    "        ax.set_ylim(bottom=0, top=y_top)\n",
+    "        ax.set_ylim(bottom=0, top=1.1)\n",
     "        ax.set_xlabel(\"Arithmetic intensity (FLOP/B)\", fontsize=10)\n",
-    "        ax.set_ylabel(\"Performance (GFLOP/s)\", fontsize=10)\n",
+    "        ax.set_ylabel(\"Throughput (fraction of peak)\", fontsize=10)\n",
     "        ax.set_title(f\"Dominant unit: {unit}\", fontsize=10)\n",
     "        ax.legend(fontsize=8, loc=\"upper left\")\n",
     "        ax.grid(True, linestyle=\":\", alpha=0.4)\n",
@@ -176,10 +151,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T23:39:24.589089Z",
-     "iopub.status.busy": "2026-06-16T23:39:24.588908Z",
-     "iopub.status.idle": "2026-06-16T23:39:24.594763Z",
-     "shell.execute_reply": "2026-06-16T23:39:24.594189Z"
+     "iopub.execute_input": "2026-07-07T15:18:27.704906Z",
+     "iopub.status.busy": "2026-07-07T15:18:27.704775Z",
+     "iopub.status.idle": "2026-07-07T15:18:27.710600Z",
+     "shell.execute_reply": "2026-07-07T15:18:27.710232Z"
     }
    },
    "outputs": [],
@@ -195,10 +170,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T23:39:24.596533Z",
-     "iopub.status.busy": "2026-06-16T23:39:24.596411Z",
-     "iopub.status.idle": "2026-06-16T23:39:24.625936Z",
-     "shell.execute_reply": "2026-06-16T23:39:24.625502Z"
+     "iopub.execute_input": "2026-07-07T15:18:27.712077Z",
+     "iopub.status.busy": "2026-07-07T15:18:27.711990Z",
+     "iopub.status.idle": "2026-07-07T15:18:27.733499Z",
+     "shell.execute_reply": "2026-07-07T15:18:27.732947Z"
     }
    },
    "outputs": [],
@@ -224,10 +199,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T23:39:24.647899Z",
-     "iopub.status.busy": "2026-06-16T23:39:24.647705Z",
-     "iopub.status.idle": "2026-06-16T23:39:24.649849Z",
-     "shell.execute_reply": "2026-06-16T23:39:24.649443Z"
+     "iopub.execute_input": "2026-07-07T15:18:27.752653Z",
+     "iopub.status.busy": "2026-07-07T15:18:27.752497Z",
+     "iopub.status.idle": "2026-07-07T15:18:27.754622Z",
+     "shell.execute_reply": "2026-07-07T15:18:27.754174Z"
     }
    },
    "outputs": [],
@@ -242,20 +217,38 @@
    "source": [
     "### Reading the report\n",
     "\n",
+    "Two methods, one per granularity: **`report.chip_roofline()`** (whole chip as one unit; plain NCU-style names)\n",
+    "and **`report.core_roofline()`** (critical-path core; `core_*` names). `report.roofline()` returns both merged.\n",
+    "\n",
+    "**General**\n",
+    "\n",
     "| Field | Meaning |\n",
     "|---|---|\n",
     "| `kernel_cycles` | Max total cycles across all cores (critical path) |\n",
     "| `kernel_time_us` | Cycles ÷ clock (default 1 GHz → 1 cycle = 1 ns) |\n",
     "| `bottleneck` | Which category dominates the critical-path core: `compute`, `memory`, or `comm` |\n",
     "| Per-core table | `compute_cycles`, `memory_cycles`, `comm_cycles` per core |\n",
-    "| `arithmetic_intensity` | FLOPs ÷ bytes transferred (FLOP/B) |\n",
-    "| `ridge_point` | AI where BW ceiling meets compute ceiling — left = memory-bound, right = compute-bound |\n",
-    "| `cores_active` / `num_cores` | Active core count (cores with nonzero total_cycles; oversized-grid idle cores excluded) vs total chip cores |\n",
-    "| `grid_coverage` | `cores_active / num_cores` — fraction of chip cores dispatched any work (spatial dispatch coverage, not core busyness — *not* Nsight *SM Active %*) |\n",
-    "| Per-unit `efficiency` | `achieved / ceiling` for that unit — per-active-core throughput vs roofline ceiling at this kernel\\'s AI (ceiling-based, so memory-bound kernels can show high efficiency relative to the BW ceiling without being close to peak) |\n",
-    "| Per-unit `peak_gflops` | Per-core flat hardware peak for that unit (AI-independent) |\n",
-    "| Per-unit `chip_peak_gflops` | `peak_gflops × num_cores` — chip-wide flat peak (distinct from `ceiling_gflops`, which is the roofline ceiling at this kernel\\'s AI) |\n",
-    "| Per-unit `chip_throughput` | `Σ(core FLOPs) / elapsed / (peak × num_cores)` — chip-wide fraction of peak from the real per-core FLOP sum; idle/lighter cores pull it down (Nsight *Compute (SM) Throughput %* analogue) |\n"
+    "\n",
+    "**Chip-level** (whole chip as one unit; aggregates over all cores, no `÷ num_cores` per-core inputs)\n",
+    "\n",
+    "| Field | Meaning |\n",
+    "|---|---|\n",
+    "| `AI` | `Σ FLOP / Σ HBM bytes` over all cores (FLOP/B) — the roofline x-axis |\n",
+    "| `compute_throughput` | `Σ FLOP / elapsed / chip_peak` — compute SOL (fraction of chip compute peak); Nsight *Compute (SM) Throughput %* analogue |\n",
+    "| `dram_throughput` | `Σ HBM bytes / (hbm_bw × elapsed)` — memory SOL (fraction of aggregate HBM bandwidth); `hbm_bw` read directly from `hbm_bandwidth_tb_s` |\n",
+    "| `mean_core_active_frac` | `Σ core.total_cycles / (num_cores × elapsed_cycles)` — time-based core occupancy (active = compute + memory + comm); Nsight *SM Active %* analogue |\n",
+    "| `grid_coverage` | `cores_active / num_cores` — **spatial** dispatch coverage (not core busyness; *not* Nsight *SM Active %* — that role is `mean_core_active_frac`) |\n",
+    "\n",
+    "**Per-core** (critical-path core; `core_` prefix)\n",
+    "\n",
+    "| Field | Meaning |\n",
+    "|---|---|\n",
+    "| `core_AI` | dominant unit FLOPs ÷ HBM bytes on the critical core (FLOP/B) |\n",
+    "| `core_efficiency` | `achieved / ceiling` for the dominant unit — per-active-core throughput vs the roofline ceiling at this kernel\\'s AI |\n",
+    "| `core_dominant_unit` | `systolic` or `simd` — the unit with the most compute cycles |\n",
+    "| `ridge_point` (per-unit) | AI where BW ceiling meets compute ceiling — left = memory-bound, right = compute-bound |\n",
+    "| Per-unit `peak_gflops` / `chip_peak_gflops` | per-core flat peak / `× num_cores` chip flat peak |\n",
+    "| Per-unit `compute_throughput` | this unit\\'s chip-wide throughput (the per-unit detail behind the chip-level `compute_throughput`) |\n"
    ]
   },
   {
@@ -263,10 +256,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T23:39:24.651934Z",
-     "iopub.status.busy": "2026-06-16T23:39:24.651814Z",
-     "iopub.status.idle": "2026-06-16T23:39:24.654858Z",
-     "shell.execute_reply": "2026-06-16T23:39:24.654520Z"
+     "iopub.execute_input": "2026-07-07T15:18:27.756022Z",
+     "iopub.status.busy": "2026-07-07T15:18:27.755930Z",
+     "iopub.status.idle": "2026-07-07T15:18:27.758541Z",
+     "shell.execute_reply": "2026-07-07T15:18:27.758169Z"
     }
    },
    "outputs": [],
@@ -275,16 +268,14 @@
     "print(f\"Kernel time   : {report.kernel_time_us:.3f} us\")\n",
     "print(f\"Bottleneck    : {report.bottleneck}\")\n",
     "\n",
-    "rf = report.roofline()\n",
-    "dominant = rf[\"dominant_unit\"]\n",
-    "u = rf[\"units\"][dominant]\n",
-    "print(f\"\\nRoofline summary  (dominant unit: {dominant})\")\n",
-    "print(f\"  arithmetic_intensity : {rf['arithmetic_intensity']:.2f} FLOP/B\")\n",
-    "print(f\"  ridge_point          : {u['ridge_point']:.2f} FLOP/B\")\n",
-    "print(f\"  efficiency           : {rf['efficiency']:.1%}      (per-active-core, achieved/ceiling)\")\n",
-    "print(f\"  cores_active           : {rf['cores_active']}/{rf['num_cores']}  (grid_coverage={rf['grid_coverage']:.1%})\")\n",
-    "print(f\"  chip_throughput      : {u['chip_throughput']:.1%}      (chip-wide, achieved/peak with idle cores)\")\n",
-    "print(f\"  Kernel is {'compute-bound' if rf['arithmetic_intensity'] >= u['ridge_point'] else 'memory-bound'}\")"
+    "core = report.core_roofline()\n",
+    "dom = core[\"core_dominant_unit\"]\n",
+    "u = core[\"units\"][dom]\n",
+    "print(f\"\\nPer-core roofline  (critical-path core; dominant unit: {dom})\")\n",
+    "print(f\"  core_AI         : {core['core_AI']:.2f} FLOP/B\")\n",
+    "print(f\"  ridge_point     : {u['ridge_point']:.2f} FLOP/B\")\n",
+    "print(f\"  core_efficiency : {core['core_efficiency']:.1%}   (per-active-core, achieved/ceiling)\")\n",
+    "print(f\"  Kernel is {'compute-bound' if core['core_AI'] >= u['ridge_point'] else 'memory-bound'} (per-core view)\")\n"
    ]
   },
   {
@@ -299,10 +290,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T23:39:24.656542Z",
-     "iopub.status.busy": "2026-06-16T23:39:24.656459Z",
-     "iopub.status.idle": "2026-06-16T23:39:24.658817Z",
-     "shell.execute_reply": "2026-06-16T23:39:24.658403Z"
+     "iopub.execute_input": "2026-07-07T15:18:27.759904Z",
+     "iopub.status.busy": "2026-07-07T15:18:27.759812Z",
+     "iopub.status.idle": "2026-07-07T15:18:27.761994Z",
+     "shell.execute_reply": "2026-07-07T15:18:27.761621Z"
     }
    },
    "outputs": [],
@@ -329,10 +320,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T23:39:24.660447Z",
-     "iopub.status.busy": "2026-06-16T23:39:24.660348Z",
-     "iopub.status.idle": "2026-06-16T23:39:24.681771Z",
-     "shell.execute_reply": "2026-06-16T23:39:24.681331Z"
+     "iopub.execute_input": "2026-07-07T15:18:27.763326Z",
+     "iopub.status.busy": "2026-07-07T15:18:27.763237Z",
+     "iopub.status.idle": "2026-07-07T15:18:27.790034Z",
+     "shell.execute_reply": "2026-07-07T15:18:27.789629Z"
     }
    },
    "outputs": [],
@@ -359,24 +350,20 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T23:39:24.683254Z",
-     "iopub.status.busy": "2026-06-16T23:39:24.683175Z",
-     "iopub.status.idle": "2026-06-16T23:39:24.685871Z",
-     "shell.execute_reply": "2026-06-16T23:39:24.685441Z"
+     "iopub.execute_input": "2026-07-07T15:18:27.791280Z",
+     "iopub.status.busy": "2026-07-07T15:18:27.791199Z",
+     "iopub.status.idle": "2026-07-07T15:18:27.793552Z",
+     "shell.execute_reply": "2026-07-07T15:18:27.793107Z"
     }
    },
    "outputs": [],
    "source": [
-    "# Side-by-side comparison\n",
+    "# Per-core comparison (critical-path core)\n",
     "for name, r in [(\"matmul\", report), (\"softmax\", softmax_report)]:\n",
-    "    rf = r.roofline()\n",
-    "    u = rf[\"units\"][rf[\"dominant_unit\"]]\n",
-    "    print(f\"{name:10s}  cycles={r.kernel_cycles:6.0f}  \"\n",
-    "          f\"bottleneck={r.bottleneck:8s}  \"\n",
-    "          f\"AI={rf['arithmetic_intensity']:.2f} FLOP/B  \"\n",
-    "          f\"efficiency={rf['efficiency']:.1%}  \"\n",
-    "          f\"cores_active={rf['cores_active']}/{rf['num_cores']}  \"\n",
-    "          f\"chip_throughput={u['chip_throughput']:.1%}\")"
+    "    core = r.core_roofline()\n",
+    "    print(f\"{name:10s} cycles={r.kernel_cycles:6.0f}  bottleneck={r.bottleneck:8s}  \"\n",
+    "          f\"core_AI={core['core_AI']:.2f} F/B  core_eff={core['core_efficiency']:.1%}  \"\n",
+    "          f\"dom={core['core_dominant_unit']}\")\n"
    ]
   },
   {
@@ -395,10 +382,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T23:39:24.687349Z",
-     "iopub.status.busy": "2026-06-16T23:39:24.687235Z",
-     "iopub.status.idle": "2026-06-16T23:39:28.691400Z",
-     "shell.execute_reply": "2026-06-16T23:39:28.690921Z"
+     "iopub.execute_input": "2026-07-07T15:18:27.794970Z",
+     "iopub.status.busy": "2026-07-07T15:18:27.794890Z",
+     "iopub.status.idle": "2026-07-07T15:18:32.413893Z",
+     "shell.execute_reply": "2026-07-07T15:18:32.413367Z"
     }
    },
    "outputs": [],
@@ -432,15 +419,15 @@
     "         num_tiles=8, context_len=120, scale=0.08838834764831843),\n",
     ")\n",
     "\n",
-    "for name, r in [(\"matmul_small\", report), (\"softmax\", softmax_report),\n",
-    "                (\"sdpa\", sdpa_report), (\"paged_attn\", paged_attn_report)]:\n",
-    "    rf = r.roofline()\n",
-    "    u = rf[\"units\"][rf[\"dominant_unit\"]]\n",
-    "    print(f\"{name:15s}  cycles={r.kernel_cycles:6.0f}  bottleneck={r.bottleneck:8s}  \"\n",
-    "          f\"AI={rf['arithmetic_intensity']:6.2f} F/B  dom={rf['dominant_unit']:8s}  \"\n",
-    "          f\"efficiency={rf['efficiency']:.1%}  \"\n",
-    "          f\"cores_active={rf['cores_active']:>2d}/{rf['num_cores']}  \"\n",
-    "          f\"chip_throughput={u['chip_throughput']:.1%}\")\n"
+    "kernels = [(\"matmul_small\", report), (\"softmax\", softmax_report),\n",
+    "           (\"sdpa\", sdpa_report), (\"paged_attn\", paged_attn_report)]\n",
+    "\n",
+    "# Per-core comparison (critical-path core)\n",
+    "for name, r in kernels:\n",
+    "    core = r.core_roofline()\n",
+    "    print(f\"{name:15s} cycles={r.kernel_cycles:6.0f}  bottleneck={r.bottleneck:8s}  \"\n",
+    "          f\"core_AI={core['core_AI']:6.2f} F/B  dom={core['core_dominant_unit']:8s}  \"\n",
+    "          f\"core_eff={core['core_efficiency']:.1%}\")\n"
    ]
   },
   {
@@ -463,10 +450,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T23:39:28.692817Z",
-     "iopub.status.busy": "2026-06-16T23:39:28.692725Z",
-     "iopub.status.idle": "2026-06-16T23:39:32.684212Z",
-     "shell.execute_reply": "2026-06-16T23:39:32.683799Z"
+     "iopub.execute_input": "2026-07-07T15:18:32.415441Z",
+     "iopub.status.busy": "2026-07-07T15:18:32.415330Z",
+     "iopub.status.idle": "2026-07-07T15:18:36.931421Z",
+     "shell.execute_reply": "2026-07-07T15:18:36.931045Z"
     }
    },
    "outputs": [],
@@ -509,20 +496,97 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T23:39:32.685795Z",
-     "iopub.status.busy": "2026-06-16T23:39:32.685693Z",
-     "iopub.status.idle": "2026-06-16T23:39:32.847973Z",
-     "shell.execute_reply": "2026-06-16T23:39:32.847567Z"
+     "iopub.execute_input": "2026-07-07T15:18:36.932982Z",
+     "iopub.status.busy": "2026-07-07T15:18:36.932885Z",
+     "iopub.status.idle": "2026-07-07T15:18:37.096505Z",
+     "shell.execute_reply": "2026-07-07T15:18:37.096121Z"
     }
    },
    "outputs": [],
    "source": [
-    "plot_roofline(\n",
-    "    hw,\n",
-    "    [(\"matmul_small\", report), (\"sdpa\", sdpa_report),\n",
-    "     (\"softmax\", softmax_report), (\"paged_attn\", paged_attn_report)],\n",
-    "    title=\"Roofline — four kernels (default HW)\",\n",
-    ")\n"
+    "_kernels = [(\"matmul_small\", report), (\"sdpa\", sdpa_report),\n",
+    "            (\"softmax\", softmax_report), (\"paged_attn\", paged_attn_report)]\n",
+    "\n",
+    "plot_roofline(hw, _kernels, granularity=\"core\", title=\"Per-core roofline — four kernels\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Chip-level analysis — the whole chip as one unit\n",
+    "\n",
+    "Everything above is the **per-core** analysis (the critical core vs its own ceiling). What follows is a\n",
+    "**separate analysis at a different granularity**: it collapses the chip to a single unit (the way Nsight\n",
+    "views a device) and asks *how much of the **entire chip** did this kernel use, and what bounds it* — a\n",
+    "question per-core cannot answer.\n",
+    "\n",
+    "**Why chip-level is meaningful (and per-core is not enough).** A core can be **~99% efficient**\n",
+    "(`core_efficiency`) while the **whole chip sits mostly idle**. The chip metrics make that visible:\n",
+    "\n",
+    "- `grid_coverage` / `mean_core_active_frac` — how many cores actually did work / for how much of the time.\n",
+    "- `dram_throughput` — whether the kernel saturates the **whole chip's** HBM bandwidth (device memory-bound).\n",
+    "- `compute_throughput` — the whole chip's compute utilisation vs its flat peak.\n",
+    "\n",
+    "Convention: plain NCU-style names (`AI`, `compute_throughput`, …) are **chip-level**; a `core_` prefix is\n",
+    "**per-core**. The two are never compared on the same axes — their denominators differ."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T15:18:37.098356Z",
+     "iopub.status.busy": "2026-07-07T15:18:37.098262Z",
+     "iopub.status.idle": "2026-07-07T15:18:37.101060Z",
+     "shell.execute_reply": "2026-07-07T15:18:37.100489Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Chip-level comparison (whole chip as one unit)\n",
+    "kernels = [(\"matmul_small\", report), (\"softmax\", softmax_report),\n",
+    "           (\"sdpa\", sdpa_report), (\"paged_attn\", paged_attn_report)]\n",
+    "\n",
+    "print(\"== Chip-level (whole chip as one unit) ==\")\n",
+    "for name, r in kernels:\n",
+    "    chip = r.chip_roofline()\n",
+    "    print(f\"{name:15s} AI={chip['AI']:6.2f} F/B  compute_thru={chip['compute_throughput']:6.1%}  \"\n",
+    "          f\"dram_thru={chip['dram_throughput']:6.1%}  mean_core_active={chip['mean_core_active_frac']:5.1%}  \"\n",
+    "          f\"grid_cov={chip['grid_coverage']:5.1%}  ({chip['cores_active']}/{chip['num_cores']} cores)\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T15:18:37.102392Z",
+     "iopub.status.busy": "2026-07-07T15:18:37.102309Z",
+     "iopub.status.idle": "2026-07-07T15:18:37.242650Z",
+     "shell.execute_reply": "2026-07-07T15:18:37.242252Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Chip-level roofline — SEPARATE figure from the per-core one above\n",
+    "plot_roofline(hw, kernels, granularity=\"chip\", title=\"Chip-level roofline — four kernels\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Reading the chip metrics — what per-core hid**\n",
+    "\n",
+    "- Kernels that fill only a few cores show low `grid_coverage` / `mean_core_active_frac` and tiny\n",
+    "  `compute_throughput` / `dram_throughput`, *even when* `core_efficiency` is ~99%: the busy core is\n",
+    "  efficient, but **most of the chip is idle**. Per-core alone would read as \"great\".\n",
+    "- Kernels that fill all cores and push `dram_throughput` toward 100% are **device HBM-bound**: they\n",
+    "  saturate the whole chip's memory bandwidth — a chip-level statement the per-core view cannot make."
    ]
   },
   {
@@ -540,10 +604,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T23:39:32.849870Z",
-     "iopub.status.busy": "2026-06-16T23:39:32.849784Z",
-     "iopub.status.idle": "2026-06-16T23:39:32.869541Z",
-     "shell.execute_reply": "2026-06-16T23:39:32.869110Z"
+     "iopub.execute_input": "2026-07-07T15:18:37.244569Z",
+     "iopub.status.busy": "2026-07-07T15:18:37.244465Z",
+     "iopub.status.idle": "2026-07-07T15:18:37.271134Z",
+     "shell.execute_reply": "2026-07-07T15:18:37.270655Z"
     }
    },
    "outputs": [],
@@ -587,10 +651,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T23:39:32.871009Z",
-     "iopub.status.busy": "2026-06-16T23:39:32.870900Z",
-     "iopub.status.idle": "2026-06-16T23:39:32.874331Z",
-     "shell.execute_reply": "2026-06-16T23:39:32.873877Z"
+     "iopub.execute_input": "2026-07-07T15:18:37.272494Z",
+     "iopub.status.busy": "2026-07-07T15:18:37.272414Z",
+     "iopub.status.idle": "2026-07-07T15:18:37.275242Z",
+     "shell.execute_reply": "2026-07-07T15:18:37.274900Z"
     }
    },
    "outputs": [],
@@ -610,10 +674,10 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T23:39:32.875594Z",
-     "iopub.status.busy": "2026-06-16T23:39:32.875510Z",
-     "iopub.status.idle": "2026-06-16T23:39:32.877758Z",
-     "shell.execute_reply": "2026-06-16T23:39:32.877459Z"
+     "iopub.execute_input": "2026-07-07T15:18:37.276765Z",
+     "iopub.status.busy": "2026-07-07T15:18:37.276681Z",
+     "iopub.status.idle": "2026-07-07T15:18:37.279082Z",
+     "shell.execute_reply": "2026-07-07T15:18:37.278697Z"
     }
    },
    "outputs": [],
@@ -644,20 +708,18 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T23:39:32.879188Z",
-     "iopub.status.busy": "2026-06-16T23:39:32.879111Z",
-     "iopub.status.idle": "2026-06-16T23:39:32.881063Z",
-     "shell.execute_reply": "2026-06-16T23:39:32.880599Z"
+     "iopub.execute_input": "2026-07-07T15:18:37.280263Z",
+     "iopub.status.busy": "2026-07-07T15:18:37.280187Z",
+     "iopub.status.idle": "2026-07-07T15:18:37.282130Z",
+     "shell.execute_reply": "2026-07-07T15:18:37.281734Z"
     }
    },
    "outputs": [],
    "source": [
     "if _mlir_available:\n",
-    "    rf_regex = report.roofline()\n",
-    "    rf_mlir  = mlir_report.roofline()\n",
-    "    print(f\"regex  cycles={report.kernel_cycles:.0f}  AI={rf_regex['arithmetic_intensity']:.2f}\")\n",
-    "    print(f\"mlir   cycles={mlir_report.kernel_cycles:.0f}  AI={rf_mlir['arithmetic_intensity']:.2f}\")\n",
-    "    print(\"Results are identical — the two parsers produce the same IR.\")"
+    "    print(f\"regex  cycles={report.kernel_cycles:.0f}  AI={report.core_roofline()['core_AI']:.2f}\")\n",
+    "    print(f\"mlir   cycles={mlir_report.kernel_cycles:.0f}  AI={mlir_report.core_roofline()['core_AI']:.2f}\")\n",
+    "    print(\"Results are identical — the two parsers produce the same IR.\")\n"
    ]
   },
   {
@@ -682,7 +744,9 @@
     "report.kernel_time_us                # float\n",
     "report.bottleneck                    # 'compute' | 'memory' | 'comm'\n",
     "report.per_core_summary()            # list[dict] — per-core breakdown\n",
-    "report.roofline()                    # dict — arithmetic intensity, efficiency, ...\n",
+    "report.chip_roofline()               # dict — AI, compute/dram_throughput, mean_core_active_frac, grid_coverage\n",
+    "report.core_roofline()               # dict — core_AI, core_efficiency, units, ...\n",
+    "report.roofline()                    # dict — chip + core merged\n",
     "```"
    ]
   }

--- a/tests/test_latency.py
+++ b/tests/test_latency.py
@@ -322,15 +322,22 @@ class TestRoofline:
         report, _ = _run_vector_add(path, func_name, entry, HardwareConfig())
         rf = report.roofline()
 
-        assert "arithmetic_intensity" in rf
+        # Per-core headline keys (core_ prefix) + shared detail.
+        assert "core_AI" in rf
         assert "peak_bw_gb_s" in rf
-        assert "dominant_unit" in rf
-        assert "efficiency" in rf
+        assert "core_dominant_unit" in rf
+        assert "core_efficiency" in rf
         assert "units" in rf
 
-        assert 0 < rf["efficiency"] <= 1.0
+        assert 0 < rf["core_efficiency"] <= 1.0
         for unit in rf["units"].values():
             assert unit["achieved_gflops"] <= unit["ceiling_gflops"]
+
+        # Chip-level keys (whole chip as one unit) — all peak-based ratios ≤ 1.
+        assert "AI" in rf
+        assert 0 <= rf["compute_throughput"] <= 1.0
+        assert 0 <= rf["dram_throughput"] <= 1.0
+        assert 0 <= rf["mean_core_active_frac"] <= 1.0
 
         # Chip-level fields (peak-based, Nsight SOL analogue).
         assert "cores_active" in rf
@@ -347,15 +354,15 @@ class TestRoofline:
             assert unit["chip_peak_gflops"] == pytest.approx(
                 unit["peak_gflops"] * rf["num_cores"]
             )
-            assert unit["chip_throughput"] >= 0
+            assert unit["compute_throughput"] >= 0
 
     @pytest.mark.parametrize("path,func_name,entry", get_test_params("add_kernel"))
-    def test_chip_throughput_even_tiling_matches_extrapolation(self, path, func_name, entry):
+    def test_compute_throughput_even_tiling_matches_extrapolation(self, path, func_name, entry):
         """For evenly-tiled work, the chip-wide aggregate equals the
         critical-core extrapolation ``grid_coverage × (achieved / peak)``.
 
-        chip_throughput is defined as the real per-core FLOP sum over elapsed
-        time (see test_chip_throughput_uneven_split_uses_aggregate); when every
+        compute_throughput is defined as the real per-core FLOP sum over elapsed
+        time (see test_compute_throughput_uneven_split_uses_aggregate); when every
         active core does equal work the two coincide. This anchors that
         equivalence so the uneven-split divergence is meaningful, not an
         artifact of an unrelated formula change.
@@ -367,13 +374,13 @@ class TestRoofline:
             extrapolation = (rf["grid_coverage"]
                              * unit["achieved_gflops"]
                              / unit["peak_gflops"])
-            assert unit["chip_throughput"] == pytest.approx(extrapolation, abs=1e-9), (
+            assert unit["compute_throughput"] == pytest.approx(extrapolation, abs=1e-9), (
                 f"even-tiling equivalence broken for unit {unit_name!r}: "
-                f"got {unit['chip_throughput']}, expected {extrapolation}"
+                f"got {unit['compute_throughput']}, expected {extrapolation}"
             )
 
-    def test_chip_throughput_uneven_split_uses_aggregate(self):
-        """Under uneven tiling chip_throughput must aggregate the real FLOPs of
+    def test_compute_throughput_uneven_split_uses_aggregate(self):
+        """Under uneven tiling compute_throughput must aggregate the real FLOPs of
         every core, not extrapolate the critical (heaviest) core's rate to all.
 
         Three cores run for the same wall time but do 300/200/100 matmul FLOPs.
@@ -400,12 +407,168 @@ class TestRoofline:
                           for c in counters.values())  # 600
 
         expected_aggregate = (total_flops / elapsed_s) / chip_peak
-        assert unit["chip_throughput"] == pytest.approx(expected_aggregate)
+        assert unit["compute_throughput"] == pytest.approx(expected_aggregate)
 
         # The critical-core extrapolation would be strictly larger (overstated).
         extrapolation = (unit["achieved_gflops"] * 1e9 * rf["cores_active"]) / chip_peak
-        assert unit["chip_throughput"] < extrapolation
-        assert extrapolation == pytest.approx(1.5 * unit["chip_throughput"])
+        assert unit["compute_throughput"] < extrapolation
+        assert extrapolation == pytest.approx(1.5 * unit["compute_throughput"])
+
+    # -- Chip-level metrics (#148: consolidates #125 dram_throughput / #127 mean_core_active_frac) --
+
+    @staticmethod
+    def _three_core_matmul_report(cfg):
+        """Three cores, equal wall time, matmul FLOPs 300/200/100 + HBM bytes.
+
+        Shared fixture for the chip-metric tests: chip aggregates are the sum
+        over these three cores, and the critical (heaviest) core sets elapsed.
+        """
+        from ktir_cpu.latency import CoreLatencyCounters
+        counters = {}
+        for cid, (flops, nbytes) in enumerate(
+            ((300.0, 600), (200.0, 400), (100.0, 200))
+        ):
+            c = CoreLatencyCounters()
+            c.record("compute_matmul", cycles=100.0, flops=flops)
+            c.record("memory", cycles=100.0, nbytes=nbytes)
+            counters[cid] = c
+        return LatencyReport(config=cfg, counters=counters), counters
+
+    def test_chip_AI_aggregates_flops_over_dram_bytes(self):
+        """Chip AI = Σ FLOP / Σ HBM bytes over all cores (derived, not hardcoded)."""
+        cfg = HardwareConfig(num_cores=32)
+        report, counters = self._three_core_matmul_report(cfg)
+        rf = report.roofline()
+
+        sigma_flops = sum(c.total_flops for c in counters.values())        # 600
+        sigma_dram = sum(c.dram_bytes for c in counters.values())          # 1200
+        assert rf["AI"] == pytest.approx(sigma_flops / sigma_dram)
+
+    def test_compute_throughput_chip_scalar_definition(self):
+        """Chip compute_throughput = Σ FLOP / elapsed / (dominant peak × num_cores)."""
+        cfg = HardwareConfig(num_cores=32)
+        report, counters = self._three_core_matmul_report(cfg)
+        rf = report.roofline()
+
+        clock = cfg.clock_ghz * 1e9
+        elapsed_s = max(c.total_cycles for c in counters.values()) / clock
+        sigma_flops = sum(c.total_flops for c in counters.values())
+        chip_peak = cfg.systolic_flops_per_cycle * clock * cfg.num_cores
+        assert rf["compute_throughput"] == pytest.approx(
+            (sigma_flops / elapsed_s) / chip_peak
+        )
+        assert 0.0 <= rf["compute_throughput"] <= 1.0
+
+    def test_dram_throughput_uses_aggregate_bandwidth_not_per_core(self):
+        """dram_throughput reads the aggregate HBM bandwidth directly, so at a
+        fixed ``hbm_bandwidth_tb_s`` it is invariant to ``num_cores`` — proving
+        it does NOT go through the per-core ``hbm_bytes_per_cycle_per_core``
+        (aggregate ÷ num_cores) partition.
+        """
+        clock = HardwareConfig().clock_ghz * 1e9
+        results = []
+        for ncores in (8, 32):
+            cfg = HardwareConfig(num_cores=ncores, hbm_bandwidth_tb_s=2.0)
+            report, counters = self._three_core_matmul_report(cfg)
+            rf = report.roofline()
+
+            elapsed_s = max(c.total_cycles for c in counters.values()) / clock
+            sigma_dram = sum(c.dram_bytes for c in counters.values())
+            hbm_bw = cfg.hbm_bandwidth_tb_s * 1e12
+            assert rf["dram_throughput"] == pytest.approx(
+                sigma_dram / (hbm_bw * elapsed_s)
+            )
+            assert 0.0 <= rf["dram_throughput"] <= 1.0
+            results.append(rf["dram_throughput"])
+        # Same aggregate bandwidth + same traffic ⇒ identical across num_cores.
+        assert results[0] == pytest.approx(results[1])
+
+    def test_mean_core_active_frac_definition(self):
+        """mean_core_active_frac = Σ total_cycles / (num_cores × elapsed_cycles),
+        averaged over ALL hardware cores (idle cores pull it down)."""
+        cfg = HardwareConfig(num_cores=32)
+        report, counters = self._three_core_matmul_report(cfg)
+        rf = report.roofline()
+
+        sigma_cycles = sum(c.total_cycles for c in counters.values())
+        elapsed_cycles = max(c.total_cycles for c in counters.values())
+        assert rf["mean_core_active_frac"] == pytest.approx(
+            sigma_cycles / (cfg.num_cores * elapsed_cycles)
+        )
+        assert 0.0 <= rf["mean_core_active_frac"] <= 1.0
+
+    def test_mean_core_active_frac_single_full_core_is_one(self):
+        """A single core that is the whole chip and runs the whole elapsed time
+        has full time-occupancy (== 1.0)."""
+        from ktir_cpu.latency import CoreLatencyCounters
+        cfg = HardwareConfig(num_cores=1)
+        c = CoreLatencyCounters()
+        c.record("compute_matmul", cycles=100.0, flops=2048.0)
+        c.record("memory", cycles=50.0, nbytes=1024)
+        rf = LatencyReport(config=cfg, counters={0: c}).roofline()
+        assert rf["mean_core_active_frac"] == pytest.approx(1.0)
+
+    # -- chip_roofline() / core_roofline() split API --
+
+    @pytest.mark.parametrize("path,func_name,entry", get_test_params("add_kernel"))
+    def test_chip_and_core_roofline_split(self, path, func_name, entry):
+        """chip_roofline() and core_roofline() each return only their own group,
+        and roofline() is exactly their merge."""
+        report, _ = _run_vector_add(path, func_name, entry, HardwareConfig())
+        chip = report.chip_roofline()
+        core = report.core_roofline()
+
+        assert set(chip) == {"AI", "compute_throughput", "dram_throughput",
+                             "mean_core_active_frac", "grid_coverage", "ridge",
+                             "dominant_unit", "num_cores", "cores_active"}
+        assert set(core) == {"core_AI", "core_efficiency", "core_dominant_unit",
+                             "peak_bw_gb_s", "ridge", "units"}
+        # chip ratios are all peak-based (0..1).
+        for key in ("compute_throughput", "dram_throughput",
+                    "mean_core_active_frac", "grid_coverage"):
+            assert 0.0 <= chip[key] <= 1.0
+        # roofline() == {**core, **chip} (disjoint keys except ridge, equal).
+        assert report.roofline() == {**core, **chip}
+        assert chip["ridge"] == pytest.approx(core["ridge"])
+
+    def test_dominant_decided_chip_wide_and_shared_by_both(self):
+        """The dominant unit is decided ONCE, chip-wide (Σ cycles over ALL
+        cores), and both chip_roofline and core_roofline use that single value
+        — they can never disagree.
+
+        The critical core (heaviest total cycles) is SIMD-heavy on its own, but
+        the chip-wide bottleneck is systolic. Both granularities must therefore
+        report systolic: core_roofline does NOT fall back to the critical
+        core's local simd choice. Because they share one dominant unit, the two
+        ridges are identical.
+        """
+        from ktir_cpu.latency import CoreLatencyCounters
+        cfg = HardwareConfig(num_cores=32)
+        counters = {}
+        # Core 0 = critical (111 cycles), simd-heavy on its own (100 simd vs 10 systolic).
+        c0 = CoreLatencyCounters()
+        c0.record("compute_float", cycles=100.0, flops=6400.0)
+        c0.record("compute_matmul", cycles=10.0, flops=5120.0)
+        c0.record("memory", cycles=1.0, nbytes=2048)
+        counters[0] = c0
+        # Cores 1..3 = systolic-heavy (50 systolic each) → chip-wide dominant = systolic.
+        for cid in range(1, 4):
+            c = CoreLatencyCounters()
+            c.record("compute_matmul", cycles=50.0, flops=25600.0)
+            c.record("memory", cycles=1.0, nbytes=2048)
+            counters[cid] = c
+        report = LatencyReport(config=cfg, counters=counters)
+
+        chip = report.chip_roofline()
+        core = report.core_roofline()
+        # Single chip-wide decision applied to both — critical core's own simd
+        # lead does NOT sway the per-core headline.
+        assert chip["dominant_unit"] == "systolic"
+        assert core["core_dominant_unit"] == "systolic"
+
+        # Same dominant unit ⇒ identical ridge at both granularities.
+        assert chip["ridge"] == pytest.approx(core["ridge"])
+        assert report.roofline()["ridge"] == pytest.approx(chip["ridge"])
 
     def test_dominant_by_cycles_and_per_unit_ai(self):
         """Dominant unit is the cycle bottleneck, not the FLOP-heaviest, and each
@@ -431,7 +594,7 @@ class TestRoofline:
         rf = LatencyReport(config=HardwareConfig(), counters={0: c}).roofline()
 
         # FLOP-heaviest is systolic; cycle-heaviest (the bottleneck) is simd.
-        assert rf["dominant_unit"] == "simd"
+        assert rf["core_dominant_unit"] == "simd"
 
         # Each unit's AI is its own FLOPs over the shared DRAM bytes — distinct,
         # not one mixed value shared by both.
@@ -441,36 +604,39 @@ class TestRoofline:
         assert ai_simd == pytest.approx(28480.0 / total_bytes)
         assert ai_sys != ai_simd
 
-        # The top-level AI is sourced from the dominant (simd) unit, not a mix.
-        assert rf["arithmetic_intensity"] == pytest.approx(ai_simd)
+        # The per-core headline core_AI is sourced from the dominant (simd)
+        # unit, not a mix.
+        assert rf["core_AI"] == pytest.approx(ai_simd)
 
     @pytest.mark.parametrize("path,func_name,entry", get_test_params("add_kernel"))
     def test_vector_add_is_memory_bound(self, path, func_name, entry):
         """vector_add has low arithmetic intensity → memory-bound on roofline."""
         report, _ = _run_vector_add(path, func_name, entry, HardwareConfig())
         rf = report.roofline()
-        dominant = rf["dominant_unit"]
+        dominant = rf["core_dominant_unit"]
 
         # AI should be well below the dominant unit's ridge point (memory-bound)
-        assert rf["arithmetic_intensity"] < rf["units"][dominant]["ridge_point"]
+        assert rf["core_AI"] < rf["units"][dominant]["ridge_point"]
 
     @pytest.mark.parametrize("path,func_name,entry", get_test_params("reduce_explicit_region"))
     def test_vector_reduce_is_memory_bound(self, path, func_name, entry):
         """A simple vector reduce should be memory-bound on the roofline."""
         report = _run_vector_reduce(path, func_name, entry, HardwareConfig())
         rf = report.roofline()
-        assert "arithmetic_intensity" in rf
-        dominant = rf["dominant_unit"]
-        assert rf["arithmetic_intensity"] < rf["units"][dominant]["ridge_point"]
+        assert "core_AI" in rf
+        dominant = rf["core_dominant_unit"]
+        assert rf["core_AI"] < rf["units"][dominant]["ridge_point"]
 
     @pytest.mark.parametrize("path,func_name,entry", get_test_params("add_kernel"))
     def test_roofline_in_report_str(self, path, func_name, entry):
         """Roofline section should appear in report __str__."""
         report, _ = _run_vector_add(path, func_name, entry, HardwareConfig())
         text = str(report)
-        assert "Roofline Analysis" in text
-        assert "Arithmetic intensity" in text
-        assert "Efficiency" in text
+        # Output is two clearly-separated blocks, one per granularity.
+        assert "Roofline: CHIP-LEVEL" in text
+        assert "Roofline: PER-CORE" in text
+        assert "core_AI" in text
+        assert "compute_throughput" in text
 
     @pytest.mark.parametrize("path,func_name,entry", get_test_params("matmul_kernel_small"))
     def test_matmul_flops(self, path, func_name, entry):
@@ -500,8 +666,8 @@ class TestRoofline:
         report, _ = _run_vector_add(path, func_name, entry, HardwareConfig())
         assert report.bottleneck == "memory"
         rf = report.roofline()
-        dominant = rf["dominant_unit"]
-        assert rf["arithmetic_intensity"] < rf["units"][dominant]["ridge_point"]
+        dominant = rf["core_dominant_unit"]
+        assert rf["core_AI"] < rf["units"][dominant]["ridge_point"]
 
     @pytest.mark.parametrize("path,func_name,entry", get_test_params("softmax_kernel_small"))
     def test_compute_bound_roofline_matches_bottleneck(self, path, func_name, entry):
@@ -511,8 +677,8 @@ class TestRoofline:
         report = _run_softmax(path, func_name, entry, cfg)
         assert report.bottleneck == "compute"
         rf = report.roofline()
-        dominant = rf["dominant_unit"]
-        assert rf["arithmetic_intensity"] > rf["units"][dominant]["ridge_point"]
+        dominant = rf["core_dominant_unit"]
+        assert rf["core_AI"] > rf["units"][dominant]["ridge_point"]
 
     def test_oversized_grid_does_not_inflate_cores_active(self):
         """An over-large grid leaves some cores with zero loop iterations; those
@@ -2170,7 +2336,7 @@ class TestRingReduceLatency:
         # (HBM only), so ring/comm bytes do not inflate the denominator and push the
         # attained point above the HBM ceiling. With the old total_bytes denominator
         # this kernel reported efficiency > 1 (point above the roof).
-        assert 0 < rep.roofline()["efficiency"] <= 1.0
+        assert 0 < rep.roofline()["core_efficiency"] <= 1.0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Add **chip (device) level** roofline metrics to `roofline()` — the whole chip as one unit (NCU device view),
by aggregating the per-core counters the model already has. **No new inputs.** Closes #148.

## Why

`roofline()` only reported the critical-path core. That can't show how much of the chip ran or whether it hit
the HBM-bandwidth wall — a high `core_efficiency` reads the same on a nearly-idle chip and a saturated one.

## What to expect in the diff

`roofline()` is split by granularity:

```text
roofline()          # = {**core_roofline(), **chip_roofline()}  — back-compatible single call
├─ chip_roofline()  # NEW — whole chip as one unit
└─ core_roofline()  # critical-path core; per-core fields renamed with a core_ prefix
```

New chip metrics (all peak-based ratios in [0,1], except `AI`):

| metric | formula | NCU analogue |
|---|---|---|
| `AI` | `Σ FLOP / Σ HBM bytes` | Arithmetic Intensity |
| `compute_throughput` | `Σ FLOP / elapsed / chip_peak` | Compute (SM) Throughput % — rename of `chip_throughput` (#120) |
| `dram_throughput` | `Σ HBM bytes / (hbm_bw × elapsed)` | DRAM Throughput % |
| `mean_core_active_frac` | `Σ total_cycles / (num_cores × elapsed_cycles)` | SM Active % |
| `grid_coverage` | `cores_active / num_cores` | (unchanged) spatial dispatch coverage |

Renames (mechanical, semantics unchanged): `arithmetic_intensity → core_AI`, `efficiency → core_efficiency`,
`dominant_unit → core_dominant_unit`.

## Files

| file | change |
|---|---|
| `ktir_cpu/latency.py` | `_roofline_common()` shared base → `chip_roofline()` / `core_roofline()`; `roofline()` merges both; `__str__` splits into CHIP-LEVEL / PER-CORE blocks |
| `docs/latency.md` | chip-level metrics section + formula table |
| `notebooks/latency_demo.ipynb` | chip block + chip roofline point; per-core block renamed `core_*` |
| `tests/test_latency.py` | chip-metric definitions, split-API, merge-equality, single chip-wide dominant |

## Assumptions

- **Op→unit mapping is fixed:** systolic ← `linalg.matmul`; SIMD ← float / transcendental / int (PE/SFP).
- **Dominant unit = most cycles** (time bottleneck, not FLOPs), decided **once, chip-wide** and shared by both granularities — assumes data-parallel execution (every core runs the same op mix).
- **Wall-clock `elapsed` = the critical core's `total_cycles`** (compute + memory + comm).
- **Cores homogeneous** → `chip_peak = per-core peak × num_cores`; throughput denominators use `num_cores` (all cores, incl. idle), so an under-filled chip reads low (device SOL). `hbm_bandwidth_tb_s` is the aggregate (per-core = `÷ num_cores`); chip reads it directly.
- **`AI` denominator is HBM `dram_bytes` only** — comm/ring excluded (NCU, per #138).
- **Pre-existing (not this PR):** the cost model sums compute + memory + comm cycles **serially** (units non-overlapping); chip metrics inherit this.

## Scope

- **In:** chip metrics + `core_` rename, in `roofline()` and the notebook. Measured-only, no new inputs.
- **Out:** cross-core comm is on its own axis (#126), excluded from `AI` (DRAM-only). Per-core roofline redesign is #122.
